### PR TITLE
XD-130 Fix removal of container entry on shutdown

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/DefaultContainer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/DefaultContainer.java
@@ -18,7 +18,6 @@ package org.springframework.xd.dirt.container;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.support.AbstractApplicationContext;
@@ -26,9 +25,11 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.util.Assert;
 import org.springframework.xd.dirt.core.Container;
 import org.springframework.xd.dirt.event.ContainerStartedEvent;
+import org.springframework.xd.dirt.event.ContainerStoppedEvent;
 
 /**
  * @author Mark Fisher
+ * @author Jennifer Hickey
  */
 public class DefaultContainer implements Container, SmartLifecycle {
 
@@ -82,6 +83,7 @@ public class DefaultContainer implements Container, SmartLifecycle {
 	@Override
 	public void stop() {
 		if (this.context != null) {
+			this.context.publishEvent(new ContainerStoppedEvent(this));
 			this.context.close();
 		}
 	}
@@ -96,5 +98,4 @@ public class DefaultContainer implements Container, SmartLifecycle {
 		Assert.state(this.context != null, "context is not initialized");
 		this.context.addApplicationListener(listener);
 	}
-
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/ContainerStoppedEvent.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/ContainerStoppedEvent.java
@@ -1,0 +1,14 @@
+package org.springframework.xd.dirt.event;
+
+import org.springframework.xd.dirt.core.Container;
+
+/**
+ * @author Jennifer Hickey
+ */
+@SuppressWarnings("serial")
+public class ContainerStoppedEvent extends AbstractContainerEvent {
+
+	public ContainerStoppedEvent(Container container) {
+		super(container);
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/listener/AbstractContainerEventListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/listener/AbstractContainerEventListener.java
@@ -19,9 +19,11 @@ package org.springframework.xd.dirt.listener;
 import org.springframework.context.ApplicationListener;
 import org.springframework.xd.dirt.event.AbstractContainerEvent;
 import org.springframework.xd.dirt.event.ContainerStartedEvent;
+import org.springframework.xd.dirt.event.ContainerStoppedEvent;
 
 /**
  * @author Mark Fisher
+ * @author Jennifer Hickey
  */
 public abstract class AbstractContainerEventListener implements ApplicationListener<AbstractContainerEvent> {
 
@@ -29,9 +31,13 @@ public abstract class AbstractContainerEventListener implements ApplicationListe
 	public void onApplicationEvent(AbstractContainerEvent event) {
 		if (event instanceof ContainerStartedEvent) {
 			onContainerStartedEvent((ContainerStartedEvent) event);
+		}else if(event instanceof ContainerStoppedEvent) {
+			onContainerStoppedEvent((ContainerStoppedEvent) event);
 		}
 	}
 
 	protected abstract void onContainerStartedEvent(ContainerStartedEvent event);
+
+	protected abstract void onContainerStoppedEvent(ContainerStoppedEvent event);
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/listener/RedisContainerEventListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/listener/RedisContainerEventListener.java
@@ -25,9 +25,11 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.xd.dirt.core.Container;
 import org.springframework.xd.dirt.event.ContainerStartedEvent;
+import org.springframework.xd.dirt.event.ContainerStoppedEvent;
 
 /**
  * @author Mark Fisher
+ * @author Jennifer Hickey
  */
 public class RedisContainerEventListener extends AbstractContainerEventListener {
 
@@ -48,6 +50,13 @@ public class RedisContainerEventListener extends AbstractContainerEventListener 
 		}
 		Container container = event.getSource();
 		this.redisTemplate.boundHashOps("containers").put(container.getId(), name);
+	}
+
+	@Override
+	protected void onContainerStoppedEvent(ContainerStoppedEvent event) {
+		Container container = event.getSource();
+		this.redisTemplate.boundHashOps("containers").delete(container.getId());
+		this.redisTemplate.delete(container.getId());
 	}
 
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest.java
@@ -1,0 +1,69 @@
+package org.springframework.xd.dirt.listener;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.xd.dirt.core.Container;
+import org.springframework.xd.dirt.event.ContainerStartedEvent;
+import org.springframework.xd.dirt.event.ContainerStoppedEvent;
+
+/**
+ * Integration test of {@link RedisContainerEventListener}
+ * 
+ * @author Jennifer Hickey
+ * 
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+public class RedisContainerEventListenerTest {
+
+	@Autowired
+	private ApplicationContext context;
+
+	@Autowired
+	private StringRedisTemplate redisTemplate;
+
+	@Mock
+	private Container container;
+
+	private final String containerId = "test" + UUID.randomUUID().toString();
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@After
+	public void tearDown() {
+		redisTemplate.boundHashOps("containers").delete(containerId);
+	}
+
+	@Test
+	public void testContainerStarted() {
+		when(container.getId()).thenReturn(containerId);
+		context.publishEvent(new ContainerStartedEvent(container));
+		assertNotNull(redisTemplate.boundHashOps("containers").get(containerId));
+	}
+
+	@Test
+	public void testContainerStopped() {
+		when(container.getId()).thenReturn(containerId);
+		redisTemplate.boundHashOps("containers").put(containerId, "container1");
+		context.publishEvent(new ContainerStoppedEvent(container));
+		assertNull(redisTemplate.boundHashOps("containers").get(containerId));
+	}
+}

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest-context.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest-context.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:int-event="http://www.springframework.org/schema/integration/event"
+	xmlns:redis="http://www.springframework.org/schema/redis"
+	xmlns:int-redis="http://www.springframework.org/schema/integration/redis"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/redis http://www.springframework.org/schema/redis/spring-redis.xsd
+		http://www.springframework.org/schema/integration/event http://www.springframework.org/schema/integration/event/spring-integration-event.xsd
+		http://www.springframework.org/schema/integration/redis http://www.springframework.org/schema/integration/redis/spring-integration-redis.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<bean id="redisConnectionFactory" class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory">	      
+		  <constructor-arg index="0" value="localhost"/>
+		  <constructor-arg index="1" value="6379"/>
+		</bean>
+	
+	<bean class="org.springframework.xd.dirt.listener.RedisContainerEventListener">
+		<constructor-arg ref="redisConnectionFactory"/>
+	</bean>
+	
+	<bean class="org.springframework.data.redis.core.StringRedisTemplate">
+		<constructor-arg ref="redisConnectionFactory"/>
+	</bean>
+	
+</beans>


### PR DESCRIPTION
- Ensure the container's LettuceConnectionFactory
  is used for removal instead of the launcher's
  factory (preventing closure of LettuceConnection
  while the entries are being removed)
- Add ContainerStoppedEvent and encapsulate lifecycle
  event processing in RedisContainerEventListener
