### PR TITLE
Fix DefaultContainer's updateLoggerFilename to call activateOptions() after setFile()

### DIFF
--- a/config/xd-admin-logger.properties
+++ b/config/xd-admin-logger.properties
@@ -15,3 +15,5 @@ log4j.appender.file.Append=false
 log4j.appender.file.MaxFileSize=100KB
 
 log4j.logger.org.springframework=WARN
+log4j.logger.org.springframework.xd=INFO
+log4j.logger.org.springframework.beans.factory.config=ERROR

--- a/config/xd-container-logger.properties
+++ b/config/xd-container-logger.properties
@@ -13,3 +13,5 @@ log4j.appender.file.Append=false
 log4j.appender.file.MaxFileSize=100KB
 
 log4j.logger.org.springframework=WARN
+log4j.logger.org.springframework.xd=INFO
+log4j.logger.org.springframework.beans.factory.config=ERROR

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/DefaultContainer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/DefaultContainer.java
@@ -130,6 +130,7 @@ public class DefaultContainer implements Container, SmartLifecycle {
 			// the xd.home system property is always set at this point
 			((RollingFileAppender) appender).setFile(
 					new File(System.getProperty("xd.home")).getAbsolutePath() + "/logs/container-" + this.getId() + ".log");
+			((RollingFileAppender) appender).activateOptions();
 		}
 	}
 


### PR DESCRIPTION
- This should activate the currently set file and open it for logging
- Also modified the logging levels to have INFO for org.springframework.xd
