### PR TITLE
Support version 1.1 of Twitter's API and application authorization in twittersearch source.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ configure(javaProjects()) { subproject ->
 		jodaTimeVersion = '1.6'
 		springVersion = '3.2.2.RELEASE'
 		springBatchVersion = '2.1.9.RELEASE'
-		springIntegrationVersion = '3.0.0.M2'
+		springIntegrationVersion = '3.0.0.BUILD-SNAPSHOT'
 		springDataMongoVersion = '1.1.1.RELEASE'
 		springDataRedisVersion = '1.0.4.RELEASE'
 		springDataGemfireVersion = '1.3.1.RELEASE'

--- a/modules/source/twittersearch.xml
+++ b/modules/source/twittersearch.xml
@@ -15,6 +15,16 @@
 
 	<int:channel id="output"/>
 
-	<bean id="twitterTemplate" class="org.springframework.social.twitter.api.impl.TwitterTemplate"/>
+	<bean id="twitterTemplate" class="org.springframework.social.twitter.api.impl.TwitterTemplate">
+		<constructor-arg value="#{oauth2Template.authenticateClient().getAccessToken()}" />
+	</bean>
+
+	<bean id="oauth2Template" class="org.springframework.social.oauth2.OAuth2Template">
+		<constructor-arg value="${consumerKey}" />
+		<constructor-arg value="${consumerSecret}" />
+		<constructor-arg value="" />
+ 		<constructor-arg value="https://api.twitter.com/oauth2/token" /> 
+		<property name="useParametersForClientAuthentication" value="false" />
+	</bean>
 
 </beans>


### PR DESCRIPTION
Updated spring-xd's dependency on spring-integration to 3.0.0.BUILD-SNAPSHOT to take advantage of the changes in https://github.com/SpringSource/spring-integration/pull/816.

Also changed the twittersearch source to use Spring Social's OAuth2Template to obtain an application access token (via OAuth2 Client Credentials Grant) and to use that token when creating an instance of TwitterTemplate. This is so that requests for the search resource will be properly authorized, as required by Twitter API 1.1.

Twitter API v1.0 will be retired on June 11, 2013, making this change necessary. Version 1.1 of the Twitter API will require authorization for all requests, even search. 
