### PR TITLE
XD-140 Parameterize Syslog Port; Support TCP

### DIFF
--- a/modules/source/syslog-tcp.xml
+++ b/modules/source/syslog-tcp.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-syslog="http://www.springframework.org/schema/integration/syslog"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/syslog http://www.springframework.org/schema/integration/syslog/spring-integration-syslog.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<int-syslog:inbound-channel-adapter id="adapter" channel="output"
+			protocol="tcp"
+			port="${port:11111}"/>
+
+	<int:channel id="output"/>
+
+</beans>

--- a/modules/source/syslog-udp.xml
+++ b/modules/source/syslog-udp.xml
@@ -7,7 +7,9 @@
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<int-syslog:inbound-channel-adapter id="adapter" channel="output" port="11111"/>
+	<int-syslog:inbound-channel-adapter id="adapter" channel="output"
+			protocol="udp"
+			port="${port:11111}"/>
 
 	<int:channel id="output"/>
 


### PR DESCRIPTION
- Rename syslog.xml to syslog-udp.xml
- Add syslog-tcp.xml
- Parameterize port

At this time, the protocol cannot be parameterized because of
context lifecycle issues (see XD-142).
- Add documentation for the syslog source:
  https://github.com/SpringSource/spring-xd/wiki/Sources#wiki-syslog
