### PR TITLE
XD-110

### DIFF
--- a/scripts/xd/xd-admin
+++ b/scripts/xd/xd-admin
@@ -6,7 +6,7 @@
 ##
 ##############################################################################
 
-# Add default JVM options here. You can also use JAVA_OPTS and SPRING_XD_DIRT_OPTS to pass JVM options to this script.
+# Add default JVM options here. You can also use JAVA_OPTS and SPRING_XD_ADMIN_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS=""
 
 APP_NAME="xd-admin"
@@ -159,6 +159,13 @@ if $cygwin ; then
         (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
     esac
 fi
+
+# check if XD_HOME is already set; if it is not, then set APP_HOME as XD_HOME
+if [ x"$XD_HOME" = x ] ; then
+    XD_HOME=$APP_HOME
+fi
+# set XD_HOME as system property via SPRING_XD_CONTAINER_OPTS
+SPRING_XD_ADMIN_OPTS=-Dxd.home=$XD_HOME
 
 # Split up the JVM_OPTS And SPRING_XD_ADMIN_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/xd/xd-admin.bat
+++ b/scripts/xd/xd-admin.bat
@@ -80,6 +80,12 @@ if exist "%APP_HOME_LIB%" (
     set CLASSPATH=!CLASSPATH!
 )
 
+@rem Set XD_HOME to APP_HOME if XD_HOME is not defined yet
+if not exist "%XD_HOME%" (
+    set XD_HOME=%APP_HOME%
+)
+set SPRING_XD_ADMIN_OPTS=-Dxd.home=%XD_HOME%
+
 @rem Execute xd-admin
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_ADMIN_OPTS%  -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.AdminMain %CMD_LINE_ARGS%
 

--- a/scripts/xd/xd-container
+++ b/scripts/xd/xd-container
@@ -6,7 +6,7 @@
 ##
 ##############################################################################
 
-# Add default JVM options here. You can also use JAVA_OPTS and SPRING_XD_DIRT_OPTS to pass JVM options to this script.
+# Add default JVM options here. You can also use JAVA_OPTS and SPRING_XD_CONTAINER_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS=""
 
 APP_NAME="xd-container"
@@ -159,6 +159,12 @@ if $cygwin ; then
         (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
     esac
 fi
+# check if XD_HOME is already set; if it is not, then set APP_HOME as XD_HOME
+if [ x"$XD_HOME" = x ] ; then
+    XD_HOME=$APP_HOME
+fi
+# set XD_HOME as system property via SPRING_XD_CONTAINER_OPTS
+SPRING_XD_CONTAINER_OPTS=-Dxd.home=$XD_HOME
 
 # Split up the JVM_OPTS And SPRING_XD_CONTAINER_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/xd/xd-container.bat
+++ b/scripts/xd/xd-container.bat
@@ -80,8 +80,14 @@ if exist "%APP_HOME_LIB%" (
     set CLASSPATH=!CLASSPATH!
 )
 
+@rem Set XD_HOME to APP_HOME if XD_HOME is not defined yet
+if not exist "%XD_HOME%" (
+    set XD_HOME=%APP_HOME% 
+)
+set SPRING_XD_CONTAINER_OPTS=-Dxd.home=%XD_HOME%
+
 @rem Execute xd-container
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_CONTAINER_OPTS%  -classpath "%CLASSPATH%" org.springframework.xd.XDContainer %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_CONTAINER_OPTS%  -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.ContainerMain %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerMain.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerMain.java
@@ -56,10 +56,6 @@ public class ContainerMain {
 		}
 		
 		if (options.isEmbeddedAdmin() == true ) {	
-			if (StringUtils.isNotEmpty(options.getXDHomeDir())) {
-				System.setProperty("xd.home", options.getXDHomeDir());
-			}
-
 			StreamServer.launch(options.getRedisHost(), options.getRedisPort());
 		}
 		


### PR DESCRIPTION
Use XD_HOME environment property
 if XD_HOME is not defined already, then use the default APP_HOME that the script runs from
Please note:  if container is invoked directly without scripts, then relative path is set (via RedisContainerLauncher) for xd home
