### PR TITLE
XD-184 Add Delete To LocalChannelRegistry

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/channel/registry/ChannelRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/channel/registry/ChannelRegistry.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.x.channel.registry;
+
+import org.springframework.integration.MessageChannel;
+
+/**
+ * A strategy interface used to bind a {@link MessageChannel} to a logical name. The name
+ * is intended to identify a logical consumer or producer of messages. This may be a
+ * queue, a channel adapter, another message channel, a Spring bean, etc.
+ *
+ * @author Mark Fisher
+ * @author David Turanski
+ * @author Gary Russell
+ * @since 1.0
+ */
+public interface ChannelRegistry {
+
+	/**
+	 * Register a message consumer
+	 * @param name the logical identity of the message source
+	 * @param channel the channel bound as a consumer
+	 */
+	void inbound(String name, MessageChannel channel);
+
+	/**
+	 * Register a message producer
+	 * @param name the logical identity of the message target
+	 * @param channel the channel bound as a producer
+	 */
+	void outbound(String name, MessageChannel channel);
+
+	/**
+	 * Create a tap on an already registered inbound channel
+	 * @param name the registered name
+	 * @param channel the channel that will receive messages from the tap
+	 */
+	void tap(String name, MessageChannel channel);
+
+	/**
+	 * Remove all subscriptions to inter-module channels for this module
+	 * and stop any active components that use those channels.
+	 * @param name the module name
+	 */
+	void cleanAll(String name);
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/channel/registry/LocalChannelRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/channel/registry/LocalChannelRegistry.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.integration.x.channel.registry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.channel.AbstractMessageChannel;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.integration.channel.interceptor.WireTap;
+import org.springframework.integration.core.SubscribableChannel;
+import org.springframework.integration.handler.BridgeHandler;
+import org.springframework.util.Assert;
+
+/**
+ * A simple implementation of {@link ChannelRegistry} for in-process use. For inbound and
+ * outbound, creates a {@link DirectChannel} and bridges the passed
+ * {@link MessageChannel} to the channel which is registered in the given application
+ * context. If that channel does not yet exist, it will be created. For tap, it adds a
+ * {@link WireTap} for an inbound channel whose name matches the one provided. If no such
+ * inbound channel exists at the time of the method invocation, it will throw an
+ * Exception. Otherwise the provided channel instance will receive messages from the wire
+ * tap on that inbound channel.
+ *
+ * @author David Turanski
+ * @author Mark Fisher
+ * @author Gary Russell
+ * @since 1.0
+ */
+public class LocalChannelRegistry implements ChannelRegistry, ApplicationContextAware, InitializingBean {
+
+	private volatile AbstractApplicationContext applicationContext;
+
+	private final List<BridgeMetadata> bridges = Collections.synchronizedList(new ArrayList<BridgeMetadata>());
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		Assert.isInstanceOf(AbstractApplicationContext.class, applicationContext);
+		this.applicationContext = (AbstractApplicationContext) applicationContext;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.notNull(applicationContext, "The 'applicationContext' property cannot be null");
+	}
+
+	/**
+	 * Looks up or creates a DirectChannel with the given name and creates a bridge from
+	 * that channel to the provided channel instance. Also registers a wire tap if the
+	 * channel for the given name had been created. The target of the wire tap is a
+	 * publish-subscribe channel.
+	 */
+	@Override
+	public void inbound(String name, MessageChannel channel) {
+		Assert.hasText(name, "a valid name is required to register an inbound channel");
+		Assert.notNull(channel, "channel must not be null");
+		DirectChannel registeredChannel = lookupOrCreateSharedChannel(name, DirectChannel.class);
+		bridge(registeredChannel, channel, registeredChannel.getComponentName() + ".in.bridge");
+		createSharedTapChannelIfNecessary(registeredChannel);
+	}
+
+	/**
+	 * Looks up or creates a DirectChannel with the given name and creates a bridge to
+	 * that channel from the provided channel instance.
+	 */
+	@Override
+	public void outbound(String name, MessageChannel channel) {
+		Assert.hasText(name, "a valid name is required to register an outbound channel");
+		Assert.notNull(channel, "channel must not be null");
+		Assert.isTrue(channel instanceof SubscribableChannel,
+				"channel must be of type " + SubscribableChannel.class.getName());
+		DirectChannel registeredChannel = lookupOrCreateSharedChannel(name, DirectChannel.class);
+		bridge((SubscribableChannel) channel, registeredChannel, registeredChannel.getComponentName() + ".out.bridge");
+	}
+
+	/**
+	 * Looks up a wiretap for the inbound channel with the given name and creates a
+	 * bridge from that wiretap's output channel to the provided channel instance.
+	 * Will throw an Exception if no such wiretap exists.
+	 */
+	@Override
+	public void tap(String name, MessageChannel channel) {
+		Assert.hasText(name, "a valid name is required to register a tap channel");
+		Assert.notNull(channel, "channel must not be null");
+		SubscribableChannel tapChannel = null;
+		String tapName = "tap." + name;
+		try {
+			tapChannel = applicationContext.getBean(tapName, SubscribableChannel.class);
+		}
+		catch (Exception e) {
+			throw new IllegalArgumentException("No tap channel exists for '" + name
+					+ "'. A tap is only valid for a registered inbound channel.");
+		}
+		bridge(tapChannel, channel, tapName + ".bridge");
+	}
+
+
+	@Override
+	public void cleanAll(String name) {
+		Assert.hasText(name, "a valid name is required to clean a module");
+		synchronized(this.bridges) {
+			Iterator<BridgeMetadata> iterator = this.bridges.iterator();
+			while (iterator.hasNext()) {
+				BridgeMetadata bridge = iterator.next();
+				if (bridge.handler.getComponentName().startsWith(name)) {
+					bridge.channel.unsubscribe(bridge.handler);
+					iterator.remove();
+				}
+			}
+		}
+	}
+
+	protected synchronized <T extends AbstractMessageChannel> T lookupOrCreateSharedChannel(String name, Class<T> requiredType) {
+		T channel = lookupSharedChannel(name, requiredType);
+		if (channel == null) {
+			channel = createSharedChannel(name, requiredType);
+		}
+		return channel;
+	}
+
+	protected synchronized <T extends AbstractMessageChannel> T lookupSharedChannel(String name, Class<T> requiredType) {
+		T channel = null;
+		if (applicationContext.containsBean(name)) {
+			try {
+				channel = applicationContext.getBean(name, requiredType);
+			}
+			catch (Exception e) {
+				throw new IllegalArgumentException("bean '" + name
+						+ "' is already registered but does not match the required type");
+			}
+		}
+		return channel;
+	}
+
+	protected <T extends AbstractMessageChannel> T createSharedChannel(String name, Class<T> requiredType) {
+		try {
+			T channel = requiredType.newInstance();
+			channel.setComponentName(name);
+			channel.setBeanFactory(applicationContext);
+			channel.setBeanName(name);
+			channel.afterPropertiesSet();
+			applicationContext.getBeanFactory().registerSingleton(name, channel);
+			return channel;
+		}
+		catch (Exception e) {
+			throw new IllegalArgumentException("failed to create channel: " + name, e);
+		}
+	}
+
+	private synchronized void createSharedTapChannelIfNecessary(AbstractMessageChannel channel) {
+		String tapName = "tap." + channel.getComponentName();
+		PublishSubscribeChannel tapChannel = null;
+		if (!applicationContext.containsBean(tapName)) {
+			tapChannel = createSharedChannel(tapName, PublishSubscribeChannel.class);
+			WireTap wireTap = new WireTap(tapChannel);
+			channel.addInterceptor(wireTap);
+		}
+		else {
+			try {
+				tapChannel = applicationContext.getBean(tapName, PublishSubscribeChannel.class);
+			}
+			catch (Exception e) {
+				throw new IllegalArgumentException("bean '" + tapName
+						+ "' is already registered but does not match the required type");
+			}
+		}
+	}
+
+	protected BridgeHandler bridge(SubscribableChannel from, MessageChannel to, String bridgeName) {
+		BridgeHandler handler = new BridgeHandler();
+		handler.setOutputChannel(to);
+		handler.setBeanName(bridgeName);
+		handler.afterPropertiesSet();
+		from.subscribe(handler);
+		this.bridges.add(new BridgeMetadata(handler, from));
+		return handler;
+	}
+
+	private class BridgeMetadata {
+		private final BridgeHandler handler;
+		private final SubscribableChannel channel;
+
+		public BridgeMetadata(BridgeHandler handler, SubscribableChannel channel) {
+			this.handler = handler;
+			this.channel = channel;
+		}
+
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/redis/RedisChannelRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/redis/RedisChannelRegistry.java
@@ -30,7 +30,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.Message;
 import org.springframework.integration.MessageChannel;
-import org.springframework.integration.channel.registry.ChannelRegistry;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.SubscribableChannel;
@@ -38,6 +37,7 @@ import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.redis.inbound.RedisInboundChannelAdapter;
 import org.springframework.integration.redis.outbound.RedisPublishingMessageHandler;
+import org.springframework.integration.x.channel.registry.ChannelRegistry;
 import org.springframework.util.Assert;
 
 /**
@@ -95,7 +95,7 @@ public class RedisChannelRegistry implements ChannelRegistry, DisposableBean {
 		adapter.start();
 	}
 
-	public void stopAndRemoveAll(String name) {
+	public void cleanAll(String name) {
 		synchronized (this.lifecycleBeans) {
 			Iterator<Lifecycle> iterator = this.lifecycleBeans.iterator();
 			while (iterator.hasNext()) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/StreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/StreamPlugin.java
@@ -20,8 +20,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.integration.MessageChannel;
-import org.springframework.integration.channel.registry.ChannelRegistry;
-import org.springframework.integration.x.redis.RedisChannelRegistry;
+import org.springframework.integration.x.channel.registry.ChannelRegistry;
 import org.springframework.util.Assert;
 import org.springframework.xd.module.Module;
 import org.springframework.xd.module.Plugin;
@@ -50,10 +49,7 @@ public class StreamPlugin implements Plugin {
 
 	@Override
 	public void removeModule(Module module, String group, int index) {
-		if (this.channelRegistry instanceof RedisChannelRegistry) {
-			RedisChannelRegistry registry = (RedisChannelRegistry) this.channelRegistry;
-			registry.stopAndRemoveAll(group + "."  + index);
-		}
+		this.channelRegistry.cleanAll(group + "."  + index);
 	}
 
 	private void registerChannels(Map<String, MessageChannel> channels, String group, int index) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/Tap.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/Tap.java
@@ -18,7 +18,7 @@ package org.springframework.xd.dirt.stream;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.integration.MessageChannel;
-import org.springframework.integration.channel.registry.ChannelRegistry;
+import org.springframework.integration.x.channel.registry.ChannelRegistry;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/channel/registry/LocalChannelRegistryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/channel/registry/LocalChannelRegistryTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.integration.x.channel.registry;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.integration.channel.DirectChannel;
+
+/**
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
+public class LocalChannelRegistryTests {
+
+	@Test
+	public void test() throws Exception {
+		LocalChannelRegistry registry = new LocalChannelRegistry();
+		registry.setApplicationContext(new GenericApplicationContext());
+		registry.afterPropertiesSet();
+		registry.outbound("foo.0", new DirectChannel());
+		registry.inbound("foo.0", new DirectChannel());
+		registry.outbound("foo.1", new DirectChannel());
+		registry.inbound("foo.1", new DirectChannel());
+		registry.outbound("foo.2", new DirectChannel());
+		registry.tap("foo.0", new DirectChannel());
+		DirectFieldAccessor accessor = new DirectFieldAccessor(registry);
+		List<?> bridges = (List<?>) accessor.getPropertyValue("bridges");
+		assertEquals(6, bridges.size());
+		registry.cleanAll("foo.0");
+		assertEquals(4, bridges.size());
+		registry.cleanAll("foo.1");
+		assertEquals(2, bridges.size());
+		registry.cleanAll("foo.2");
+		assertEquals(1, bridges.size()); // tap remains
+	}
+
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/StreamPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/StreamPluginTests.java
@@ -19,8 +19,7 @@ package org.springframework.xd.dirt.plugins;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-
-import org.springframework.integration.channel.registry.LocalChannelRegistry;
+import org.springframework.integration.x.channel.registry.LocalChannelRegistry;
 import org.springframework.xd.module.Module;
 import org.springframework.xd.module.SimpleModule;
 


### PR DESCRIPTION
Temporarily "moved" the (Local)ChannelRegistry to xd; enhanced to support clean up of bridges when a module is undeployed (glue channels are not removed; perhaps a future optimization).

Also pushed those changes to an SI branch to make reviewing the changes easier...

https://github.com/garyrussell/spring-integration/compare/XD-184
