### PR TITLE
Fix redis transport's deployer configs

### DIFF
--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/redis-admin.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/redis-admin.xml
@@ -23,7 +23,7 @@
 	
 	<bean id="tapDeployer" class="org.springframework.xd.dirt.stream.TapDeployer">
 		<constructor-arg ref="tapRepository" />
-		<constructor-arg ref="streamRepository" />
+		<constructor-arg ref="streamDefinitionRepository" />
 		<constructor-arg>
 			<bean class="org.springframework.xd.dirt.stream.TapDeploymentMessageSender">
 				<constructor-arg ref="deployChannel"/>
@@ -48,6 +48,15 @@
 	<bean id="jobDeployer" class="org.springframework.xd.dirt.stream.JobDeployer">
 		<constructor-arg name="repository" ref="jobRepository" />
 		<constructor-arg name="messageSender" ref="jobDeploymentMessageSender" />
+	</bean>
+	
+	<bean id="triggerDeployer" class="org.springframework.xd.dirt.stream.TriggerDeployer">
+		<constructor-arg ref="triggerRepository"/>
+		<constructor-arg>
+			<bean class="org.springframework.xd.dirt.stream.TriggerDeploymentMessageSender">
+				<constructor-arg ref="deployChannel"/>
+			</bean>
+		</constructor-arg>
 	</bean>
 		
 </beans>


### PR DESCRIPTION
-Added triggerDeployer bean definition at redis-admin transport config
-Fixed tapDeployer constructor to use streamDefinitionRepository
