### PR TITLE
XD-503 User can now have an job that has an invalid definition deleted.

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
@@ -130,7 +130,13 @@ public class JobsController {
 		final JobDefinition jobDefinition = new JobDefinition(name, definition);
 		final JobDefinition savedJobDefinition = jobDeployer.save(jobDefinition);
 		if(deploy) {
-			jobDeployer.deploy(name);
+			try {
+				jobDeployer.deploy(name);
+			} catch (RuntimeException dslException) {
+				jobDeployer.remove(name); // don't allow the creation of a job
+											// if it failed to deploy
+				throw dslException;
+			}
 		}
 		final JobDefinitionResource result = definitionResourceAssembler.toResource(savedJobDefinition);
 		return result;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
@@ -31,6 +31,7 @@ import org.springframework.xd.dirt.stream.AlreadyDeployedException;
 import org.springframework.xd.dirt.stream.DefinitionAlreadyExistsException;
 import org.springframework.xd.dirt.stream.MissingRequiredDefinitionException;
 import org.springframework.xd.dirt.stream.NoSuchDefinitionException;
+import org.springframework.xd.dirt.stream.dsl.DSLException;
 
 /**
  * Central class for behavior common to all REST controllers.
@@ -111,6 +112,18 @@ public class RestControllerAdvice {
 	@ExceptionHandler
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public VndErrors onStreamAlreadyDeployedException(AlreadyDeployedException e) {
+		String logref = log(e);
+		return new VndErrors(logref, e.getMessage());
+	}
+
+	/**
+	 * Handles the case where client tried to deploy something that is has an
+	 * invalid definition.
+	 */
+	@ResponseBody
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public VndErrors onInvalidDefintion(DSLException e) {
 		String logref = log(e);
 		return new VndErrors(logref, e.getMessage());
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
@@ -116,4 +116,25 @@ public class JobsControllerIntegrationTests extends AbstractControllerIntegratio
 	public void testFailedJobDeletion() throws Exception {
 		mockMvc.perform(delete("/jobs/{name}", "job1")).andExpect(status().isNotFound());
 	}
+
+	@Test
+	public void testInvalidDefinitionCreate() throws Exception {
+		mockMvc.perform(
+				post("/jobs").param("name", "job1")
+						.param("definition", "Job adsfa")
+						.accept(MediaType.APPLICATION_JSON)).andExpect(
+				status().isBadRequest());
+	}
+
+	@Test
+	public void testInvalidDefinitionDelete() throws Exception {
+		mockMvc.perform(
+				post("/jobs").param("name", "job1")
+						.param("definition", "Job adsfa")
+						.param("deploy", "false")
+						.accept(MediaType.APPLICATION_JSON)).andExpect(
+				status().isCreated());
+		mockMvc.perform(delete("/jobs/{name}", "job1")).andExpect(
+				status().isOk());
+	}
 }


### PR DESCRIPTION
JobController now support the ability to handle runtime exceptions.
JobDeployer has the ability to remove a module from the repository even though the definition is invalid.
