### PR TITLE
XD-206

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AbstractMain.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AbstractMain.java
@@ -16,10 +16,15 @@ abstract class AbstractMain {
 	 * Set xd.home system property. If not a valid String, fallback to default.
 	 */
 	static void setXDHome(String home) {
-		if (!StringUtils.hasText(home)) {
-			home = DEFAULT_HOME;
+		String xdHome = DEFAULT_HOME;
+		if (StringUtils.hasText(home)) {
+			xdHome = home;
 		}
-		System.setProperty(XD_HOME_KEY, home);
+		// Check if xd.home system property already exists
+		else if (System.getProperty(XD_HOME_KEY) != null) {
+			xdHome = System.getProperty(XD_HOME_KEY);
+		}
+		System.setProperty(XD_HOME_KEY, xdHome);
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamServer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamServer.java
@@ -207,9 +207,6 @@ public class StreamServer implements SmartLifecycle, InitializingBean {
 			xdhome = (args.length > 0) ? args[0] : "..";
 			System.setProperty("xd.home", xdhome);
 		}
-		else {
-			System.setProperty("xd.home", System.getProperty("user.dir") + "/../");
-		}
 	}
 
 }


### PR DESCRIPTION
Consider pre-existing xd.home system property
For both ContainerMain & AdminMain, XD home is set in the following ways:

1) From xd-\* scripts, specify "--xdHomeDir" command line option.
   This will override any existing system property "xd.home".
2) If "--xdHomeDir" is not specified, then the "xd.home" system property will
   have the preference
3) If both "--xdHomeDir" and "xd.home" system property are not provided,
   then the relative path ".." is set to be XD home
