### PR TITLE
XD-476 correct the AbstractRedisRepository to delete the correct key bas...

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/store/AbstractRedisRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/store/AbstractRedisRepository.java
@@ -67,7 +67,7 @@ public abstract class AbstractRedisRepository<T, ID extends Serializable> implem
 
 	@Override
 	public void delete(ID id) {
-		if (zSetOperations.remove(serializeId(id))) {
+		if (zSetOperations.remove(redisKeyFromId(id))) {
 			redisOperations.delete(redisKeyFromId(id));
 		}
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/redis/RedisStreamDefinitionRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/redis/RedisStreamDefinitionRepositoryTests.java
@@ -14,6 +14,7 @@ package org.springframework.xd.dirt.stream.redis;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import java.util.Iterator;
 
@@ -83,6 +84,15 @@ public class RedisStreamDefinitionRepositoryTests {
 		assertTrue(repository.exists("test3"));
 		assertTrue(!repository.exists("test4"));
 	}
+	
+	@Test
+	public void testDelete() {
+		StreamDefinition streamDefinition = new StreamDefinition("test", "time | log");
+		repository.save(streamDefinition);
+		StreamDefinition saved = repository.findOne("test");
+		repository.delete(saved);
+		assertNull(repository.findOne("test"));
+	}	
 
 	@After
 	public void clearRepo() {


### PR DESCRIPTION
Problem described at https://jira.springsource.org/browse/XD-476
The problem happens because when a stream created, it has the prefix for the member of a sorted order(E.g. streams.httptest). But when delete happens the prefix is not attached (only httptest passed in), which resulted the corresponding deletion silently failure. 

Corresponding unit test also created for XD-476
