### PR TITLE
XD-482 Changed the FIXED-DELAY separator from a '-' to a '_' so that the parser...

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
@@ -51,7 +51,7 @@ public class JobPlugin extends AbstractPlugin  {
 	private static final String COMMON_XML = CONTEXT_CONFIG_ROOT + "common.xml";
 	private static final String TRIGGER = "trigger";
 	private static final String CRON = "cron";
-	private static final String FIXED_DELAY= "fixed_delay";
+	private static final String FIXED_DELAY= "fixedDelay";
 
 
 	public JobPlugin(){

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/registrar-with-fixed-delay.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/registrar-with-fixed-delay.xml
@@ -8,7 +8,7 @@
 	<import resource="classpath:META-INF/spring-xd/plugins/job/registrar.xml"/>
 
 	<task:scheduled-tasks scheduler="scheduler">
-		<task:scheduled ref="startupJobLauncher" method="executeBatchJob" fixed-delay="${fixed_delay}" />
+		<task:scheduled ref="startupJobLauncher" method="executeBatchJob" fixed-delay="${fixedDelay}" />
 	</task:scheduled-tasks>
 
 </beans>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
@@ -89,7 +89,7 @@ public class JobPluginTests {
 	@Test
 	public void testThatLocalFixedDelayTaskIsAdded() {
 		SimpleModule module = new SimpleModule("testFixedDelayJob", "job");
-		module.getProperties().put("fixed_delay", "60000");
+		module.getProperties().put("fixedDelay", "60000");
 		plugin.processModule(module, "foo", 0);
 		String[] moduleBeans = module.getApplicationContext().getBeanNamesForType(IntervalTask.class);
 		assertEquals(1, moduleBeans.length);


### PR DESCRIPTION
... will not think we are beginning another parameter.
