### PR TITLE
XD-444 Make External Server Rules Optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,7 @@ project('spring-xd-analytics') {
 		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
 		compile "org.springframework.integration:spring-integration-splunk:$springIntegrationSplunkVersion"
 		compile "joda-time:joda-time:$jodaTimeVersion"
+		testCompile project(":spring-xd-test")
 		testCompile "nl.jqno.equalsverifier:equalsverifier:1.1.3"
 		testCompile "org.springframework:spring-test:$springVersion"
 		testCompile ("org.mockito:mockito-core:$mockitoVersion") {

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractAggregateCounterTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractAggregateCounterTests.java
@@ -24,12 +24,14 @@ import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.joda.time.chrono.ISOChronology;
 import org.junit.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.xd.analytics.metrics.core.AggregateCount;
 import org.springframework.xd.analytics.metrics.core.AggregateCounterService;
 
 /**
  * @author Luke Taylor
+ * @author Gary Russell
  */
 public abstract class AbstractAggregateCounterTests {
 	protected final String counterName = "test";
@@ -109,7 +111,8 @@ public abstract class AbstractAggregateCounterTests {
 		assertEquals(48, counts.length);
 		// The first hour starts before the first counts are added
 		assertEquals(1419, counts[0]); // sum [27..59]
-		for (int i = 1; i < counts.length; i++)
+		for (int i = 1; i < counts.length; i++) {
 			assertEquals(1770, counts[i]); // sum [0..59]
+		}
 	}
 }

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/common/ServicesConfig.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/common/ServicesConfig.java
@@ -1,52 +1,88 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.analytics.metrics.common;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.xd.analytics.metrics.redis.*;
+import org.springframework.xd.analytics.metrics.redis.RedisAggregateCounterService;
+import org.springframework.xd.analytics.metrics.redis.RedisCounterRepository;
+import org.springframework.xd.analytics.metrics.redis.RedisCounterService;
+import org.springframework.xd.analytics.metrics.redis.RedisFieldValueCounterRepository;
+import org.springframework.xd.analytics.metrics.redis.RedisFieldValueCounterService;
+import org.springframework.xd.analytics.metrics.redis.RedisGaugeRepository;
+import org.springframework.xd.analytics.metrics.redis.RedisGaugeService;
+import org.springframework.xd.analytics.metrics.redis.RedisRichGaugeRepository;
+import org.springframework.xd.analytics.metrics.redis.RedisRichGaugeService;
 
+/**
+ *
+ * @author Mark Pollack
+ * @author Luke Taylor
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
 @Configuration
 public class ServicesConfig {
-	
+
 	@Bean
 	public RedisFieldValueCounterService fieldValueCounterService() {
 		return new RedisFieldValueCounterService(redisFieldValueCounterRepository());
 	}
-	
+
 	@Bean
 	public RedisFieldValueCounterRepository redisFieldValueCounterRepository() {
 		return new RedisFieldValueCounterRepository(redisConnectionFactory());
 	}
-	
+
 	@Bean
 	public RedisRichGaugeService redisRichGaugeService() {
 		return new RedisRichGaugeService(redisRichGaugeRepository());
 	}
-	
+
 	@Bean
 	public RedisRichGaugeRepository redisRichGaugeRepository() {
 		return new RedisRichGaugeRepository(redisConnectionFactory());
 	}
-	
+
 	@Bean
 	public RedisGaugeService redisGaugeService() {
 		return new RedisGaugeService(redisGaugeRepository());
 	}
-	
+
 	@Bean
 	public RedisGaugeRepository redisGaugeRepository() {
 		return new RedisGaugeRepository(redisConnectionFactory());
 	}
-	
+
 	@Bean
 	public RedisCounterService redisCounterService() {
 		return new RedisCounterService(redisCounterRepository());
 	}
-	
+
 	@Bean
-	public RedisCounterRepository redisCounterRepository() {	
+	public RedisCounterRepository redisCounterRepository() {
 		return new RedisCounterRepository(redisConnectionFactory());
 	}
 
@@ -59,14 +95,22 @@ public class ServicesConfig {
 	public StringRedisTemplate stringRedisTemplate() {
 		return new StringRedisTemplate(redisConnectionFactory());
 	}
-	
+
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		LettuceConnectionFactory cf = new LettuceConnectionFactory();
-		cf.setHostName("localhost");
-		cf.setPort(6379);
-		return cf;
+		try {
+			LettuceConnectionFactory cf = new LettuceConnectionFactory();
+			cf.setHostName("localhost");
+			cf.setPort(6379);
+			cf.afterPropertiesSet();
+			return cf;
+		}
+		catch (RedisConnectionFailureException e) {
+			RedisConnectionFactory mockCF = mock(RedisConnectionFactory.class);
+			when(mockCF.getConnection()).thenReturn(mock(RedisConnection.class));
+			return mockCF;
+		}
 	}
-	
-	
+
+
 }

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/FieldValueCounterHandlerTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/FieldValueCounterHandlerTests.java
@@ -1,15 +1,18 @@
 package org.springframework.xd.analytics.metrics.integration;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
 import org.springframework.integration.message.GenericMessage;
@@ -21,6 +24,7 @@ import org.springframework.xd.analytics.metrics.common.ServicesConfig;
 import org.springframework.xd.analytics.metrics.core.FieldValueCounter;
 import org.springframework.xd.analytics.metrics.core.FieldValueCounterRepository;
 import org.springframework.xd.analytics.metrics.core.FieldValueCounterService;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 import org.springframework.xd.tuple.Tuple;
 import org.springframework.xd.tuple.TupleBuilder;
 
@@ -28,60 +32,63 @@ import org.springframework.xd.tuple.TupleBuilder;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FieldValueCounterHandlerTests {
 
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
+
 	@Autowired
 	private FieldValueCounterService fieldValueCounterService;
-	
+
 	@Autowired
 	private FieldValueCounterRepository repo;
-	
+
 	private final String mentionsFieldValueCounterName = "tweetMentionsCounter";
-	
+
 	@Before
 	@After
 	public void initAndCleanup() {
 		repo.delete(mentionsFieldValueCounterName);
 	}
-	
+
 	@Test
 	public void messageCountTest() {
 		FieldValueCounter counter = fieldValueCounterService.getOrCreate(mentionsFieldValueCounterName);
-				
+
 		assertThat(repo.findOne(counter.getName()), notNullValue());
-		
+
 		FieldValueCounterHandler handler = new FieldValueCounterHandler(fieldValueCounterService, mentionsFieldValueCounterName, "mentions");
 
 
 		Tuple tuple = TupleBuilder.tuple().of("mentions", Arrays.asList(new String[]{"markp","markf","jurgen"}));
 		Message<Tuple> message = MessageBuilder.withPayload(tuple).build();
-		
-		handler.process(message);		
-		Map<String, Double> counts = repo.findOne(mentionsFieldValueCounterName).getFieldValueCount();		
+
+		handler.process(message);
+		Map<String, Double> counts = repo.findOne(mentionsFieldValueCounterName).getFieldValueCount();
 		assertThat(counts.get("markp"), equalTo(1.0));
 		assertThat(counts.get("markf"), equalTo(1.0));
 		assertThat(counts.get("jurgen"), equalTo(1.0));
-		
-		
+
+
 		tuple = TupleBuilder.tuple().of("mentions", Arrays.asList(new String[]{"markp","jon","jurgen"}));
 		message = MessageBuilder.withPayload(tuple).build();
-		
-		handler.process(message);		
-		counts = repo.findOne(mentionsFieldValueCounterName).getFieldValueCount();		
+
+		handler.process(message);
+		counts = repo.findOne(mentionsFieldValueCounterName).getFieldValueCount();
 		assertThat(counts.get("markp"), equalTo(2.0));
 		assertThat(counts.get("jon"), equalTo(1.0));
 		assertThat(counts.get("jurgen"), equalTo(2.0));
-		
-		
+
+
 		SimpleTweet tweet = new SimpleTweet("joe", "say hello to @markp and @jon and @jurgen");
 		Message<SimpleTweet> msg = MessageBuilder.withPayload(tweet).build();
-		
+
 		handler.process(msg);
-		counts = repo.findOne(mentionsFieldValueCounterName).getFieldValueCount();		
+		counts = repo.findOne(mentionsFieldValueCounterName).getFieldValueCount();
 		assertThat(counts.get("markp"), equalTo(3.0));
 		assertThat(counts.get("jon"), equalTo(2.0));
 		assertThat(counts.get("jurgen"), equalTo(3.0));
-		
+
 	}
-	
+
 	@Test
 	public void acceptsJson() {
 		String json = "{\"mentions\":[\"markp\",\"markf\",\"jurgen\"]}";
@@ -92,6 +99,6 @@ public class FieldValueCounterHandlerTests {
 		assertThat(counts.get("markf"), equalTo(1.0));
 		assertThat(counts.get("jurgen"), equalTo(1.0));
 	}
-	
+
 
 }

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/GaugeHandlerTests-context.xml
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/GaugeHandlerTests-context.xml
@@ -30,10 +30,4 @@
 		<constructor-arg ref="connectionFactory" />
 	</bean>
 
-	<bean id="connectionFactory"
-		class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory">
-		<constructor-arg index="0" value="${redis.hostname:localhost}" />
-		<constructor-arg index="1" value="${redis.port:6379}" />
-	</bean>
-
 </beans>

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/GaugeHandlerTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/GaugeHandlerTests.java
@@ -18,6 +18,7 @@ package org.springframework.xd.analytics.metrics.integration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -26,11 +27,20 @@ import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
 import org.springframework.core.env.MapPropertySource;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.integration.MessageChannel;
 import org.springframework.integration.message.GenericMessage;
 import org.springframework.integration.transformer.MessageTransformationException;
@@ -38,19 +48,22 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.xd.analytics.metrics.core.Gauge;
 import org.springframework.xd.analytics.metrics.core.GaugeService;
-import org.springframework.xd.analytics.metrics.core.RichGauge;
-import org.springframework.xd.analytics.metrics.core.RichGaugeService;
 import org.springframework.xd.analytics.metrics.redis.RedisGaugeRepository;
-import org.springframework.xd.analytics.metrics.redis.RedisRichGaugeRepository;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
 /**
  * @author David Turanski
  * @author Luke Taylor
+ * @author Gary Russell
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@ContextConfiguration(classes=GaugeHandlerTestsConfig.class)
 public class GaugeHandlerTests {
+
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
+
 	@Autowired
 	RedisGaugeRepository repo;
 
@@ -96,15 +109,14 @@ public class GaugeHandlerTests {
 	public void testhandlerWithExpression() {
 
 		@SuppressWarnings("resource")
-		ClassPathXmlApplicationContext applicationContext = new ClassPathXmlApplicationContext();
+		AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext();
 
 		MapPropertySource propertiesSource = new MapPropertySource("test", Collections.singletonMap("valueExpression",
 				(Object) "payload.get('price').asDouble()"));
 
 		applicationContext.getEnvironment().getPropertySources().addLast(propertiesSource);
 
-		applicationContext
-				.setConfigLocation("/org/springframework/xd/analytics/metrics/integration/GaugeHandlerTests-context.xml");
+		applicationContext.register(GaugeHandlerTestsConfig.class);
 
 		applicationContext.refresh();
 		input = applicationContext.getBean("input", MessageChannel.class);
@@ -122,7 +134,7 @@ public class GaugeHandlerTests {
 		assertEquals(73, gauge.getValue());
 		//assertEquals(1, gauge.getCount());
 
-		//Included here because the message handler constructor creates the gauge. Don't want to 
+		//Included here because the message handler constructor creates the gauge. Don't want to
 		//delete it in @After.
 		repo.delete("test");
 	}
@@ -143,3 +155,23 @@ public class GaugeHandlerTests {
 	}
 }
 
+@Configuration
+@ImportResource("org/springframework/xd/analytics/metrics/integration/GaugeHandlerTests-context.xml")
+class GaugeHandlerTestsConfig {
+
+	@Bean
+	public RedisConnectionFactory connectionFactory() {
+		try {
+			LettuceConnectionFactory cf = new LettuceConnectionFactory();
+			cf.setHostName("localhost");
+			cf.setPort(6379);
+			cf.afterPropertiesSet();
+			return cf;
+		}
+		catch (RedisConnectionFailureException e) {
+			RedisConnectionFactory mockCF = mock(RedisConnectionFactory.class);
+			when(mockCF.getConnection()).thenReturn(mock(RedisConnection.class));
+			return mockCF;
+		}
+	}
+}

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/MessageCounterHandlerTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/MessageCounterHandlerTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.analytics.metrics.integration;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -5,10 +20,11 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.Message;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.test.context.ContextConfiguration;
@@ -16,36 +32,46 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.xd.analytics.metrics.core.Counter;
 import org.springframework.xd.analytics.metrics.core.CounterRepository;
 import org.springframework.xd.analytics.metrics.redis.RedisCounterService;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
+/**
+ * @author Mark Pollack
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
 public class MessageCounterHandlerTests {
 
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
+
 	@Autowired
 	private RedisCounterService counterService;
-	
+
 	@Autowired
 	private CounterRepository repo;
-	
+
 	@Before
 	@After
 	public void initAndCleanup() {
 		repo.delete("tupleCounter");
 	}
-	
+
 	@Test
 	public void messageCountTest() {
 		Counter counter = counterService.getOrCreate("tupleCounter");
-		
+
 		//Counter counter = repo.findByName("tupleCounter");
 		assertThat(counter.getValue(), equalTo(0L));
 		MessageCounterHandler handler = new MessageCounterHandler(counterService, "tupleCounter");
 		Message<String> message = MessageBuilder.withPayload("Hi").build();
-		
+
 		handler.process(message);
 		counter = repo.findOne("tupleCounter");
 		assertThat(counter.getValue(), equalTo(1L));
-		
+
 	}
 
 }

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/RichGaugeHandlerTests-context.xml
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/RichGaugeHandlerTests-context.xml
@@ -30,10 +30,4 @@
 		<constructor-arg ref="connectionFactory" />
 	</bean>
 
-	<bean id="connectionFactory"
-		class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory">
-		<constructor-arg index="0" value="${redis.hostname:localhost}" />
-		<constructor-arg index="1" value="${redis.port:6379}" />
-	</bean>
-
 </beans>

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterTests.java
@@ -18,16 +18,28 @@ package org.springframework.xd.analytics.metrics.redis;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
+
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.xd.analytics.metrics.AbstractAggregateCounterTests;
 import org.springframework.xd.analytics.metrics.common.ServicesConfig;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
+/**
+ * @author Luke Taylor
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
 @ContextConfiguration(classes=ServicesConfig.class, loader=AnnotationConfigContextLoader.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RedisAggregateCounterTests extends AbstractAggregateCounterTests {
+
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
 
 	@Before
 	@After

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisCounterRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisCounterRepositoryTests.java
@@ -17,16 +17,29 @@ package org.springframework.xd.analytics.metrics.redis;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
+
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.xd.analytics.metrics.SharedCounterRepositoryTests;
 import org.springframework.xd.analytics.metrics.common.ServicesConfig;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
+/**
+ * @author Mark Pollack
+ * @author Luke Taylor
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
 @ContextConfiguration(classes=ServicesConfig.class, loader=AnnotationConfigContextLoader.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RedisCounterRepositoryTests extends SharedCounterRepositoryTests {
+
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
 
 	@After
 	@Before

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisCounterServiceTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisCounterServiceTests.java
@@ -19,8 +19,10 @@ import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.ContextConfiguration;
@@ -28,21 +30,31 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.xd.analytics.metrics.AbstractCounterServiceTests;
 import org.springframework.xd.analytics.metrics.common.ServicesConfig;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
-
+/**
+ * @author Mark Pollack
+ * @author Luke Taylor
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
 @ContextConfiguration(classes=ServicesConfig.class, loader=AnnotationConfigContextLoader.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RedisCounterServiceTests extends AbstractCounterServiceTests {
 
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
+
 	@Autowired
 	private RedisCounterRepository counterRepository;
-	
-	@Autowired 
+
+	@Autowired
 	private RedisCounterService counterService;
 
 	@Autowired
 	private StringRedisTemplate stringRedisTemplate;
-	
+
 
 	@After
 	@Before

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterRepositoryTests.java
@@ -17,22 +17,34 @@ package org.springframework.xd.analytics.metrics.redis;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
+
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.xd.analytics.metrics.SharedFieldValueCounterRepositoryTests;
 import org.springframework.xd.analytics.metrics.common.ServicesConfig;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
+/**
+ * @author Mark Pollack
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
 @ContextConfiguration(classes=ServicesConfig.class, loader=AnnotationConfigContextLoader.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RedisFieldValueCounterRepositoryTests extends SharedFieldValueCounterRepositoryTests {
+
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
 
 	@After
 	@Before
 	public void beforeAndAfter() {
 		fvRepository.deleteAll();
 	}
-	
+
 
 }

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterServiceTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterServiceTests.java
@@ -17,22 +17,34 @@ package org.springframework.xd.analytics.metrics.redis;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
+
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.xd.analytics.metrics.AbstractRedisFieldValueCounterServiceTests;
 import org.springframework.xd.analytics.metrics.common.ServicesConfig;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
 
+/**
+ * @author Mark Pollack
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
 @ContextConfiguration(classes=ServicesConfig.class, loader=AnnotationConfigContextLoader.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RedisFieldValueCounterServiceTests extends AbstractRedisFieldValueCounterServiceTests {
+
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
 
 	@After
 	@Before
 	public void beforeAndAfter() {
 		fieldValueCounterRepository.deleteAll();
-	}	
-	
+	}
+
 }

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisGaugeRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisGaugeRepositoryTests.java
@@ -17,16 +17,29 @@ package org.springframework.xd.analytics.metrics.redis;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
+
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.xd.analytics.metrics.SharedGaugeRepositoryTests;
 import org.springframework.xd.analytics.metrics.common.ServicesConfig;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
+/**
+ * @author Mark Pollack
+ * @author Luke Taylor
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
 @ContextConfiguration(classes=ServicesConfig.class, loader=AnnotationConfigContextLoader.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RedisGaugeRepositoryTests extends SharedGaugeRepositoryTests {
+
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
 
 	@After
 	@Before

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisGaugeServiceTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisGaugeServiceTests.java
@@ -17,23 +17,36 @@ package org.springframework.xd.analytics.metrics.redis;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.xd.analytics.metrics.AbstractGaugeServiceTests;
 import org.springframework.xd.analytics.metrics.common.ServicesConfig;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
 
+/**
+ * @author Mark Pollack
+ * @author Luke Taylor
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
 @ContextConfiguration(classes=ServicesConfig.class, loader=AnnotationConfigContextLoader.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RedisGaugeServiceTests extends AbstractGaugeServiceTests {
 
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
+
 	@Autowired
 	protected RedisGaugeRepository repo;
-	
+
 	@Autowired
 	protected RedisGaugeService service;
 

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisRichGaugeServiceTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisRichGaugeServiceTests.java
@@ -2,7 +2,9 @@ package org.springframework.xd.analytics.metrics.redis;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -10,17 +12,22 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.xd.analytics.metrics.AbstractRichGaugeServiceTests;
 import org.springframework.xd.analytics.metrics.common.ServicesConfig;
 import org.springframework.xd.analytics.metrics.core.RichGaugeService;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
 /**
  * @author Luke Taylor
+ * @author Gary Russell
  */
 @ContextConfiguration(classes=ServicesConfig.class, loader=AnnotationConfigContextLoader.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RedisRichGaugeServiceTests extends AbstractRichGaugeServiceTests {
 
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
+
 	@Autowired
 	private RedisRichGaugeRepository repo;
-	
+
 	@Autowired
 	private RedisRichGaugeService service;
 

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/rabbit/RabbitChannelRegistryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/rabbit/RabbitChannelRegistryTests.java
@@ -37,7 +37,7 @@ public class RabbitChannelRegistryTests extends AbstractChannelRegistryTests {
 
 	@Override
 	protected ChannelRegistry getRegistry() throws Exception {
-		CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+		CachingConnectionFactory connectionFactory = new CachingConnectionFactory("localhost");
 		RabbitChannelRegistry registry = new RabbitChannelRegistry(connectionFactory);
 		return registry;
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest.java
@@ -17,12 +17,14 @@ package org.springframework.xd.dirt.listener;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -30,22 +32,34 @@ import org.mockito.MockitoAnnotations;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.xd.dirt.core.Container;
 import org.springframework.xd.dirt.event.ContainerStartedEvent;
 import org.springframework.xd.dirt.event.ContainerStoppedEvent;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
 /**
  * Integration test of {@link RedisContainerEventListener}
  *
  * @author Jennifer Hickey
+ * @author Gary Russell
  *
  */
-@ContextConfiguration
+@ContextConfiguration(classes=RedisContainerEventListenerTestConfig.class)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RedisContainerEventListenerTest {
+
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
 
 	@Autowired
 	private ApplicationContext context;
@@ -84,3 +98,25 @@ public class RedisContainerEventListenerTest {
 		assertNull(redisTemplate.boundHashOps("containers").get(containerId));
 	}
 }
+
+@Configuration
+@ImportResource("org/springframework/xd/dirt/listener/RedisContainerEventListenerTest-context.xml")
+class RedisContainerEventListenerTestConfig {
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		try {
+			LettuceConnectionFactory cf = new LettuceConnectionFactory();
+			cf.setHostName("localhost");
+			cf.setPort(6379);
+			cf.afterPropertiesSet();
+			return cf;
+		}
+		catch (RedisConnectionFailureException e) {
+			RedisConnectionFactory mockCF = mock(RedisConnectionFactory.class);
+			when(mockCF.getConnection()).thenReturn(mock(RedisConnection.class));
+			return mockCF;
+		}
+	}
+}
+

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/redis/RedisStreamDefinitionRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/redis/RedisStreamDefinitionRepositoryTests.java
@@ -19,16 +19,23 @@ import java.util.Iterator;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.xd.dirt.stream.StreamDefinition;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
 /**
  * @author David Turanski
+ * @author Gary Russell
  *
  */
 public class RedisStreamDefinitionRepositoryTests {
+
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
 
 	RedisStreamDefinitionRepository repository;
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/redis/RedisTapDefinitionRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/redis/RedisTapDefinitionRepositoryTests.java
@@ -19,16 +19,23 @@ import java.util.Iterator;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.xd.dirt.stream.TapDefinition;
+import org.springframework.xd.test.redis.RedisAvailableRule;
 
 /**
  * @author David Turanski
+ * @author Gary Russell
  *
  */
 public class RedisTapDefinitionRepositoryTests {
+
+	@Rule
+	public RedisAvailableRule redisAvailableRule = new RedisAvailableRule();
 
 	RedisTapDefinitionRepository repository;
 

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest-context.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/listener/RedisContainerEventListenerTest-context.xml
@@ -13,11 +13,6 @@
 		http://www.springframework.org/schema/integration/redis http://www.springframework.org/schema/integration/redis/spring-integration-redis.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<bean id="redisConnectionFactory" class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory">	      
-		  <constructor-arg index="0" value="localhost"/>
-		  <constructor-arg index="1" value="6379"/>
-		</bean>
-	
 	<bean class="org.springframework.xd.dirt.listener.RedisContainerEventListener">
 		<constructor-arg ref="redisConnectionFactory"/>
 	</bean>

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/AbstractExternalServerAvailableRule.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/AbstractExternalServerAvailableRule.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.test;
+
+import static org.junit.Assert.fail;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.rules.TestWatcher;
+import org.junit.runners.model.Statement;
+
+/**
+ * @author Gary Russell
+ * @since 1.0
+ *
+ */
+public abstract class AbstractExternalServerAvailableRule extends TestWatcher {
+
+	protected final Log logger = LogFactory.getLog(this.getClass());
+
+	protected Statement failOrSkipTests(String server, Exception e) {
+		String serversRequired = System.getenv("XD_EXTERNAL_SERVERS_REQUIRED");
+		if (serversRequired != null && "true".equalsIgnoreCase(serversRequired)) {
+			logger.error(server + " IS REQUIRED BUT NOT AVAILABLE", e);
+			fail(server + " IS NOT AVAILABLE");
+		}
+		else {
+			logger.error(server + " IS NOT AVAILABLE, SKIPPING TESTS", e);
+		}
+		return new Statement() {
+			@Override
+			public void evaluate() throws Throwable {}
+		};
+	}
+
+}

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/rabbit/RabbitAvailableRule.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/rabbit/RabbitAvailableRule.java
@@ -16,35 +16,30 @@
 
 package org.springframework.xd.test.rabbit;
 
-import static org.junit.Assert.fail;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.xd.test.AbstractExternalServerAvailableRule;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
-public class RabbitAvailableRule extends TestWatcher {
-
-	private final static Log logger = LogFactory.getLog(RabbitAvailableRule.class);
+public class RabbitAvailableRule extends AbstractExternalServerAvailableRule {
 
 	@Override
 	public Statement apply(Statement base, Description description) {
 		CachingConnectionFactory connectionFactory = null;
 		try {
-			connectionFactory = new CachingConnectionFactory();
+			connectionFactory = new CachingConnectionFactory("localhost");
 			Connection connection = connectionFactory.createConnection();
 			connection.close();
 		}
 		catch (Exception e) {
-			logger.error("RABBIT IS NOT AVAILABLE", e);
-			fail("RABBIT IS NOT AVAILABLE");
+			return super.failOrSkipTests("RABBIT", e);
 		}
 		finally {
 			if (connectionFactory != null) {

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/redis/RedisAvailableRule.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/redis/RedisAvailableRule.java
@@ -15,26 +15,21 @@
  */
 package org.springframework.xd.test.redis;
 
-import static org.junit.Assert.fail;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.xd.test.AbstractExternalServerAvailableRule;
 
 /**
  * @author Gary Russell
  * @since 1.0
  *
  */
-public class RedisAvailableRule extends TestWatcher {
-
-	private final static Log logger = LogFactory.getLog(RedisAvailableRule.class);
+public class RedisAvailableRule extends AbstractExternalServerAvailableRule {
 
 	@Override
-	public Statement apply(Statement base, Description description) {		
+	public Statement apply(Statement base, Description description) {
 		LettuceConnectionFactory connectionFactory = null;
 		try {
 			connectionFactory = new LettuceConnectionFactory();
@@ -42,8 +37,7 @@ public class RedisAvailableRule extends TestWatcher {
 			connectionFactory.getConnection().close();
 		}
 		catch (Exception e) {
-			logger.error("REDIS IS NOT AVAILABLE", e);
-			fail("REDIS IS NOT AVAILABLE");
+			return super.failOrSkipTests("REDIS", e);
 		}
 		finally {
 			if (connectionFactory != null) {


### PR DESCRIPTION
When Redis and/or Rabbit is not available (e.g. on developer
machine), the tests should not fail.

However, if the servers are not available on the CI server, the
tests should fail.

Add an environment variable XD_EXTERNAL_SERVERS_REQUIRED. Gradle
passes environment variables to worker tasks.

When true, the tests will fail; when false, the tests will be
skipped.

Set the environment variable on the CI build plan to true.

Fix all Redis tests to use the RedisAvailableRule. Some tests
needed @Configuration of the connection factory because when
declared in XML it eagerly connects to Redis.

**Also fixes a lot of whitespace violations, add `?w=1` to URL for review**
