### PR TITLE
XD-165 Externalize log4j config for xd-admin & xd-container scripts

### DIFF
--- a/config/xd-admin-logger.properties
+++ b/config/xd-admin-logger.properties
@@ -1,0 +1,17 @@
+log4j.rootLogger=INFO, stdout, file
+
+# Console appender 
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2}:%L - %m%n
+
+# Rolling File Appender
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c:%L - %m%n
+
+log4j.appender.file.File=${xd.home}/logs/admin.log
+log4j.appender.file.Append=false
+log4j.appender.file.MaxFileSize=100KB
+
+log4j.logger.org.springframework=WARN

--- a/config/xd-container-logger.properties
+++ b/config/xd-container-logger.properties
@@ -1,0 +1,15 @@
+log4j.rootLogger=INFO, stdout, file
+ 
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2}:%L - %m%n
+
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c:%L - %m%n
+
+log4j.appender.file.File=${xd.home}/logs/${xd.container}.log
+log4j.appender.file.Append=false
+log4j.appender.file.MaxFileSize=100KB
+
+log4j.logger.org.springframework=WARN

--- a/scripts/xd/xd-admin
+++ b/scripts/xd/xd-admin
@@ -165,7 +165,7 @@ if [ x"$XD_HOME" = x ] ; then
     XD_HOME=$APP_HOME
 fi
 # set XD_HOME as system property via SPRING_XD_CONTAINER_OPTS
-SPRING_XD_ADMIN_OPTS=-Dxd.home=$XD_HOME
+SPRING_XD_ADMIN_OPTS="-Dxd.home=$XD_HOME -Dlog4j.configuration=file:///$XD_HOME/config/xd-admin-logger.properties"
 
 # Split up the JVM_OPTS And SPRING_XD_ADMIN_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/xd/xd-admin.bat
+++ b/scripts/xd/xd-admin.bat
@@ -81,7 +81,7 @@ if exist "%APP_HOME_LIB%" (
 if not exist "%XD_HOME%" (
     set XD_HOME=%APP_HOME%
 )
-set SPRING_XD_ADMIN_OPTS=-Dxd.home=%XD_HOME%
+set SPRING_XD_ADMIN_OPTS="-Dxd.home=%XD_HOME% -Dlog4j.configuration=file:///$XD_HOME/config/xd-admin-logger.properties"
 
 @rem Execute xd-admin
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_ADMIN_OPTS%  -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.AdminMain %CMD_LINE_ARGS%

--- a/scripts/xd/xd-container
+++ b/scripts/xd/xd-container
@@ -164,7 +164,7 @@ if [ x"$XD_HOME" = x ] ; then
     XD_HOME=$APP_HOME
 fi
 # set XD_HOME as system property via SPRING_XD_CONTAINER_OPTS
-SPRING_XD_CONTAINER_OPTS=-Dxd.home=$XD_HOME
+SPRING_XD_CONTAINER_OPTS="-Dxd.container=container -Dxd.home=$XD_HOME -Dlog4j.configuration=file:///$XD_HOME/config/xd-container-logger.properties"
 
 # Split up the JVM_OPTS And SPRING_XD_CONTAINER_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/xd/xd-container.bat
+++ b/scripts/xd/xd-container.bat
@@ -81,7 +81,7 @@ if exist "%APP_HOME_LIB%" (
 if not exist "%XD_HOME%" (
     set XD_HOME=%APP_HOME% 
 )
-set SPRING_XD_CONTAINER_OPTS=-Dxd.home=%XD_HOME%
+set SPRING_XD_CONTAINER_OPTS="-Dxd.container=container -Dxd.home=%XD_HOME% -Dlog4j.configuration=file:///$XD_HOME/config/xd-container-logger.properties"
 
 @rem Execute xd-container
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_CONTAINER_OPTS%  -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.ContainerMain %CMD_LINE_ARGS%

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/DefaultContainer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/DefaultContainer.java
@@ -16,10 +16,13 @@
 
 package org.springframework.xd.dirt.container;
 
+import java.io.File;
 import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.Logger;
+import org.apache.log4j.RollingFileAppender;
 
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.SmartLifecycle;
@@ -43,6 +46,8 @@ public class DefaultContainer implements Container, SmartLifecycle {
 
 	// TODO: consider moving to a file: location pattern within $XD_HOME
 	private static final String PLUGIN_CONFIGS = "classpath*:META-INF/spring/plugins/*.xml";
+	
+	private static final String LOG4J_FILE_APPENDER = "file";
 
 	private volatile AbstractApplicationContext context;
 
@@ -87,6 +92,7 @@ public class DefaultContainer implements Container, SmartLifecycle {
 	public void start() {
 		this.context = new ClassPathXmlApplicationContext(new String[]{CORE_CONFIG, PLUGIN_CONFIGS}, false);
 		context.setId(this.id);
+		setContainerLoggerFile();
 		context.registerShutdownHook();
 		context.refresh();
 		if (logger.isInfoEnabled()) {
@@ -112,5 +118,17 @@ public class DefaultContainer implements Container, SmartLifecycle {
 	public void addListener(ApplicationListener<?> listener) {
 		Assert.state(this.context != null, "context is not initialized");
 		this.context.addApplicationListener(listener);
+	}
+	
+	/**
+	 * Set container log appender file name with container id
+	 */
+	private void setContainerLoggerFile() {
+		// Update container log file name to use the current container id
+		if (Logger.getRootLogger().getAppender(LOG4J_FILE_APPENDER) != null) {
+			RollingFileAppender fileAppender = (RollingFileAppender)Logger.getRootLogger().getAppender(LOG4J_FILE_APPENDER);
+			// the xd.home system property is always set at this point
+			fileAppender.setFile(new File(System.getProperty("xd.home")).getAbsolutePath()+"/logs/container-"+this.getId()+".log");
+		}
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/launcher/RedisContainerLauncher.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/launcher/RedisContainerLauncher.java
@@ -20,7 +20,6 @@ import java.io.File;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;

--- a/spring-xd-dirt/src/main/resources/log4j.properties
+++ b/spring-xd-dirt/src/main/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootCategory=WARN, stdout
+log4j.rootLogger=WARN, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
  Added xd-admin & xd-container logger properties with rolling file appender
  Updated scripts to use the logger properties
  Set container log file name based on it's id
  Modified AbstractMain's setXDHome() to use exisitng xd.home system property(that comes mostly from scripts)
