### PR TITLE
XD-499 Cron Jobs stop firing when a named trigger is created and deploye...

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/trigger/TriggerPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/trigger/TriggerPluginTests.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.scheduling.support.CronTrigger;
@@ -122,6 +121,9 @@ public class TriggerPluginTests {
 	public void failIfNoValidTriggerProperty() {
 		Module module = new SimpleModule("testTrigger", "trigger");
 		assertEquals(0, module.getProperties().size());
+		GenericApplicationContext commonContext = new GenericApplicationContext();
+		plugin.postProcessSharedContext(commonContext);
+
 		try {
 			plugin.processModule(module, "newTrigger", 0);
 		}
@@ -136,15 +138,17 @@ public class TriggerPluginTests {
 	@Test
 	public void failIfMultipleTriggerProperties() {
 		Module module = new SimpleModule("testTrigger", "trigger");
+		GenericApplicationContext commonContext = new GenericApplicationContext();
+		plugin.postProcessSharedContext(commonContext);
+
 		module.getProperties().put("cron", "*/15 * * * * *");
 		module.getProperties().put("fixedRate", "6000");
 		assertEquals(2, module.getProperties().size());
 		try {
 			plugin.processModule(module, "newTrigger", 0);
-		}
-		catch (ResourceDefinitionException e) {
-			assertEquals("Only one trigger property allowed, but received: " +
-					"cron,fixedRate", e.getMessage());
+		} catch (ResourceDefinitionException e) {
+			assertEquals("Only one trigger property allowed, but received: "
+					+ "cron,fixedRate", e.getMessage());
 			return;
 		}
 		fail("Expected an ResourceDefinitionException to be thrown.");


### PR DESCRIPTION
...d.

The issue was that after the trigger was created programmatically the code would refresh the context and that would clear the scheduler.
- The fix was to create the triggers as singletons.  Thus eliminating the need to refresh the context.
- Also did some code cleanup.
- Had to remove some commented code.
