### PR TITLE
XD-245: Added basic job support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ allprojects {
 	repositories {
 		maven { url 'http://repo.springsource.org/libs-milestone' }
 		maven { url 'http://repo.springsource.org/plugins-release' }
+		maven { url 'http://repo.springsource.org/plugins-snapshot' }
 	}
 	apply plugin: 'javadocHotfix'
 }
@@ -60,13 +61,13 @@ configure(javaProjects()) { subproject ->
 		hamcrestVersion = '1.3'
 		jodaTimeVersion = '1.6'
 		springVersion = '3.2.2.RELEASE'
-		springBatchVersion = '2.1.9.RELEASE'
+		springBatchVersion = '2.2.0.RELEASE'
 		springIntegrationVersion = '3.0.0.M2'
 		springDataMongoVersion = '1.1.1.RELEASE'
 		springDataRedisVersion = '1.0.4.RELEASE'
 		springDataGemfireVersion = '1.3.1.RELEASE'
 		lettuceVersion = '2.3.2'
-		springDataHadoopVersion = '1.0.0.RELEASE'
+		springDataHadoopVersion = '1.0.1.BUILD-SNAPSHOT'
 		springHATEOASVersion = '0.6.0.RELEASE'
 		tomcatVersion = '7.0.35'
 		commonsBeanUtilsVersion = '1.6'

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.plugins.job;
+
+import java.util.Properties;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.xd.dirt.container.DefaultContainer;
+import org.springframework.xd.dirt.plugins.BeanDefinitionAddingPostProcessor;
+import org.springframework.xd.module.Module;
+import org.springframework.xd.module.Plugin;
+
+/**
+ * Plugin to enable the registration of jobs in a central registry
+ * 
+ * @author Michael Minella
+ *
+ */
+public class JobPlugin implements Plugin {
+
+	private static final String CONTEXT_CONFIG_ROOT = DefaultContainer.XD_CONFIG_ROOT
+			+ "plugins/job/";
+
+	@Override
+	public void processModule(Module module, String group, int index) {
+		module.addComponents(new ClassPathResource(CONTEXT_CONFIG_ROOT + "registrar.xml"));
+		configureProperties(module, group);
+	}
+
+	@Override
+	public void removeModule(Module module, String group, int index) {
+	}
+
+	@Override
+	public void postProcessSharedContext(ConfigurableApplicationContext context) {
+		context.addBeanFactoryPostProcessor(new BeanDefinitionAddingPostProcessor(new ClassPathResource(CONTEXT_CONFIG_ROOT + "common.xml")));
+	}
+
+	private void configureProperties(Module module, String group) {
+		Properties properties = new Properties();
+		properties.setProperty("xd.stream.name", group);
+		module.addProperties(properties);
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/ModuleJobLauncher.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/ModuleJobLauncher.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.plugins.job;
+
+import java.util.Collection;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.Lifecycle;
+import org.springframework.util.Assert;
+
+/**
+ * Executes all jobs defined within a given stream once the context has been
+ * started.  This really should be replaced once we have the concept of
+ * triggers built in.
+ * 
+ * @author Michael Minella
+ *
+ */
+public class ModuleJobLauncher implements Lifecycle {
+
+	protected final Log logger = LogFactory.getLog(getClass());
+
+	private JobLauncher launcher;
+	private String groupName;
+	private JobRegistry registry;
+
+	private boolean isRunning = false;
+
+	public ModuleJobLauncher(JobLauncher launcher, JobRegistry registry) {
+		Assert.notNull(launcher, "A JobLauncher is required");
+
+		this.launcher = launcher;
+		this.registry = registry;
+	}
+
+	@Override
+	public void start() {
+		isRunning = true;
+
+		Collection<String> names = registry.getJobNames();
+
+		for (String curName : names) {
+			if(curName.startsWith(groupName)) {
+				try {
+					launcher.run(registry.getJob(curName), new JobParameters());
+				} catch (Exception e) {
+					logger.error("An error occured while starting job " + curName, e);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void stop() {
+		isRunning = false;
+	}
+
+	@Override
+	public boolean isRunning() {
+		return isRunning;
+	}
+
+	public void setGroupName(String groupName) {
+		this.groupName = groupName;
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/EnhancedStreamParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/EnhancedStreamParser.java
@@ -42,7 +42,7 @@ public class EnhancedStreamParser implements StreamParser {
 			ModuleNode moduleNode = moduleNodes.get(m);
 			ModuleDeploymentRequest request = new ModuleDeploymentRequest();
 			request.setGroup(name);
-			request.setType((m == 0) ? "source" : (m == moduleNodes.size() - 1) ? "sink" : "processor");
+			request.setType((m == 0) ? ((moduleNodes.size() == 1) ? "job" : "source") : (m == moduleNodes.size() - 1) ? "sink" : "processor");
 			request.setModule(moduleNode.getName());
 			request.setIndex(m);
 			if (moduleNode.hasArguments()) {

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/common.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/common.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+        
+
+        <bean id="jobRepository" class="org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean"/>
+
+        <bean id="transactionManager" class="org.springframework.batch.support.transaction.ResourcelessTransactionManager"/>
+
+        <bean id="jobRegistry" class="org.springframework.batch.core.configuration.support.MapJobRegistry"/>
+        
+        <bean id="jobLauncher" class="org.springframework.batch.core.launch.support.SimpleJobLauncher">
+                <property name="jobRepository" ref="jobRepository"/>
+        </bean>
+</beans>

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/registrar.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/registrar.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans.xsd">
+        
+        <bean id="registrar" class="org.springframework.batch.core.configuration.support.JobRegistryBeanPostProcessor">
+                <property name="jobRegistry" ref="jobRegistry"/>
+                <property name="groupName" value="${xd.stream.name}"/>
+        </bean>
+        
+        <bean id="startupJobLauncher" class="org.springframework.xd.dirt.plugins.job.ModuleJobLauncher">
+        	<constructor-arg ref="jobLauncher"/>
+        	<constructor-arg ref="jobRegistry"/>
+        	<property name="groupName" value="${xd.stream.name}"/>
+        </bean>
+</beans>

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/jobs.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/jobs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+	<bean class="org.springframework.xd.dirt.plugins.job.JobPlugin"/>
+
+</beans>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
@@ -1,0 +1,54 @@
+package org.springframework.xd.dirt.plugins.job;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.xd.dirt.plugins.BeanDefinitionAddingPostProcessor;
+import org.springframework.xd.module.Module;
+import org.springframework.xd.module.SimpleModule;
+
+public class JobPluginTests {
+
+	private JobPlugin plugin;
+
+	@Before
+	public void setUp() throws Exception {
+		plugin = new JobPlugin();
+	}
+
+	@Test
+	public void streamPropertiesAdded() {
+		Module module = new SimpleModule("testJob", "job");
+		assertEquals(0, module.getProperties().size());
+		plugin.processModule(module, "foo", 0);
+		assertEquals(1, module.getProperties().size());
+		assertEquals("foo", module.getProperties().getProperty("xd.stream.name"));
+	}
+
+	@Test
+	public void streamComponentsAdded() {
+		SimpleModule module = new SimpleModule("testJob", "job");
+		plugin.processModule(module, "foo", 0);
+		String[] moduleBeans = module.getApplicationContext().getBeanDefinitionNames();
+		Arrays.sort(moduleBeans);
+		assertEquals(2, moduleBeans.length);
+		assertTrue(moduleBeans[0].contains("registrar"));
+		assertTrue(moduleBeans[1].contains("startupJobLauncher"));
+	}
+
+	@Test
+	public void sharedComponentsAdded() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		plugin.postProcessSharedContext(context);
+		List<BeanFactoryPostProcessor> sharedBeans = context.getBeanFactoryPostProcessors();
+		assertEquals(1, sharedBeans.size());
+		assertTrue(sharedBeans.get(0) instanceof BeanDefinitionAddingPostProcessor);
+	}
+}


### PR DESCRIPTION
- Adds a new jobs directory under modules
- Allows DSL users to specify a job via the DSL
- Configuring a job via the DSL registers one that has the XML stored in the modules/job directory
- When a job is registered, it is immediately executed (need to remove this once we have a trigger concept in place).
