### PR TITLE
XD-58: Patch build job to use mavenCentral as a third option.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ buildscript {
 allprojects {
 	group = 'org.springframework.xd'
 	repositories {
+		mavenCentral()
 		maven { url 'http://repo.springsource.org/libs-snapshot' }
 		maven { url 'http://repo.springsource.org/plugins-release' }
-		mavenCentral()
 	}
 }
 


### PR DESCRIPTION
While trying to build Spring XD, it failed to pull in all the dependencies. This patch fixes that by adding mavenCentral as a 3rd option.
