### PR TITLE
XD-439: stream directory hooked up to parser

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -36,11 +36,12 @@ import org.springframework.xd.dirt.module.ModuleDeploymentRequest;
  * @author Luke Taylor
  * @author Mark Pollack
  * @author Eric Bottard
+ * @author Andy Clement
  */
 public abstract class AbstractDeployer<D extends BaseDefinition> implements ResourceDeployer<D> {
 	private PagingAndSortingRepository<D, String> repository;
 
-	private final StreamParser streamParser = new EnhancedStreamParser();
+	private final StreamParser streamParser;
 
 	private final DeploymentMessageSender messageSender;
 
@@ -59,6 +60,7 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 		this.repository = repository;
 		this.messageSender = messageSender;
 		this.definitionKind = definitionKind;
+		this.streamParser = new EnhancedStreamParser(repository);
 	}
 
 	public D save(D definition) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/EnhancedStreamParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/EnhancedStreamParser.java
@@ -19,6 +19,8 @@ package org.springframework.xd.dirt.stream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.xd.dirt.core.BaseDefinition;
 import org.springframework.xd.dirt.module.ModuleDeploymentRequest;
 import org.springframework.xd.dirt.stream.dsl.*;
 
@@ -29,10 +31,20 @@ import org.springframework.xd.dirt.stream.dsl.*;
  */
 public class EnhancedStreamParser implements StreamParser {
 
+	private CrudRepository<? extends BaseDefinition, String> repository;
+
+	public EnhancedStreamParser(CrudRepository<? extends BaseDefinition, String> repository) {
+		this.repository = repository;
+	}
+	
+	public EnhancedStreamParser() {
+		// no repository, will not be able to resolve substream/label references
+	}
+
 	@Override
 	public List<ModuleDeploymentRequest> parse(String name, String config) {
 
-		StreamConfigParser parser = new StreamConfigParser();
+		StreamConfigParser parser = new StreamConfigParser(repository);
 		StreamsNode ast = parser.parse(name, config);
 		List<ModuleDeploymentRequest> requests = new ArrayList<ModuleDeploymentRequest>();
 
@@ -56,11 +68,11 @@ public class EnhancedStreamParser implements StreamParser {
 		SinkChannelNode sinkChannel = stream.getSinkChannelNode();
 
 		if (sourceChannel != null) {
-			requests.get(requests.size() - 1).setSourceChannelName(sourceChannel.getChannelNode().getChannelName());
+			requests.get(requests.size() - 1).setSourceChannelName(sourceChannel.getChannelName());
 		}
 
 		if (sinkChannel != null) {
-			requests.get(0).setSinkChannelName(sinkChannel.getChannelNode().getChannelName());
+			requests.get(0).setSinkChannelName(sinkChannel.getChannelName());
 		}
 
 		for (int m = 0; m < moduleNodes.size(); m++) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ModuleReferenceNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ModuleReferenceNode.java
@@ -89,5 +89,9 @@ public class ModuleReferenceNode extends AstNode {
 		moduleReferenceNode.resolvedChannel = resolvedChannel;
 		return moduleReferenceNode;
 	}
+	
+	public String getChannelName() {
+		return resolvedChannel;
+	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SinkChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SinkChannelNode.java
@@ -46,5 +46,9 @@ public class SinkChannelNode extends AstNode {
 	public ChannelNode getChannelNode() {
 		return channelNode;
 	}
+	
+	public String getChannelName() {
+		return channelNode.getChannelName();
+	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SourceChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SourceChannelNode.java
@@ -97,4 +97,12 @@ public class SourceChannelNode extends AstNode {
 		}
 	}
 
+	public String getChannelName() {
+		if (channelNode != null) {
+			return channelNode.getChannelName();
+		} else {
+			return moduleReferenceNode.getChannelName();
+		}
+	}
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamNode.java
@@ -193,4 +193,8 @@ public class StreamNode extends AstNode {
 		return -1;
 	}
 
+	public String getStreamData() {
+		return toString(); // TODO is toString always ok? currently only used in testing...
+	}
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamsNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamsNode.java
@@ -83,5 +83,9 @@ public class StreamsNode extends AstNode {
 	public List<StreamNode> getStreams() {
 		return streamNodes;
 	}
+	
+	public int getSize() {
+		return streamNodes.size();
+	}
 
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -20,12 +20,16 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.xd.dirt.stream.EnhancedStreamParser;
+import org.springframework.xd.dirt.stream.StreamDefinition;
 
 /**
  * Parse streams and verify either the correct abstract syntax tree is 
@@ -51,40 +55,40 @@ public class StreamConfigParserTests {
 	// Naming a stream is done via <name>=<something> where <something> might be 0 or more modules/channels
 	@Test
 	public void streamNaming() {
-		StreamsNode ast = new StreamConfigParser().parse("mystream = foo");
+		StreamsNode ast = parse("mystream = foo");
 		assertEquals("Streams[mystream = foo][mystream = (ModuleNode:foo:11>14)]",ast.stringify(true));
 	}
 	
 	// Pipes are used to connect modules
 	@Test
 	public void twoModules() {
-		StreamsNode ast = new StreamConfigParser().parse("foo | bar");
+		StreamsNode ast = parse("foo | bar");
 		assertEquals("Streams[foo | bar][(ModuleNode:foo:0>3)(ModuleNode:bar:6>9)]",ast.stringify(true));
 	}
 	
 	// Modules can be labeled
 	@Test
 	public void moduleLabels() {
-		StreamsNode ast = new StreamConfigParser().parse("label: http");
+		StreamsNode ast = parse("label: http");
 		assertEquals("Streams[label: http][((Label:label:0>5) ModuleNode:http:0>11)]",ast.stringify(true));
 	}
 	
 	@Test
 	public void moduleLabels2() {
-		StreamsNode ast = new StreamConfigParser().parse("label: label2: http | label3: foo");
+		StreamsNode ast = parse("label: label2: http | label3: foo");
 		assertEquals("Streams[label: label2: http | label3: foo][((Label:label:0>5) (Label:label2:7>13) ModuleNode:http:0>19)((Label:label3:22>28) ModuleNode:foo:22>33)]",ast.stringify(true));
 	}
 	
 	@Test
 	public void moduleLabels3() {
-		StreamsNode ast = new StreamConfigParser().parse("food = http | label3: foo");
+		StreamsNode ast = parse("food = http | label3: foo");
 		assertEquals("Streams[food = http | label3: foo][food = (ModuleNode:http:7>11)((Label:label3:14>20) ModuleNode:foo:14>25)]",ast.stringify(true));
 	}
 	
 	// Modules can take parameters
 	@Test
 	public void oneModuleWithParam() {
-		StreamsNode ast = new StreamConfigParser().parse("foo --name=value");
+		StreamsNode ast = parse("foo --name=value");
 		assertEquals("Streams[foo --name=value][(ModuleNode:foo --name=value:0>16)]",ast.stringify(true));
 	}
 
@@ -92,7 +96,7 @@ public class StreamConfigParserTests {
 	// Modules can take two parameters
 	@Test
 	public void oneModuleWithTwoParams() {
-		StreamsNode ast = new StreamConfigParser().parse("foo --name=value --x=y");
+		StreamsNode ast = parse("foo --name=value --x=y");
 		assertTrue(ast instanceof StreamsNode);
 		StreamsNode sn = ast;
 		List<ModuleNode> moduleNodes = sn.getModuleNodes();
@@ -114,8 +118,7 @@ public class StreamConfigParserTests {
 	@Test
 	public void testHorribleTap() {
 		String stream = "tap @twitter";
-		StreamConfigParser parser = new StreamConfigParser();
-		StreamsNode ast = parser.parse(stream);
+		StreamsNode ast = parse(stream);
 		assertEquals("Streams[tap @twitter][(ModuleNode:tap --channel=twitter.0:0>12)]",ast.stringify(true));
 	}
 
@@ -123,8 +126,7 @@ public class StreamConfigParserTests {
 	@Test
 	public void testMultiline() {
 		String stream = "foo\nbar";
-		StreamConfigParser parser = new StreamConfigParser();
-		StreamsNode ast = parser.parse(stream);
+		StreamsNode ast = parse(stream);
 		List<StreamNode> streams = ast.getStreams();
 		assertEquals(2,streams.size());
 	}
@@ -132,8 +134,7 @@ public class StreamConfigParserTests {
 	@Test
 	public void testMultiline2() {
 		String stream = "foo  ;  bar";
-		StreamConfigParser parser = new StreamConfigParser();
-		StreamsNode ast = parser.parse(stream);
+		StreamsNode ast = parse(stream);
 		List<StreamNode> streams = ast.getStreams();
 		assertEquals(2,streams.size());
 	}
@@ -141,8 +142,7 @@ public class StreamConfigParserTests {
 	@Test
 	public void testParameters() {
 		String module = "gemfire-cq --query='Select * from /Stocks where symbol=''VMW''' --regionName=foo --foo=bar";
-		StreamConfigParser parser = new StreamConfigParser();
-		StreamsNode ast = parser.parse(module);
+		StreamsNode ast = parse(module);
 		ModuleNode gemfireModule = ast.getModule("gemfire-cq");
 		Properties parameters = gemfireModule.getArgumentsAsProperties();
 		assertEquals(3, parameters.size());
@@ -151,29 +151,29 @@ public class StreamConfigParserTests {
 		assertEquals("bar", parameters.get("foo"));
 
 		module = "test";
-		parameters = parser.parse(module).getModule("test").getArgumentsAsProperties();
+		parameters = parse(module).getModule("test").getArgumentsAsProperties();
 		assertEquals(0, parameters.size());
 
 		module = "foo --x=1 --y=two ";
-		parameters = parser.parse(module).getModule("foo").getArgumentsAsProperties();
+		parameters = parse(module).getModule("foo").getArgumentsAsProperties();
 		assertEquals(2, parameters.size());
 		assertEquals("1", parameters.get("x"));
 		assertEquals("two", parameters.get("y"));
 
 		module = "foo --x=1a2b --y=two ";
-		parameters = parser.parse(module).getModule("foo").getArgumentsAsProperties();
+		parameters = parse(module).getModule("foo").getArgumentsAsProperties();
 		assertEquals(2, parameters.size());
 		assertEquals("1a2b", parameters.get("x"));
 		assertEquals("two", parameters.get("y"));
 
 		module = "foo --x=2";
-		parameters = parser.parse(module).getModule("foo").getArgumentsAsProperties();
+		parameters = parse(module).getModule("foo").getArgumentsAsProperties();
 		assertEquals(1, parameters.size());
 		assertEquals("2", parameters.get("x"));
 
 		module = "--foo = bar";
 		try {
-			parser.parse(module);
+			parse(module);
 			fail(module + " is invalid. Should throw exception");
 		} catch (Exception e) {
 			// success
@@ -183,7 +183,7 @@ public class StreamConfigParserTests {
 	@Test
 	public void testInvalidModules() {
 		String config = "test | foo--x=13";
-		EnhancedStreamParser parser = new EnhancedStreamParser();
+		EnhancedStreamParser parser = new EnhancedStreamParser(testRepository);
 		try {
 			parser.parse("t", config);
 			fail(config + " is invalid. Should throw exception");
@@ -194,11 +194,10 @@ public class StreamConfigParserTests {
 	
 	@Test
 	public void testDirtyTapSupport() {
-//		StreamsNode ast = 
-		new StreamConfigParser().parse("one", "foo | transform --expression=--payload | bar");
-		StreamsNode ast2 = new StreamConfigParser().parse("two", "tap one.foo");
+		parse("one", "foo | transform --expression=--payload | bar");
+		StreamsNode ast2 = parse("two", "tap one.foo");
 		assertEquals("Streams[tap one.foo][(ModuleNode:tap --channel=one.0:0>11)]",ast2.stringify(true));
-		StreamsNode ast3 = new StreamConfigParser().parse("two", "tap one.transform");
+		StreamsNode ast3 = parse("two", "tap one.transform");
 		assertEquals("Streams[tap one.transform][(ModuleNode:tap --channel=one.1:0>17)]",ast3.stringify(true));
 	}
 	
@@ -207,6 +206,15 @@ public class StreamConfigParserTests {
 		StreamsNode ast = parse("tap foo > file");
 		// TODO verify source positions for source channel - include tap?
 		assertEquals("Streams[tap foo > file][tap (foo:4>7)>(ModuleNode:file:10>14)]",ast.stringify(true));
+	}
+	
+	@Test
+	public void testTap() {
+		parse("one", "foo | transform --expression=--payload | bar");
+		StreamsNode ast2 = parse("two", "tap one.foo");
+		assertEquals("Streams[tap one.foo][(ModuleNode:tap --channel=one.0:0>11)]",ast2.stringify(true));
+		StreamsNode ast3 = parse("two", "tap one.transform");
+		assertEquals("Streams[tap one.transform][(ModuleNode:tap --channel=one.1:0>17)]",ast3.stringify(true));
 	}
 	
 	@Test
@@ -249,7 +257,7 @@ public class StreamConfigParserTests {
 
 	@Test
 	public void expressions_xd159() {
-		StreamsNode ast = new StreamConfigParser().parse("foo | transform --expression=--payload | bar");
+		StreamsNode ast = parse("foo | transform --expression=--payload | bar");
 		ModuleNode mn = ast.getModule("transform");
 		Properties props = mn.getArgumentsAsProperties();
 		assertEquals("--payload",props.get("expression"));
@@ -263,7 +271,7 @@ public class StreamConfigParserTests {
 
 	@Test
 	public void expressions_xd159_3() {
-		StreamsNode ast = new StreamConfigParser().parse("foo |  transform --expression='new StringBuilder(payload).reverse()' | bar");
+		StreamsNode ast = parse("foo |  transform --expression='new StringBuilder(payload).reverse()' | bar");
 		ModuleNode mn = ast.getModule("transform");
 		Properties props = mn.getArgumentsAsProperties();
 		assertEquals("new StringBuilder(payload).reverse()",props.get("expression"));
@@ -271,11 +279,11 @@ public class StreamConfigParserTests {
 
 	@Test
 	public void expressions_xd159_4() {
-		StreamsNode ast = new StreamConfigParser().parse("foo |  transform --expression=\"'Hello, world!'\" | bar");
+		StreamsNode ast = parse("foo |  transform --expression=\"'Hello, world!'\" | bar");
 		ModuleNode mn = ast.getModule("transform");
 		Properties props = mn.getArgumentsAsProperties();
 		assertEquals("'Hello, world!'",props.get("expression"));
-		ast = new StreamConfigParser().parse("foo |  transform --expression='''Hello, world!''' | bar");
+		ast = parse("foo |  transform --expression='''Hello, world!''' | bar");
 		mn = ast.getModule("transform");
 		props = mn.getArgumentsAsProperties();
 		assertEquals("'Hello, world!'",props.get("expression"));
@@ -284,7 +292,7 @@ public class StreamConfigParserTests {
 
 	@Test
 	public void expressions_gh1() {
-		StreamsNode ast = new StreamConfigParser().parse("http --port=9014 | filter --expression=\"payload == 'foo'\" | log");
+		StreamsNode ast = parse("http --port=9014 | filter --expression=\"payload == 'foo'\" | log");
 		ModuleNode mn = ast.getModule("filter");
 		Properties props = mn.getArgumentsAsProperties();
 		assertEquals("payload == 'foo'",props.get("expression"));
@@ -292,7 +300,7 @@ public class StreamConfigParserTests {
 
 	@Test
 	public void expressions_gh1_2() {
-		StreamsNode ast = new StreamConfigParser().parse("http --port=9014 | filter --expression='new Foo()' | log");
+		StreamsNode ast = parse("http --port=9014 | filter --expression='new Foo()' | log");
 		ModuleNode mn = ast.getModule("filter");
 		Properties props = mn.getArgumentsAsProperties();
 		assertEquals("new Foo()",props.get("expression"));
@@ -301,7 +309,7 @@ public class StreamConfigParserTests {
 	// Job steps joined with '&'
 	@Test
 	public void jobsteps() {
-		StreamsNode ast =parse("step1 & step2");
+		StreamsNode ast = parse("step1 & step2");
 		assertEquals("Streams[step1 & step2][(ModuleNode:step1:isJobStep:0>5)(ModuleNode:step2:isJobStep:8>13)]",ast.stringify(true));
 	}
 	
@@ -342,99 +350,118 @@ public class StreamConfigParserTests {
 	
 	@Test
 	public void substreams() {
-		StreamsNode ast = parse("myhttp = http --port=9000; myhttp | file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
-		assertEquals("[(ModuleNode:http --port=9000:9>25)(ModuleNode:file:36>40)]",stream2.stringify(true));
+		parse("myhttp = http --port=9000");
+		StreamsNode ast = parse("myhttp | file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
+		assertEquals("[(ModuleNode:http --port=9000:9>25)(ModuleNode:file:9>13)]",stream2.stringify(true));
 	}
 	
 	@Test
 	public void substreamsWithSourceChannels() {
-		checkForParseError("myhttp = :foo > foo: filter --name=payload; myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = :foo > foo: filter --name=payload");
-		checkForParseError("myhttp = :foo > filter; myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = :foo > filter");
-		checkForParseError("myhttp = :aaa.foo > filter; myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = :aaa.foo > filter");
-		checkForParseError("myhttp = tap :foo > filter; myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = tap :foo > filter");
-		checkForParseError("myhttp = tap aaa.foo > filter; myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = tap aaa.foo > filter");
-		checkForParseError("myhttp = :foo > filter --name=payload; myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = :foo > filter --name=payload");
+		parse("myhttp = :foo > foo: filter --name=payload");
+		checkForParseError("myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = :foo > foo: filter --name=payload");
+		parse("myhttp = :foo > filter");
+		checkForParseError("myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = :foo > filter");
+		parse("myhttp = :aaa.foo > filter");
+		checkForParseError("myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = :aaa.foo > filter");
+		parse("myhttp = tap :foo > filter");
+		checkForParseError("myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = tap :foo > filter");
+		parse("myhttp = tap aaa.foo > filter");
+		checkForParseError("myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = tap aaa.foo > filter");
+		parse("myhttp = :foo > filter --name=payload");
+		checkForParseError("myhttp | file",XDDSLMessages.NO_SOURCE_IN_SUBSTREAM,-1,"myhttp = :foo > filter --name=payload");
 	}
 
 	@Test
 	public void substreamsWithSinkChannels() {
-		checkForParseError("myhttp = filter > :foo; file | myhttp",XDDSLMessages.NO_SINK_IN_SUBSTREAM,-1,"myhttp = filter > :foo");
+		parse("myhttp = filter > :foo");
+		checkForParseError("file | myhttp",XDDSLMessages.NO_SINK_IN_SUBSTREAM,-1,"myhttp = filter > :foo");
 	}
 
 	@Test
 	public void substreamsMultipleModules() {
-		StreamsNode ast = parse("foo = transform --expression='abc' | transform --expression='def'; http | foo | file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
+		parse("foo = transform --expression='abc' | transform --expression='def'");
+		StreamsNode ast = parse("http | foo | file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
 		// TODO after macro insertion the source locations for the inserted modules are kind of meaningless, reset them?
-		assertEquals("[(ModuleNode:http:67>71)(ModuleNode:transform --expression=abc:6>34)(ModuleNode:transform --expression=def:37>65)(ModuleNode:file:80>84)]",stream2.stringify(true));
+		assertEquals("[(ModuleNode:http:0>4)(ModuleNode:transform --expression=abc:6>32)(ModuleNode:transform --expression=def:35>61)(ModuleNode:file:13>17)]",stream2.stringify(true));
 	}
 	
 	@Test
 	public void substreamsAdditionalParams() {
-		StreamsNode ast = parse("myhttp = http --port=9000; myhttp --setting2=value2 | file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
+		parse("myhttp = http --port=9000");
+		StreamsNode ast = parse("myhttp --setting2=value2 | file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
 		assertEquals("[(ModuleNode:http --port=9000 --setting2=value2)(ModuleNode:file)]",stream2.stringify());
 	}
 	
 	@Test
 	public void substreamsOverrideParams() {
-		StreamsNode ast = parse("myhttp = http --port=9000; myhttp --port=9010| file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
+		parse("myhttp = http --port=9000");
+		StreamsNode ast = parse("myhttp --port=9010| file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
 		assertEquals("[(ModuleNode:http --port=9010)(ModuleNode:file)]",stream2.stringify());
 	}
 	
 	@Test
 	public void parameterizedStreams() {
-		StreamsNode ast = parse("nameReplacer = transform --expression=payload.replaceAll('${name}','x'); http | nameReplacer --name='Andy' | file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
+		parse("nameReplacer = transform --expression=payload.replaceAll('${name}','x')");
+		StreamsNode ast = parse("http | nameReplacer --name='Andy' | file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
 		assertEquals("[(ModuleNode:http)(ModuleNode:transform --expression=payload.replaceAll('Andy','x'))(ModuleNode:file)]",stream2.stringify());
 	}
 
 	@Test
 	public void parameterizedStreamsMissingValue() {
-		checkForParseError("nameReplacer = transform --expression=payload.replaceAll('${name}','x'); http | nameReplacer --name2='Andy' | file",
+		parse("nameReplacer = transform --expression=payload.replaceAll('${name}','x')");
+		checkForParseError("http | nameReplacer --name2='Andy' | file",
 				XDDSLMessages.MISSING_VALUE_FOR_VARIABLE, -1,"name");
 	}
 
 	@Test
 	public void parameterizedStreamsMissingCloseCurly() {
-		checkForParseError("nameReplacer = transform --expression=payload.replaceAll('${name','x'); http | nameReplacer --name2='Andy' | file",
+		parse("nameReplacer = transform --expression=payload.replaceAll('${name','x')");
+		checkForParseError("http | nameReplacer --name2='Andy' | file",
 				XDDSLMessages.VARIABLE_NOT_TERMINATED, -1,"--expression=payload.replaceAll('${name','x')");
 	}
 	
 	@Test
 	public void parameterizedStreamsDefaultValues() {
-		StreamsNode ast = parse("nameReplacer = transform --expression=payload.replaceAll('${name:foo}','x'); http | nameReplacer | file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
+		parse("nameReplacer = transform --expression=payload.replaceAll('${name:foo}','x')");
+		StreamsNode ast = parse("http | nameReplacer | file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
 		assertEquals("[(ModuleNode:http)(ModuleNode:transform --expression=payload.replaceAll('foo','x'))(ModuleNode:file)]",stream2.stringify());
 	}
 	
 	@Test
 	public void parameterizedStreamsMixingItUp() {
-		StreamsNode ast = parse("nameReplacer = transform --expression=payload.replaceAll('${name:foo}','x'); http | nameReplacer --setting2=value2 | file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
+		parse("nameReplacer = transform --expression=payload.replaceAll('${name:foo}','x')");
+		StreamsNode ast = parse("http | nameReplacer --setting2=value2 | file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
 		assertEquals("[(ModuleNode:http)(ModuleNode:transform --expression=payload.replaceAll('foo','x') --setting2=value2)(ModuleNode:file)]",stream2.stringify());
 	}
 	
 	@Test
 	public void parameterizedStreamsMixingItUp2() {
-		StreamsNode ast = parse("nameReplacer = transform --a1=${foo} --b1=${bar}; http | nameReplacer --foo=abc --bar=def | file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
+		parse("nameReplacer = transform --a1=${foo} --b1=${bar}");
+		StreamsNode ast = parse("http | nameReplacer --foo=abc --bar=def | file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
 		assertEquals("[(ModuleNode:http)(ModuleNode:transform --a1=abc --b1=def)(ModuleNode:file)]",stream2.stringify());
 	}
 
 	@Test
 	public void parameterizedSubstreamsMultipleModules() {
-		StreamsNode ast = parse("nameReplacer = transform --a1=${foo} | transform --b1=${bar}; http | nameReplacer --foo=abc --bar=def | file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
+		parse("nameReplacer = transform --a1=${foo} | transform --b1=${bar}");
+		StreamsNode ast = parse("http | nameReplacer --foo=abc --bar=def | file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
 		assertEquals("[(ModuleNode:http)(ModuleNode:transform --a1=abc)(ModuleNode:transform --b1=def)(ModuleNode:file)]",stream2.stringify());
 	}
 	
 	@Test
 	public void parameterizedSubstreamsMultipleModulesDefaultValues() {
-		StreamsNode ast = parse("nameReplacer = transform --a1=${foo:default} | transform --b1=${bar}; http | nameReplacer --bar=def | file");
-		StreamNode stream2 = ast.getStreamNodes().get(1);
+		parse("nameReplacer = transform --a1=${foo:default} | transform --b1=${bar}");
+		StreamsNode ast = parse("http | nameReplacer --bar=def | file");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
 		assertEquals("[(ModuleNode:http)(ModuleNode:transform --a1=default)(ModuleNode:transform --b1=def)(ModuleNode:file)]",stream2.stringify());
 	}
 	
@@ -524,19 +551,45 @@ public class StreamConfigParserTests {
 
 	// ---
 	
+	private TestRepository testRepository = new TestRepository();
+	
 	@After
 	public void reset() {
-		StreamConfigParser.reset();
+		testRepository.reset();
+	}
+	
+	private StreamConfigParser getParser() {
+		return new StreamConfigParser(testRepository);
 	}
 	
 	StreamsNode parse(String streamDefinition) {
-		return new StreamConfigParser().parse(streamDefinition);
+		StreamsNode streamsNode = getParser().parse(streamDefinition);
+		for (StreamNode sn: streamsNode.getStreamNodes()) {
+			if (sn.getStreamName()!=null) {
+				testRepository.save(new StreamDefinition(sn.getStreamName(),sn.getStreamData()));
+			}
+		}
+		return streamsNode;
 	}
-	
+
+	StreamsNode parse(String streamName, String streamDefinition) {
+		StreamsNode streamsNode = getParser().parse(streamName,streamDefinition);
+		for (int s=0;s<streamsNode.getStreamNodes().size();s++) {
+			StreamNode sn = streamsNode.getStreamNodes().get(s);
+			String sname = sn.getStreamName();
+			if (sname==null && s==0) {
+				sname = streamName;
+			}
+			if (sname!=null) {
+				testRepository.save(new StreamDefinition(sname,sn.getStreamData()));
+			}
+		}
+		return streamsNode;
+	}
 
 	private void checkForParseError(String stream,XDDSLMessages msg,int pos,String... inserts) {
 		try {
-			StreamsNode sn = new StreamConfigParser().parse(stream);
+			StreamsNode sn = parse(stream);
 			fail("expected to fail but parsed "+sn.stringify());
 		} catch (DSLException e) {
 			e.printStackTrace();
@@ -548,5 +601,69 @@ public class StreamConfigParserTests {
 				}
 			}
 		}
+	}
+	
+	private static class TestRepository implements CrudRepository<StreamDefinition,String> {
+		
+		private final static boolean debugRepository = false;
+		
+		private Map<String,StreamDefinition> data = new HashMap<String,StreamDefinition>();
+
+		public void reset() {
+			data.clear();
+		}
+		
+		public <S extends StreamDefinition> S save(S entity) {
+			if (debugRepository) {
+				System.out.println(System.identityHashCode(this)+" save("+entity+")");
+			}
+			data.put(entity.getName(), entity);
+			return entity;
+		}
+
+		public <S extends StreamDefinition> Iterable<S> save(Iterable<S> entities) {
+			throw new IllegalStateException();
+		}
+
+		public StreamDefinition findOne(String id) {
+			StreamDefinition sd = data.get(id);
+			if (debugRepository) {
+				System.out.println(System.identityHashCode(this)+" repository findOne("+id+") returning "+sd);
+			}
+			return sd;
+		}
+
+		public boolean exists(String id) {
+			throw new IllegalStateException();
+		}
+
+		public Iterable<StreamDefinition> findAll() {
+			return data.values();
+		}
+
+		public Iterable<StreamDefinition> findAll(Iterable<String> ids) {
+			throw new IllegalStateException();
+		}
+
+		public long count() {
+			throw new IllegalStateException();
+		}
+
+		public void delete(String id) {
+			throw new IllegalStateException();
+		}
+
+		public void delete(StreamDefinition entity) {
+			throw new IllegalStateException();
+		}
+
+		public void delete(Iterable<? extends StreamDefinition> entities) {
+			throw new IllegalStateException();
+		}
+
+		public void deleteAll() {
+			throw new IllegalStateException();
+		}
+		
 	}
 }


### PR DESCRIPTION
For substream reference resolving I had to make the parser aware of the stream definition repository. That is the primary change here.  At the end you will see the new StreamCommandTests that work because of this, e.g testSubSubstreams().  
