### PR TITLE
XD-437 Removed package tangles identified by Sonar.

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -22,9 +22,9 @@ import java.util.TreeSet;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.util.Assert;
+import org.springframework.xd.dirt.core.BaseDefinition;
 import org.springframework.xd.dirt.core.ResourceDeployer;
 import org.springframework.xd.dirt.module.ModuleDeploymentRequest;
-import org.springframework.xd.dirt.core.BaseDefinition;
 
 /**
  * Abstract implementation of the @link {@link org.springframework.xd.dirt.core.ResourceDeployer} interface. It provides the basic support for calling

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/EnhancedStreamParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/EnhancedStreamParser.java
@@ -20,10 +20,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.xd.dirt.module.ModuleDeploymentRequest;
+import org.springframework.xd.dirt.stream.dsl.ArgumentNode;
+import org.springframework.xd.dirt.stream.dsl.ModuleNode;
 import org.springframework.xd.dirt.stream.dsl.StreamConfigParser;
-import org.springframework.xd.dirt.stream.dsl.ast.ArgumentNode;
-import org.springframework.xd.dirt.stream.dsl.ast.ModuleNode;
-import org.springframework.xd.dirt.stream.dsl.ast.StreamsNode;
+import org.springframework.xd.dirt.stream.dsl.StreamsNode;
 
 /**
  * @author Andy Clement

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDefinition.java
@@ -12,6 +12,8 @@
  */
 package org.springframework.xd.dirt.stream;
 
+import org.springframework.xd.dirt.core.BaseDefinition;
+
 
 import org.springframework.xd.dirt.core.BaseDefinition;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/TriggerDefinition.java
@@ -12,6 +12,8 @@
  */
 package org.springframework.xd.dirt.stream;
 
+import org.springframework.xd.dirt.core.BaseDefinition;
+
 
 import org.springframework.xd.dirt.core.BaseDefinition;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ArgumentNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ArgumentNode.java
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
+package org.springframework.xd.dirt.stream.dsl;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.xd.dirt.stream.dsl.DSLException;
-import org.springframework.xd.dirt.stream.dsl.XDDSLMessages;
-import org.springframework.xd.dirt.stream.dsl.ast.ModuleNode.ConsumedArgumentNode;
+import org.springframework.xd.dirt.stream.dsl.ModuleNode.ConsumedArgumentNode;
 
 /**
  * Represents an argument like "--name=value".

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/AstNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/AstNode.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
+package org.springframework.xd.dirt.stream.dsl;
 
 /**
  * Common supertype for the ast nodes built during stream parsing.

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
@@ -13,37 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
-
-import org.springframework.xd.dirt.stream.dsl.StreamLookupEnvironment;
+package org.springframework.xd.dirt.stream.dsl;
 
 /**
  * @author Andy Clement
  */
