### PR TITLE
XD-364 - Create Trigger Registry

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
@@ -43,6 +43,7 @@ public class AdminController {
 	public XDRuntime info() {
 		XDRuntime xdRuntime = new XDRuntime();
 		xdRuntime.add(entityLinks.linkFor(StreamDefinitionResource.class).withRel("streams"));
+		xdRuntime.add(entityLinks.linkFor(StreamDefinitionResource.class).withRel("triggers"));
 		return xdRuntime;
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/TriggerController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/TriggerController.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.rest;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.VndErrors.VndError;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.xd.dirt.stream.NoSuchStreamException;
+import org.springframework.xd.dirt.stream.TriggerDefinition;
+import org.springframework.xd.dirt.stream.TriggerDefinitionRepository;
+import org.springframework.xd.dirt.stream.TriggerDeployer;
+import org.springframework.xd.rest.client.domain.TriggerDefinitionResource;
+
+/**
+ * Handles all Trigger related interactions.
+ *
+ * @author Gunnar Hillert
+ * @since 1.0
+ */
+@Controller
+@RequestMapping("/triggers")
+@ExposesResourceFor(TriggerDefinitionResource.class)
+public class TriggerController {
+
+	private final TriggerDeployer triggerDeployer;
+
+	private final TriggerDefinitionRepository triggerDefinitionRepository;
+
+	private final TriggerDefinitionResourceAssembler definitionResourceAssembler = new TriggerDefinitionResourceAssembler();
+
+	@Autowired
+	public TriggerController(TriggerDeployer streamDeployer, TriggerDefinitionRepository streamDefinitionRepository) {
+		this.triggerDeployer = streamDeployer;
+		this.triggerDefinitionRepository = streamDefinitionRepository;
+	}
+
+	/**
+	 * Create a new Trigger.
+	 *
+	 * @param name The name of the trigger to create (required)
+	 * @param definition The Trigger definition, expressed in the XD DSL (required)
+	 */
+	@RequestMapping(value = "", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	@ResponseBody
+	public TriggerDefinitionResource deploy(@RequestParam("name")
+	String name, @RequestParam("definition")
+	String definition) {
+		TriggerDefinition triggerDefinition = new TriggerDefinition(name, definition);
+		TriggerDefinition streamDefinition = triggerDeployer.create(triggerDefinition);
+		triggerDeployer.deploy(name);
+		TriggerDefinitionResource result = definitionResourceAssembler.toResource(streamDefinition);
+		return result;
+	}
+
+	/**
+	 * Retrieve information about a single {@link TriggerDefinition}.
+	 *
+	 * @param name the name of an existing trigger (required)
+	 */
+	@ResponseBody
+	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	public TriggerDefinitionResource display(@PathVariable("name")
+	String name) {
+		TriggerDefinition def = triggerDefinitionRepository.findOne(name);
+		return definitionResourceAssembler.toResource(def);
+	}
+
+	/**
+	 * Request removal of an existing trigger.
+	 *
+	 * @param name the name of an existing trigger (required)
+	 */
+	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
+	@ResponseStatus(HttpStatus.OK)
+	public void undeploy(@PathVariable("name")
+	String name) {
+		throw new NotImplementedException("Removal of Triggers is not Implemented, yet.");
+	}
+
+	// ---------------- Exception Handlers ------------------------
+
+	/**
+	 * Handles the case where client referenced an unknown entity.
+	 */
+	@ResponseBody
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public VndError onNoSuchStreamException(NoSuchStreamException e) {
+		return new VndError("NoSuchStreamException", e.getMessage());
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/TriggerDefinitionResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/TriggerDefinitionResourceAssembler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.rest;
+
+import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
+import org.springframework.xd.dirt.stream.StreamDefinition;
+import org.springframework.xd.dirt.stream.TriggerDefinition;
+import org.springframework.xd.rest.client.domain.TriggerDefinitionResource;
+
+/**
+ * Knows how to build a REST resource out of our domain model {@link TriggerDefinition}.
+ *
+ * @author Gunnar Hillert
+ * @since 1.0
+ */
+public class TriggerDefinitionResourceAssembler extends
+		ResourceAssemblerSupport<TriggerDefinition, TriggerDefinitionResource> {
+
+	public TriggerDefinitionResourceAssembler() {
+		super(TriggerController.class, TriggerDefinitionResource.class);
+	}
+
+	@Override
+	public TriggerDefinitionResource toResource(TriggerDefinition entity) {
+		return createResourceWithId(entity.getName(), entity);
+	}
+
+	@Override
+	protected TriggerDefinitionResource instantiateResource(TriggerDefinition entity) {
+		return new TriggerDefinitionResource(entity.getName(), entity.getDefinition());
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDefinition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.xd.dirt.stream;
+
+
+/**
+ * Represents the model for defining Triggers.
+ *
+ * @author Gunnar Hillert
+ * @since 1.0
+ *
+ */
+public class TriggerDefinition extends StreamDefinition {
+
+	/**
+	 * @param name The trigger name
+	 * @param definition The trigger definition
+	 *
+	 */
+	public TriggerDefinition(String name, String definition) {
+		super(name, definition);
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDefinitionRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.xd.dirt.stream;
+
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Data Repository for {@link TriggerDefinition}s.
+ *
+ * @author Gunnar Hillert
+ * @since 1.0
+ *
+ */
+public interface TriggerDefinitionRepository extends CrudRepository<TriggerDefinition,String> {
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDeployer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.xd.dirt.stream;
+
+import java.util.List;
+
+import org.springframework.util.Assert;
+import org.springframework.xd.dirt.core.ResourceDeployer;
+import org.springframework.xd.dirt.module.ModuleDeploymentRequest;
+
+/**
+ * Responsible for deploying {@link TriggerDefinition}s.
+ *
+ * @author Gunnar Hillert
+ * @since 1.0
+ *
+ */
+public class TriggerDeployer implements ResourceDeployer<TriggerDefinition> {
+
+	private final TriggerDefinitionRepository repository;
+	private final TriggerDeploymentMessageSender messageSender;
+
+	//TODO This should possibly be handled by a dedicated TriggerStreamParser
+	private final StreamParser streamParser = new EnhancedStreamParser();
+
+	public TriggerDeployer(TriggerDefinitionRepository repository, TriggerDeploymentMessageSender messageSender) {
+		Assert.notNull(repository, "repository cannot be null");
+		Assert.notNull(messageSender, "message sender cannot be null");
+		this.repository = repository;
+		this.messageSender = messageSender;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.xd.dirt.core.ResourceDeployer#deploy(java.lang.String)
+	 */
+	@Override
+	public void deploy(String name) {
+		Assert.hasText(name, "name cannot be blank or null");
+
+		TriggerDefinition triggerDefinition = repository.findOne(name);
+		Assert.notNull(triggerDefinition, "tap '" + name+ " not found");
+		List<ModuleDeploymentRequest> requests = streamParser.parse(name, triggerDefinition.getDefinition());
+		messageSender.sendDeploymentRequests(name, requests);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.xd.dirt.core.ResourceDeployer#create(java.lang.Object)
+	 */
+	@Override
+	public TriggerDefinition create(TriggerDefinition triggerDefinition) {
+		Assert.notNull(triggerDefinition, "trigger definition may not be null");
+		return repository.save(triggerDefinition);
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDeploymentMessageSender.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDeploymentMessageSender.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.xd.dirt.stream;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.integration.Message;
+import org.springframework.integration.MessageChannel;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.util.Assert;
+import org.springframework.xd.dirt.module.ModuleDeploymentRequest;
+
+/**
+ * @author Gunnar Hillert
+ * @since 1.0
+ *
+ */
+public class TriggerDeploymentMessageSender {
+
+	private final MessageChannel outputChannel;
+	private final Map<String, List<ModuleDeploymentRequest>> deployments = new ConcurrentHashMap<String, List<ModuleDeploymentRequest>>();
+
+	/**
+	 * @param outputChannel Must not be null
+	 */
+	public TriggerDeploymentMessageSender(MessageChannel outputChannel) {
+		Assert.notNull(outputChannel, "The outputChannel must not be null.");
+		this.outputChannel = outputChannel;
+	}
+
+	public void sendDeploymentRequests(String name, List<ModuleDeploymentRequest> requests) {
+		this.addDeployment(name, requests);
+		for (ModuleDeploymentRequest request : requests) {
+			Message<?> message = MessageBuilder.withPayload(request.toString()).build();
+			this.outputChannel.send(message);
+		};
+
+	}
+
+	protected final void addDeployment(String name, List<ModuleDeploymentRequest> modules) {
+		this.deployments.put(name, modules);
+	}
+
+	protected List<ModuleDeploymentRequest> removeDeployment(String name) {
+		return this.deployments.remove(name);
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/redis/RedisTriggerDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/redis/RedisTriggerDefinitionRepository.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.stream.redis;
+
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.xd.dirt.store.AbstractRedisRepository;
+import org.springframework.xd.dirt.stream.TriggerDefinition;
+import org.springframework.xd.dirt.stream.TriggerDefinitionRepository;
+
+/**
+ * An implementation of {@link TriggerDefinitionRepository} that persists
+ * {@link TriggerDefinition}s to Redis.
+ *
+ * @author Gunnar Hillert
+ * @since 1.0
+ *
+ */
+public class RedisTriggerDefinitionRepository extends AbstractRedisRepository<TriggerDefinition, String> implements
+		TriggerDefinitionRepository {
+
+	public RedisTriggerDefinitionRepository(RedisOperations<String, String> redisOperations) {
+		super("triggers.", redisOperations);
+	}
+
+	@Override
+	protected TriggerDefinition deserialize(String v) {
+		String[] parts = v.split("\n");
+		return new TriggerDefinition(parts[0], parts[1]);
+	}
+
+	@Override
+	protected String serialize(TriggerDefinition entity) {
+		return entity.getName() + "\n" + entity.getDefinition();
+	}
+
+	@Override
+	protected String keyFor(TriggerDefinition entity) {
+		return entity.getName();
+	}
+
+	@Override
+	protected String serializeId(String id) {
+		return id;
+	}
+
+}

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/store/redis-admin.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/store/redis-admin.xml
@@ -23,4 +23,12 @@
 		</constructor-arg>
 	</bean>
 
+	<bean id="triggerRepository" class="org.springframework.xd.dirt.stream.redis.RedisTriggerDefinitionRepository">
+		<constructor-arg>
+			<bean class="org.springframework.data.redis.core.RedisTemplate">
+				<property name="connectionFactory" ref="redisConnectionFactory" />
+			</bean>
+		</constructor-arg>
+	</bean>
+
 </beans>

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/local-admin.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/local-admin.xml
@@ -16,8 +16,17 @@
 <!-- Pipe the deployment messages directly to the container input -->
 
 	<bean id="streamDeployer" class="org.springframework.xd.dirt.stream.DefaultStreamDeployer">
-		<constructor-arg ref="input" />
-		<constructor-arg ref="streamRepository" />
+		<constructor-arg name="outputChannel"              ref="input" />
+		<constructor-arg name="streamDefinitionRepository" ref="streamRepository" />
+	</bean>
+
+	<bean id="triggerDeploymentMessageSender" class="org.springframework.xd.dirt.stream.TriggerDeploymentMessageSender">
+		<constructor-arg name="outputChannel" ref="input" />
+	</bean>
+
+	<bean id="triggerDeployer" class="org.springframework.xd.dirt.stream.TriggerDeployer">
+		<constructor-arg name="messageSender" ref="triggerDeploymentMessageSender" />
+		<constructor-arg name="repository"    ref="triggerRepository" />
 	</bean>
 	
 	<bean id="tapDeployer" class="org.springframework.xd.dirt.stream.TapDeployer">

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/MockedDependencies.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/MockedDependencies.java
@@ -24,6 +24,8 @@ import org.springframework.xd.dirt.stream.StreamDefinitionRepository;
 import org.springframework.xd.dirt.stream.StreamDeployer;
 import org.springframework.xd.dirt.stream.TapDefinitionRepository;
 import org.springframework.xd.dirt.stream.TapDeployer;
+import org.springframework.xd.dirt.stream.TriggerDefinitionRepository;
+import org.springframework.xd.dirt.stream.TriggerDeployer;
 
 @Configuration
 public class MockedDependencies {
@@ -31,6 +33,16 @@ public class MockedDependencies {
 	@Bean
 	public StreamDeployer streamDeployer() {
 		return mock(StreamDeployer.class);
+	}
+
+	@Bean
+	public TapDeployer tapDeployer() {
+		return mock(TapDeployer.class);
+	}
+
+	@Bean
+	public TriggerDeployer triggerDeployer() {
+		return mock(TriggerDeployer.class);
 	}
 
 	@Bean
@@ -44,8 +56,8 @@ public class MockedDependencies {
 	}
 
 	@Bean
-	public TapDeployer tapDeployer() {
-		return mock(TapDeployer.class);
+	public TriggerDefinitionRepository triggerDefinitionRepository() {
+		return mock(TriggerDefinitionRepository.class);
 	}
 
 }

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/TriggerDefinitionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/TriggerDefinitionResource.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.rest.client.domain;
+
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ * Represents a Trigger Definition.
+ *
+ * @author Gunnar Hillert
+ * @since 1.0
+ */
+public class TriggerDefinitionResource extends ResourceSupport {
+
+	/**
+	 * The name of the trigger definition.
+	 */
+	private String name;
+
+	/**
+	 * The DSL representation of this trigger definition.
+	 */
+	private String definition;
+
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	@SuppressWarnings("unused")
+	private TriggerDefinitionResource() {
+
+	}
+
+	public TriggerDefinitionResource(String name, String definition) {
+		this.name = name;
+		this.definition = definition;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getDefinition() {
+		return definition;
+	}
+
+}


### PR DESCRIPTION
- Create Trigger Controller (REST Endpoint)
- Persist Trigger to Redis
- Create associated domain objects

Originally the ideas was to allow the following REST call using `POST` to `http://localhost:8080/triggers/myAwesomeTrigger`:

`--cron='*/10 * * * * *'` but in order to support the existing Stream parser you need to use: `trigger --cron='*/10 * * * * *'`
