### PR TITLE
XD-291 resolve the shutdown of http adapter

### DIFF
--- a/spring-xd-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
+++ b/spring-xd-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
@@ -59,6 +59,7 @@ import org.springframework.integration.support.MessageBuilder;
 public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 
 	private final int port;
+	private ServerBootstrap bootstrap;
 
 	public NettyHttpInboundChannelAdapter(int port) {
 		this.port = port;
@@ -66,11 +67,16 @@ public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
-		ServerBootstrap bootstrap = new ServerBootstrap(new NioServerSocketChannelFactory(
+		bootstrap = new ServerBootstrap(new NioServerSocketChannelFactory(
 				Executors.newCachedThreadPool(), Executors.newCachedThreadPool()));
 		bootstrap.setOption("child.tcpNoDelay", true);
 		bootstrap.setPipelineFactory(new PipelineFactory());
 		bootstrap.bind(new InetSocketAddress(this.port));
+	}
+	
+	@Override
+	protected void doStop(){
+		bootstrap.shutdown();
 	}
 
 	private class PipelineFactory implements ChannelPipelineFactory {


### PR DESCRIPTION
The problem of XD-291 is that the httpAdapter does not implement the stop method, so when the user tried to delete the stream of a http module, the server can not stop.

The solution is to implement the stop method to actually stop the embedded http adapter.

-Shaozhen Ding from Pivotal