-public class ModuleReferenceNode extends AstNode {
+public class ChannelNode extends AstNode {
 
 	private final String streamName;
-	private final String labelOrModuleName;
-	
-	private String resolvedChannel;
+	private final String channelName;
 
-	public ModuleReferenceNode(String streamName, String moduleName, int startpos, int endpos) {
+	public ChannelNode(String streamName, String channelName, int startpos, int endpos) {
 		super(startpos,endpos);
 		this.streamName = streamName;
-		this.labelOrModuleName = moduleName;
+		this.channelName = channelName;
 	}
 
 	@Override
 	public String stringify(boolean includePositionalInfo) {
 		StringBuilder s = new StringBuilder();
 		s.append("(");
+		s.append(":");
 		if (streamName != null) {
 			s.append(streamName).append(".");
 		}
-		s.append(labelOrModuleName);
-		if (resolvedChannel!=null) {
-			s.append("[[channel:").append(resolvedChannel).append("]]");
-		}
+		s.append(channelName);
 		if (includePositionalInfo) {
 			s.append(":");
 			s.append(getStartPos()).append(">").append(getEndPos());
@@ -51,13 +45,14 @@ public class ModuleReferenceNode extends AstNode {
 		s.append(")");
 		return s.toString();
 	}
-	
+
 	public String toString() {
 		StringBuilder s = new StringBuilder();
+		s.append(":");
 		if (streamName != null) {
 			s.append(streamName).append(".");
 		}
-		s.append(labelOrModuleName);
+		s.append(channelName);
 		return s.toString();
 	}
 
@@ -68,27 +63,12 @@ public class ModuleReferenceNode extends AstNode {
 		return streamName;
 	}
 	
-	public String getModuleName() {
-		return labelOrModuleName;
+	public String getChannelName() {
+		return channelName;
 	}
 
-	public void resolve(StreamLookupEnvironment env) {
-		resolvedChannel = env.lookupChannelForLabelOrModule(streamName, labelOrModuleName);
-		if (streamName==null && resolvedChannel == null) {
-			// it is possible the singular name in labelOrModuleName is actually
-			// a stream reference
-			StreamNode sn = env.lookupStream(labelOrModuleName);
-			if (sn!=null) {
-				resolvedChannel = sn.getStreamName()+".0";
-			}
-		}
-	}
-
-	public ModuleReferenceNode copyOf() {
-		ModuleReferenceNode moduleReferenceNode =
-			new ModuleReferenceNode(streamName, labelOrModuleName, startpos, endpos);
-		moduleReferenceNode.resolvedChannel = resolvedChannel;
-		return moduleReferenceNode;
+	public ChannelNode copyOf() {
+		return new ChannelNode(streamName,channelName,startpos,endpos);
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/LabelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/LabelNode.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
+package org.springframework.xd.dirt.stream.dsl;
 
 /**
  * Represents a label attached to a module.

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ModuleNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ModuleNode.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
+package org.springframework.xd.dirt.stream.dsl;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ModuleReferenceNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ModuleReferenceNode.java
@@ -13,31 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
+package org.springframework.xd.dirt.stream.dsl;
+
 
 /**
  * @author Andy Clement
  */
-public class ChannelNode extends AstNode {
+public class ModuleReferenceNode extends AstNode {
 
 	private final String streamName;
-	private final String channelName;
+	private final String labelOrModuleName;
+	
+	private String resolvedChannel;
 
-	public ChannelNode(String streamName, String channelName, int startpos, int endpos) {
+	public ModuleReferenceNode(String streamName, String moduleName, int startpos, int endpos) {
 		super(startpos,endpos);
 		this.streamName = streamName;
-		this.channelName = channelName;
+		this.labelOrModuleName = moduleName;
 	}
 
 	@Override
 	public String stringify(boolean includePositionalInfo) {
 		StringBuilder s = new StringBuilder();
 		s.append("(");
-		s.append(":");
 		if (streamName != null) {
 			s.append(streamName).append(".");
 		}
-		s.append(channelName);
+		s.append(labelOrModuleName);
+		if (resolvedChannel!=null) {
+			s.append("[[channel:").append(resolvedChannel).append("]]");
+		}
 		if (includePositionalInfo) {
 			s.append(":");
 			s.append(getStartPos()).append(">").append(getEndPos());
@@ -45,14 +50,13 @@ public class ChannelNode extends AstNode {
 		s.append(")");
 		return s.toString();
 	}
-
+	
 	public String toString() {
 		StringBuilder s = new StringBuilder();
-		s.append(":");
 		if (streamName != null) {
 			s.append(streamName).append(".");
 		}
-		s.append(channelName);
+		s.append(labelOrModuleName);
 		return s.toString();
 	}
 
@@ -63,12 +67,27 @@ public class ChannelNode extends AstNode {
 		return streamName;
 	}
 	
-	public String getChannelName() {
-		return channelName;
+	public String getModuleName() {
+		return labelOrModuleName;
 	}
 
-	public ChannelNode copyOf() {
-		return new ChannelNode(streamName,channelName,startpos,endpos);
+	public void resolve(StreamLookupEnvironment env) {
+		resolvedChannel = env.lookupChannelForLabelOrModule(streamName, labelOrModuleName);
+		if (streamName==null && resolvedChannel == null) {
+			// it is possible the singular name in labelOrModuleName is actually
+			// a stream reference
+			StreamNode sn = env.lookupStream(labelOrModuleName);
+			if (sn!=null) {
+				resolvedChannel = sn.getStreamName()+".0";
+			}
+		}
+	}
+
+	public ModuleReferenceNode copyOf() {
+		ModuleReferenceNode moduleReferenceNode =
+			new ModuleReferenceNode(streamName, labelOrModuleName, startpos, endpos);
+		moduleReferenceNode.resolvedChannel = resolvedChannel;
+		return moduleReferenceNode;
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SinkChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SinkChannelNode.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
+package org.springframework.xd.dirt.stream.dsl;
 
 /**
  * @author Andy Clement

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SourceChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SourceChannelNode.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
+package org.springframework.xd.dirt.stream.dsl;
 
-import org.springframework.xd.dirt.stream.dsl.StreamLookupEnvironment;
 
 /**
  * @author Andy Clement

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
@@ -20,15 +20,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.xd.dirt.stream.dsl.ast.ArgumentNode;
-import org.springframework.xd.dirt.stream.dsl.ast.ChannelNode;
-import org.springframework.xd.dirt.stream.dsl.ast.LabelNode;
-import org.springframework.xd.dirt.stream.dsl.ast.ModuleNode;
-import org.springframework.xd.dirt.stream.dsl.ast.ModuleReferenceNode;
-import org.springframework.xd.dirt.stream.dsl.ast.SinkChannelNode;
-import org.springframework.xd.dirt.stream.dsl.ast.SourceChannelNode;
-import org.springframework.xd.dirt.stream.dsl.ast.StreamNode;
-import org.springframework.xd.dirt.stream.dsl.ast.StreamsNode;
 
 /**
  * @author Andy Clement

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamLookupEnvironment.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamLookupEnvironment.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.xd.dirt.stream.dsl;
 
-import org.springframework.xd.dirt.stream.dsl.ast.StreamNode;
 
 /**
  * A lookup environment is used to resolve a stream. Stream resolution chases

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamNode.java
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
+package org.springframework.xd.dirt.stream.dsl;
 
 import java.util.List;
 
-import org.springframework.xd.dirt.stream.dsl.DSLException;
-import org.springframework.xd.dirt.stream.dsl.StreamLookupEnvironment;
-import org.springframework.xd.dirt.stream.dsl.XDDSLMessages;
 
 /**
  * @author Andy Clement

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamsNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamsNode.java
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.xd.dirt.stream.dsl.ast;
+package org.springframework.xd.dirt.stream.dsl;
 
 import java.util.List;
 
-import org.springframework.xd.dirt.stream.dsl.StreamLookupEnvironment;
 
 /**
  * @author Andy Clement

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -26,10 +26,6 @@ import java.util.Properties;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.xd.dirt.stream.EnhancedStreamParser;
-import org.springframework.xd.dirt.stream.dsl.ast.ArgumentNode;
-import org.springframework.xd.dirt.stream.dsl.ast.ModuleNode;
-import org.springframework.xd.dirt.stream.dsl.ast.StreamNode;
-import org.springframework.xd.dirt.stream.dsl.ast.StreamsNode;
 
 /**
  * Parse streams and verify either the correct abstract syntax tree is 


### PR DESCRIPTION
Moved abstract Deployer to the stream package because this is the only place it is used.  We probably want to create a deploy package and move all deploy based classes there.
Moved Base Definition to core because its used by ResourceDefinition in the core package, and the ResourceDefinition is used by the streams package.
ArgumentNode was used by StreamConfigParser in the dsl package.  Moved it there to be remove package tangle.
The package tangles between streams.dsl and stream.dsl.ast were fairly extensive.  Specifically around  StreamConfigParser having use of the nodes in the ast package
and the Nodes having use in the dsl package.  The relationship was fairly tight, so I merged the 2 back together.  The only option that came to mind is to create a
interface for the StreamConfigParser, but I was concerned, that I would be creating a patch instead of a real fix.  We may want to revisit the package structure
here.
