### PR TITLE
xd-216: tap stream.module syntax

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/EnhancedStreamParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/EnhancedStreamParser.java
@@ -34,7 +34,7 @@ public class EnhancedStreamParser implements StreamParser {
 	public List<ModuleDeploymentRequest> parse(String name, String config) {
 
 		StreamConfigParser parser = new StreamConfigParser();
-		StreamsNode ast = parser.parse(config);
+		StreamsNode ast = parser.parse(name, config);
 		List<ModuleDeploymentRequest> requests = new ArrayList<ModuleDeploymentRequest>();
 
 		List<ModuleNode> moduleNodes = ast.getModuleNodes();

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/TokenKind.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/TokenKind.java
@@ -27,7 +27,8 @@ enum TokenKind {
 	NEWLINE("\n"),
 	SEMICOLON(";"),
 	REFERENCE("@"),
-	LITERAL_STRING
+	DOT("."),
+	LITERAL_STRING,
 	;
 
 	char[] tokenChars;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/Tokenizer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/Tokenizer.java
@@ -94,6 +94,9 @@ class Tokenizer {
 				case '\n':
 					pushCharToken(TokenKind.NEWLINE);
 					break;
+				case '.':
+					pushCharToken(TokenKind.DOT);
+					break;
 				case ';':
 					pushCharToken(TokenKind.SEMICOLON);
 					break;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/XDDSLMessages.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/XDDSLMessages.java
@@ -49,6 +49,8 @@ public enum XDDSLMessages {
 	OOD(Kind.ERROR,112,"Unexpectedly ran out of input"), //
 	UNEXPECTED_ESCAPE_CHAR(Kind.ERROR,114,"unexpected escape character."), //
 	UNEXPECTED_DATA(Kind.ERROR,115,"unexpected data in stream configuration ''{0}''"), //
+	UNRECOGNIZED_STREAM_REFERENCE(Kind.ERROR,116,"unrecognized stream reference ''{0}''"), //
+	UNRECOGNIZED_MODULE_REFERENCE(Kind.ERROR,117,"unrecognized module reference ''{0}''"), //
 	;
 
 	private Kind kind;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -170,6 +170,16 @@ public class StreamConfigParserTests {
 			// success
 		}
 	}
+	
+	@Test
+	public void testDirtyTapSupport() {
+//		StreamsNode ast = 
+		new StreamConfigParser().parse("one", "foo | transform --expression=--payload | bar");
+		StreamsNode ast2 = new StreamConfigParser().parse("two", "tap one.foo");
+		assertEquals("Streams[tap one.foo][(ModuleNode:tap --channel=one.0:0>11)]",ast2.stringify());
+		StreamsNode ast3 = new StreamConfigParser().parse("two", "tap one.transform");
+		assertEquals("Streams[tap one.transform][(ModuleNode:tap --channel=one.1:0>17)]",ast3.stringify());
+	}
 
 	@Test
 	public void expressions_xd159() {

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/TokenizerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/TokenizerTests.java
@@ -40,6 +40,12 @@ public class TokenizerTests {
 	}
 
 	@Test
+	public void dirtyTap() {
+		Tokenizer t = new Tokenizer("tap one.foo");
+		checkTokens(t,token_identifier("tap",0,3),token_identifier("one",4,7),token(TokenKind.DOT,7,8),token_identifier("foo",8,11));
+	}
+
+	@Test
 	public void moduleAliasingWithOptions() {
 		Tokenizer t = new Tokenizer("myhttp = http --port=9090");
 		checkTokens(t,token_identifier("myhttp",0,6),token(TokenKind.EQUALS,7,8),token_identifier("http",9,13),


### PR DESCRIPTION
This syntax will work

```
tap stream.module
```

This enables the following to work:

```
curl -X POST -d "http --port=9004 | transform --expression='new StringBuilder(payload).reverse()' | log" http://localhost:8080/streams/reverser

curl -X POST -d "tap reverser.transform | log" http://localhost:8080/streams/reverser2
```

Then when I do this:

```
curl -X POST -d "hello" http://localhost:9004
```

The container prints this (so both streams see the output of the transform).
    11:30:10,757  WARN ThreadPoolTaskScheduler-1 logger.reverser:141 - olleh
    11:30:10,760  WARN ThreadPoolTaskScheduler-1 logger.reverser2:141 - olleh

I could also write:

```
curl -X POST -d "tap @reverser.1 | log" http://localhost:8080/streams/reverser2
```

Without a StreamRepository the implementation is a bit dirty.  Basically the parser becomes stateful maintaining a list of streams it has seen - and uses it to resolve stream.module references that occur in tap calls.  

Note: I _think_ this implementation means if you restart the admin component the tap syntax will stop behaving because the state in the parser will be lost.
