### PR TITLE
XD-148 Improve experience when Redis not running

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/ContainerStoppedEvent.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/ContainerStoppedEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.dirt.event;
 
 import org.springframework.xd.dirt.core.Container;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/redis/ExceptionWrappingLettuceConnectionFactory.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/redis/ExceptionWrappingLettuceConnectionFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.redis;
+
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import com.lambdaworks.redis.RedisException;
+
+/**
+ * Temporary extension of {@link LettuceConnectionFactory} that addresses
+ * DATAREDIS-191 LettuceConnectionFactory should throw wrapped Exceptions on
+ * connection failure
+ * 
+ * @author Jennifer Hickey
+ * 
+ */
+public class ExceptionWrappingLettuceConnectionFactory extends LettuceConnectionFactory {
+
+	public ExceptionWrappingLettuceConnectionFactory() {
+		super();
+	}
+
+	public ExceptionWrappingLettuceConnectionFactory(String host, int port) {
+		super(host, port);
+	}
+
+	@Override
+	public void initConnection() {
+		try {
+			super.initConnection();
+		} catch (RedisException e) {
+			throw new RedisConnectionFailureException("Unable to connect to Redis on " + getHostName() + ":"
+					+ getPort(), e);
+		}
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminMain.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminMain.java
@@ -26,6 +26,7 @@ import org.springframework.xd.dirt.stream.StreamServer;
 /**
  * The main driver class for the AdminMain
  * @author Mark Pollack
+ * @author Jennifer Hickey
  *
  */
 public class AdminMain {
@@ -57,7 +58,8 @@ public class AdminMain {
 			RedisContainerLauncher.main(new String[]{});
 		}
 
-		StreamServer.launch(options.getRedisHost(), options.getRedisPort());
+		StreamServer.main(new String[] {options.getRedisHost(), Integer.toString(options.getRedisPort())});
+
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerMain.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerMain.java
@@ -26,6 +26,7 @@ import org.springframework.xd.dirt.stream.StreamServer;
 /**
  * The main driver class for ContainerMain 
  * @author Mark Pollack
+ * @author Jennifer Hickey
  *
  */
 public class ContainerMain {
@@ -56,7 +57,7 @@ public class ContainerMain {
 		}
 		
 		if (options.isEmbeddedAdmin() == true ) {	
-			StreamServer.launch(options.getRedisHost(), options.getRedisPort());
+			StreamServer.main(new String[] {options.getRedisHost(), Integer.toString(options.getRedisPort())});
 		}
 		
 		//Future versions to support other types of container launchers

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamServer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamServer.java
@@ -34,11 +34,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.SmartLifecycle;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.integration.MessagingException;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.xd.dirt.redis.ExceptionWrappingLettuceConnectionFactory;
 
 /**
  * This is a temporary "server" for the REST API. Currently it only handles simple
@@ -184,24 +186,32 @@ public class StreamServer implements SmartLifecycle, InitializingBean {
 	}
 
 	public static void main(String[] args) {
-		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory();
-		bootstrap(connectionFactory);
+		try {
+			bootstrap(args);
+		}catch(RedisConnectionFailureException e) {
+			final Log logger = LogFactory.getLog(StreamServer.class);
+			logger.fatal(e.getMessage());
+			System.err.println("Redis does not seem to be running. Did you install and start Redis? " +
+					"Please see the Getting Started section of the guide for instructions.");
+			System.exit(1);
+		}
 	}
 	
-	public static void launch(String host, int port) {
-		LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(host, port);
-		bootstrap(connectionFactory);
-	}
-	
-	/**
-	 * @param connectionFactory
-	 */
-	private static void bootstrap(LettuceConnectionFactory connectionFactory) {
+	private static void bootstrap(String[] args) {
+		LettuceConnectionFactory connectionFactory = getConnectionFactory(args);
 		connectionFactory.afterPropertiesSet();
 		RedisStreamDeployer streamDeployer = new RedisStreamDeployer(connectionFactory);
 		StreamServer server = new StreamServer(streamDeployer);
 		server.afterPropertiesSet();
 		server.start();
+	}
+
+	private static LettuceConnectionFactory getConnectionFactory(String[] args) {
+		if(args.length >= 2) {
+			return new ExceptionWrappingLettuceConnectionFactory(args[0], Integer.parseInt(args[1]));
+		} else {
+			return new ExceptionWrappingLettuceConnectionFactory();
+		}
 	}
 
 }

--- a/spring-xd-dirt/src/main/resources/META-INF/spring/redis.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring/redis.xml
@@ -12,7 +12,7 @@
 	<context:property-placeholder/>
 	
 	<beans profile="default">
-	    <bean id="redisConnectionFactory" class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory">	      
+	    <bean id="redisConnectionFactory" class="org.springframework.xd.dirt.redis.ExceptionWrappingLettuceConnectionFactory">
 		  <constructor-arg index="0" value="${redis.hostname:localhost}"/>
 		  <constructor-arg index="1" value="${redis.port:6379}"/>
 		</bean>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.dirt.listener;
 
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
- Log a friendlier message (minus giant stack trace)
  when Redis is not available
- Print helpful message to console
- Remove redundant StreamServer launch method to
  consolidate exception handling code
