### PR TITLE
XD-373 Add 'create tap' shell command

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.xd.rest.client.domain.StreamDefinitionResource;
+import org.springframework.xd.rest.client.domain.TapDefinitionResource;
 import org.springframework.xd.rest.client.domain.XDRuntime;
 
 /**
@@ -43,6 +44,7 @@ public class AdminController {
 	public XDRuntime info() {
 		XDRuntime xdRuntime = new XDRuntime();
 		xdRuntime.add(entityLinks.linkFor(StreamDefinitionResource.class).withRel("streams"));
+		xdRuntime.add(entityLinks.linkFor(TapDefinitionResource.class).withRel("taps"));
 		return xdRuntime;
 	}
 }

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/SpringXDClient.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/SpringXDClient.java
@@ -25,12 +25,14 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.xd.rest.client.domain.StreamDefinitionResource;
+import org.springframework.xd.rest.client.domain.TapDefinitionResource;
 import org.springframework.xd.rest.client.domain.XDRuntime;
 
 /**
  * Implementation of the SpringXD remote interaction API.
  *
  * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
  */
 public class SpringXDClient implements SpringXDOperations {
 
@@ -43,6 +45,8 @@ public class SpringXDClient implements SpringXDOperations {
 				XDRuntime.class);
 		resources.put("streams",
 				URI.create(xdRuntime.getLink("streams").getHref()));
+		resources.put("taps",
+				URI.create(xdRuntime.getLink("taps").getHref()));
 
 	}
 
@@ -64,6 +68,19 @@ public class SpringXDClient implements SpringXDOperations {
 		String uriTemplate = resources.get("streams").toString() + "/{name}";
 		restTemplate
 				.delete(uriTemplate, Collections.singletonMap("name", name));
+	}
+	
+	@Override
+	public TapDefinitionResource createTap(String name, String definition, Boolean autoStart) {
+		String control = ((autoStart != null && autoStart.booleanValue()) ? "start" : "");
+		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
+		values.add("name", name);
+		values.add("definition", definition);
+		values.add("control", control);
+
+		TapDefinitionResource tap = restTemplate.postForObject(resources.get("taps"),
+				values, TapDefinitionResource.class);
+		return tap;
 	}
 
 }

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/SpringXDOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/SpringXDOperations.java
@@ -17,16 +17,20 @@
 package org.springframework.xd.rest.client;
 
 import org.springframework.xd.rest.client.domain.StreamDefinitionResource;
+import org.springframework.xd.rest.client.domain.TapDefinitionResource;
 
 /**
  * The interface defining operations available against a Spring XD runtime.
  *
  * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
  */
 public interface SpringXDOperations {
 
 	public StreamDefinitionResource deployStream(String name, String defintion);
 
 	public void undeployStream(String name);
+	
+	public TapDefinitionResource createTap(String name, String definition, Boolean control);
 
 }

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/StreamDefinitionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/StreamDefinitionResource.java
@@ -38,8 +38,7 @@ public class StreamDefinitionResource extends ResourceSupport {
 	/**
 	 * Default constructor for serialization frameworks.
 	 */
-	@SuppressWarnings("unused")
-	private StreamDefinitionResource() {
+	protected StreamDefinitionResource() {
 
 	}
 

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/TapDefinitionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/TapDefinitionResource.java
@@ -26,7 +26,15 @@ import org.springframework.util.Assert;
  */
 public class TapDefinitionResource extends StreamDefinitionResource {
 
-	private final String streamName;
+	private String streamName;
+	
+	/**
+	 * Default constructor for serialization frameworks.
+	 */
+	@SuppressWarnings("unused")
+	private TapDefinitionResource() {
+		super();
+	}
 
 	/**
 	 * @param name

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/StreamCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/StreamCommands.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.shell;
+package org.springframework.xd.shell.command;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.shell.core.CommandMarker;
@@ -22,6 +22,7 @@ import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
+import org.springframework.xd.shell.XDShell;
 
 @Component
 public class StreamCommands implements CommandMarker {

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/TapCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/TapCommands.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.shell.command;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.stereotype.Component;
+import org.springframework.xd.shell.XDShell;
+
+/**
+ * Tap commands.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+
+@Component
+public class TapCommands implements CommandMarker {
+
+	@Autowired
+	private XDShell xdShell;
+
+	@CliAvailabilityIndicator({ "create tap" })
+	public boolean available() {
+		return xdShell.getSpringXDOperations() != null;
+	}
+
+	@CliCommand(value = "create tap", help = "Create a tap")
+	public String createTap(
+			@CliOption(mandatory = true, key = "name", help = "the name to give to the tap")
+			String name,
+			@CliOption(mandatory = true, key = { "", "definition" }, help = "Tap definition, using XD DSL (e.g. \"tap@mystream.filter | sink1\")")
+			String dsl,
+			@CliOption(key = "autostart", help = "flag to set true to autostart after creation")
+			Boolean autoStart) {
+		try {
+			xdShell.getSpringXDOperations().createTap(name, dsl, autoStart);
+		} 
+		catch (Exception e) {
+			return String.format("Error creating tap '%s'", name);
+		}
+		return String.format(((autoStart != null && autoStart.booleanValue()) ? 
+				"Successfully created and deployed tap '%s'" : "Successfully created tap '%s'"), name);
+	}
+
+}


### PR DESCRIPTION
Added '/taps' link to AdminController to represent TapDefinitionResource at XDRuntime
Defined createTap method as SpringXDOperation
Added createTap rest client method at SpringXDClient to invoke TapsController
Added 'createTap' shell cli command to the new class TapCommands
Moved StreamCommands into xd.shell.command package along with TapCommands
Added no-arg constructor for TapDefinitionResource for serialization during REST operation
