### PR TITLE
XD-430 different JMX port for admin and container

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/AbstractOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/AbstractOptions.java
@@ -23,17 +23,18 @@ import org.kohsuke.args4j.OptionDef;
 import org.kohsuke.args4j.spi.OptionHandler;
 import org.kohsuke.args4j.spi.Parameters;
 import org.kohsuke.args4j.spi.Setter;
+
 import org.springframework.util.StringUtils;
 
 /**
  * Options shared by both the admin and the container server.
- * 
+ *
  * @author Eric Bottard
  * @author Mark Pollack
  * @author David Turanski
  * @author Mark Fisher
  */
-public class AbstractOptions {
+public abstract class AbstractOptions {
 
 	public static final String DEFAULT_HOME = "..";
 
@@ -88,9 +89,6 @@ public class AbstractOptions {
 	@Option(name = "--disableJmx", usage = "Disable JMX in the XD container", handler = JmxDisabledHandler.class)
 	private boolean jmxDisabled = false;
 
-	@Option(name = "--jmxPort", usage = "The JMX port for the container", metaVar = "<jmxPort>")
-	private int jmxPort = 8778;
-
 	@Option(name = "--transformer", usage = "The default payload transformer class name", handler = PayloadTransformerHandler.class)
 	private String transformer;
 
@@ -122,9 +120,7 @@ public class AbstractOptions {
 		return System.getProperty(XD_DISABLE_JMX_KEY) == null ? false : true;
 	}
 
-	public int getJmxPort() {
-		return jmxPort;
-	}
+	public abstract int getJmxPort();
 
 	public String getTransformer() {
 		return transformer;
@@ -171,7 +167,7 @@ public class AbstractOptions {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see
 		 * org.kohsuke.args4j.spi.OptionHandler#parseArguments(org.kohsuke.args4j.spi.
 		 * Parameters)
@@ -184,7 +180,7 @@ public class AbstractOptions {
 
 		/*
 		 * (non-Javadoc)
-		 * 
+		 *
 		 * @see org.kohsuke.args4j.spi.OptionHandler#getDefaultMetaVariable()
 		 */
 		@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/AdminOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/AdminOptions.java
@@ -30,6 +30,9 @@ public class AdminOptions extends AbstractOptions {
 	@Option(name = "--store", usage = "How to persist admin data (default: redis)")
 	private Store store = Store.redis;
 
+	@Option(name = "--jmxPort", usage = "The JMX port for the admin", metaVar = "<jmxPort>")
+	private int jmxPort = 8778;
+
 	/**
 	 * @return http port
 	 */
@@ -43,6 +46,11 @@ public class AdminOptions extends AbstractOptions {
 
 	public static void setXDStore(Store store) {
 		System.setProperty("xd.store", store.name());
+	}
+
+	@Override
+	public int getJmxPort() {
+		return this.jmxPort;
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ContainerOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ContainerOptions.java
@@ -16,9 +16,19 @@
 
 package org.springframework.xd.dirt.server.options;
 
+import org.kohsuke.args4j.Option;
+
 /**
  * A class the defines the options that will be parsed on the container command line.
  */
 public class ContainerOptions extends AbstractOptions {
+
+	@Option(name = "--jmxPort", usage = "The JMX port for the container", metaVar = "<jmxPort>")
+	private int jmxPort = 8779;
+
+	@Override
+	public int getJmxPort() {
+		return this.jmxPort;
+	}
 
 }


### PR DESCRIPTION
This is just an initial step, providing different default ports for the AdminOptions and ContainerOptions.

A better solution would allow for dynamic port allocation, at least on the Container side (since we're likely to have more than 1 Container instance). Since it's common to have only 1 Admin instance, that could keep the 8778 default, but apparently Jolokia will determine a port if you pass 0. So, we may want to pass 0 as the default for the Container... the only problem is we can only do that once we also know how to retrieve that info and make it available to the user (our current banner logging just displays the option value so would show 0). An alternative to that would be to use our own SocketFinder (there is one within Spring Integration, and in fact a revised version of that has moved to Spring core as of 4.0 M2).
