### PR TITLE
XD-587 Controllers now inherit from a base class for boiler plate code.

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ResourceDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ResourceDeployer.java
@@ -47,4 +47,5 @@ public interface ResourceDeployer<R extends BaseDefinition> {
 	 */
 	void delete(String name);
 
+	void undeploy(String name);
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
@@ -16,26 +16,20 @@
 
 package org.springframework.xd.dirt.rest;
 
-import java.util.ArrayList;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.xd.dirt.stream.StreamDeployer;
-import org.springframework.xd.dirt.stream.NoSuchDefinitionException;
 import org.springframework.xd.dirt.stream.StreamDefinition;
 import org.springframework.xd.dirt.stream.StreamDefinitionRepository;
+import org.springframework.xd.dirt.stream.StreamDeployer;
 import org.springframework.xd.rest.client.domain.StreamDefinitionResource;
 
 /**
@@ -49,56 +43,12 @@ import org.springframework.xd.rest.client.domain.StreamDefinitionResource;
 @Controller
 @RequestMapping("/streams")
 @ExposesResourceFor(StreamDefinitionResource.class)
-public class StreamsController {
-
-	private final StreamDeployer streamDeployer;
-
-	private final StreamDefinitionRepository streamDefinitionRepository;
-
-	private final StreamDefinitionResourceAssembler definitionResourceAssembler = new StreamDefinitionResourceAssembler();
+public class StreamsController extends
+		XDController<StreamDefinition, StreamDefinitionResourceAssembler, StreamDefinitionResource> {
 
 	@Autowired
 	public StreamsController(StreamDeployer streamDeployer, StreamDefinitionRepository streamDefinitionRepository) {
-		this.streamDeployer = streamDeployer;
-		this.streamDefinitionRepository = streamDefinitionRepository;
-	}
-
-	/**
-	 * Request removal of an existing stream.
-	 *
-	 * @param name the name of an existing stream (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
-	@ResponseStatus(HttpStatus.OK)
-	public void delete(@PathVariable("name") String name) {
-		streamDeployer.delete(name);
-	}
-
-	/**
-	 * Request deployment of an existing named stream.
-	 *
-	 * @param name the name of an existing stream (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.PUT, params = "deploy=true")
-	@ResponseStatus(HttpStatus.OK)
-	public void deploy(@PathVariable("name") String name) {
-		streamDeployer.deploy(name);
-	}
-
-	/**
-	 * Retrieve information about a single {@link StreamDefinition}.
-	 *
-	 * @param name the name of an existing stream (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
-	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
-	public StreamDefinitionResource display(@PathVariable("name") String name) {
-		StreamDefinition streamDefinition = streamDefinitionRepository.findOne(name);
-		if (streamDefinition == null) {
-			throw new NoSuchDefinitionException(name, "There is no stream definition named '%s'");
-		}
-		return definitionResourceAssembler.toResource(streamDefinition);
+		super(streamDeployer, new StreamDefinitionResourceAssembler());
 	}
 
 	/**
@@ -109,48 +59,11 @@ public class StreamsController {
 	@ResponseStatus(HttpStatus.OK)
 	public PagedResources<StreamDefinitionResource> list(Pageable pageable,
 			PagedResourcesAssembler<StreamDefinition> assembler) {
-		Page<StreamDefinition> page = streamDefinitionRepository.findAll(pageable);
-		// Workaround https://github.com/SpringSource/spring-hateoas/issues/89
-		if (page.hasContent()) {
-			return assembler.toResource(page, definitionResourceAssembler);
-		}
-		else {
-			return new PagedResources<StreamDefinitionResource>(new ArrayList<StreamDefinitionResource>(), null);
-		}
+		return listValues(pageable, assembler);
 	}
 
-	/**
-	 * Create a new Stream, optionally deploying it.
-	 *
-	 * @param name the name of the stream to create (required)
-	 * @param definition some representation of the stream behavior, expressed in the XD DSL (required)
-	 * @param deploy whether to also immediately deploy the stream (default true)
-	 */
-	@RequestMapping(value = "", method = RequestMethod.POST)
-	@ResponseStatus(HttpStatus.CREATED)
-	@ResponseBody
-	public StreamDefinitionResource save(@RequestParam("name") String name,
-			@RequestParam("definition") String definition,
-			@RequestParam(value = "deploy", defaultValue = "true") boolean deploy) {
-
-		final StreamDefinition streamDefinition = new StreamDefinition(name, definition);
-		final StreamDefinition savedStreamDefinition = streamDeployer.save(streamDefinition);
-		final StreamDefinitionResource result = definitionResourceAssembler.toResource(savedStreamDefinition);
-		if (deploy) {
-			streamDeployer.deploy(name);
-		}
-		return result;
-	}
-
-	/**
-	 * Request un-deployment of an existing named stream.
-	 *
-	 * @param name the name of an existing stream (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.PUT, params = "deploy=false")
-	@ResponseStatus(HttpStatus.OK)
-	public void undeploy(@PathVariable("name") String name) {
-		streamDeployer.undeploy(name);
+	protected StreamDefinition definitionFactory(String name, String definition) {
+		return new StreamDefinition(name, definition);
 	}
 }
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/TapsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/TapsController.java
@@ -16,23 +16,17 @@
 
 package org.springframework.xd.dirt.rest;
 
-import java.util.ArrayList;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.xd.dirt.stream.NoSuchDefinitionException;
 import org.springframework.xd.dirt.stream.TapDefinition;
 import org.springframework.xd.dirt.stream.TapDeployer;
 import org.springframework.xd.rest.client.domain.TapDefinitionResource;
@@ -46,56 +40,13 @@ import org.springframework.xd.rest.client.domain.TapDefinitionResource;
 @Controller
 @RequestMapping("/taps")
 @ExposesResourceFor(TapDefinitionResource.class)
-public class TapsController {
-
-	private final TapDeployer tapDeployer;
-
-	private final TapDefinitionResourceAssembler definitionResourceAssembler = new TapDefinitionResourceAssembler();
+public class TapsController
+		extends
+		XDController<TapDefinition, TapDefinitionResourceAssembler, TapDefinitionResource> {
 
 	@Autowired
 	public TapsController(TapDeployer tapDeployer) {
-		this.tapDeployer = tapDeployer;
-	}
-
-	/**
-	 * Request removal of an existing tap.
-	 *
-	 * @param name the name of an existing tap (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
-	@ResponseStatus(HttpStatus.OK)
-	public void delete(@PathVariable("name") String name) {
-		tapDeployer.delete(name);
-	}
-
-	/**
-	 * Deploy an existing Tap.
-	 *
-	 * @param name the name of the tap to deploy (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.PUT, params = "deploy=true")
-	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
-	public void deploy(@PathVariable("name") String name) {
-		tapDeployer.deploy(name);
-	}
-
-	/**
-	 * Retrieve information about a single {@link TapDefinition}.
-	 *
-	 * @param name the name of an existing tap (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
-	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
-	public TapDefinitionResource display(@PathVariable("name") String name) {
-		final TapDefinition tapDefinition = tapDeployer.findOne(name);
-
-		if (tapDefinition == null) {
-			throw new NoSuchDefinitionException(name, "There is no tap definition named '%s'");
-		}
-
-		return definitionResourceAssembler.toResource(tapDefinition);
+		super(tapDeployer, new TapDefinitionResourceAssembler());
 	}
 
 	/**
@@ -105,48 +56,13 @@ public class TapsController {
 	@RequestMapping(value = "", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	public PagedResources<TapDefinitionResource> list(Pageable pageable, PagedResourcesAssembler<TapDefinition> assembler) {
-
-		final Page<TapDefinition> page = tapDeployer.findAll(pageable);
-
-		if (page.hasContent()) {
-			return assembler.toResource(page, definitionResourceAssembler);
-		}
-		else {
-			return new PagedResources<TapDefinitionResource>(new ArrayList<TapDefinitionResource>(), null);
-		}
+		return this.listValues(pageable, assembler);
 	}
 
-	/**
-	 * Create a new Tap.
-	 *
-	 * @param name the name of the tap to create (required)
-	 * @param definition the tap definition expressed in the XD DSL (required)
-	 */
-	@RequestMapping(value = "", method = RequestMethod.POST)
-	@ResponseStatus(HttpStatus.CREATED)
-	@ResponseBody
-	public TapDefinitionResource save(@RequestParam("name") String name,
-			@RequestParam("definition") String definition,
-			@RequestParam(value = "deploy", defaultValue = "true") boolean deploy) {
-
-		final TapDefinition tapDefinition = new TapDefinition(name, definition);
-		final TapDefinition savedTapDefinition = tapDeployer.save(tapDefinition);
-		final TapDefinitionResource result = definitionResourceAssembler.toResource(savedTapDefinition);
-		if (deploy) {
-			tapDeployer.deploy(name);
-		}
-		return result;
+	protected TapDefinition definitionFactory(String name, String definition) {
+		return new TapDefinition(name, definition);
 	}
 
-	/**
-	 * Request un-deployment of an existing named tap.
-	 *
-	 * @param name the name of an existing tap (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.PUT, params = "deploy=false")
-	@ResponseStatus(HttpStatus.OK)
-	public void undeploy(@PathVariable("name") String name) {
-		tapDeployer.undeploy(name);
-	}
+
 }
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/TriggersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/TriggersController.java
@@ -16,11 +16,9 @@
 
 package org.springframework.xd.dirt.rest;
 
-import java.util.ArrayList;
-
 import org.apache.commons.lang.NotImplementedException;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -30,73 +28,28 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.xd.dirt.stream.NoSuchDefinitionException;
 import org.springframework.xd.dirt.stream.TriggerDefinition;
 import org.springframework.xd.dirt.stream.TriggerDeployer;
 import org.springframework.xd.rest.client.domain.TriggerDefinitionResource;
 
 /**
  * Handles all Trigger related interactions.
- *
+ * 
  * @author Gunnar Hillert
  * @since 1.0
  */
 @Controller
 @RequestMapping("/triggers")
 @ExposesResourceFor(TriggerDefinitionResource.class)
-public class TriggersController {
-
-	private final TriggerDeployer triggerDeployer;
-
-	private final TriggerDefinitionResourceAssembler definitionResourceAssembler = new TriggerDefinitionResourceAssembler();
+public class TriggersController
+		extends
+		XDController<TriggerDefinition, TriggerDefinitionResourceAssembler, TriggerDefinitionResource> {
 
 	@Autowired
-	public TriggersController(TriggerDeployer streamDeployer) {
-		this.triggerDeployer = streamDeployer;
-	}
-
-	/**
-	 * Request removal of an existing {@link TriggerDefinition}.
-	 *
-	 * @param name the name of an existing trigger (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
-	@ResponseStatus(HttpStatus.OK)
-	public void delete(@PathVariable("name") String name) {
-		triggerDeployer.delete(name);
-	}
-
-	/**
-	 * Deploy an existing Trigger.
-	 *
-	 * @param name the name of the tap to create (required)
-	 * @param definition the tap definition expressed in the XD DSL (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.PUT, params = "deploy=true")
-	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
-	public void deploy(@PathVariable("name") String name) {
-		triggerDeployer.deploy(name);
-	}
-
-	/**
-	 * Retrieve information about a single {@link TriggerDefinition}.
-	 *
-	 * @param name the name of an existing trigger (required)
-	 */
-	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
-	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
-	public TriggerDefinitionResource display(@PathVariable("name") String name) {
-		final TriggerDefinition triggerDefinition = triggerDeployer.findOne(name);
-
-		if (triggerDefinition == null) {
-			throw new NoSuchDefinitionException(name, "There is no trigger definition named '%s'");
-		}
-		return definitionResourceAssembler.toResource(triggerDefinition);
+	public TriggersController(TriggerDeployer triggerDeployer) {
+		super(triggerDeployer, new TriggerDefinitionResourceAssembler());
 	}
 
 	/**
@@ -105,48 +58,26 @@ public class TriggersController {
 	@RequestMapping(value = "", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public PagedResources<TriggerDefinitionResource> list(Pageable pageable, PagedResourcesAssembler<TriggerDefinition> assembler) {
+	public PagedResources<TriggerDefinitionResource> list(Pageable pageable,
+			PagedResourcesAssembler<TriggerDefinition> assembler) {
 
-		final Page<TriggerDefinition> page = triggerDeployer.findAll(pageable);
-
-		if (page.hasContent()) {
-			return assembler.toResource(page, definitionResourceAssembler);
-		}
-		else {
-			return new PagedResources<TriggerDefinitionResource>(new ArrayList<TriggerDefinitionResource>(), null);
-		}
-	}
-
-	/**
-	 * Create a new Trigger.
-	 *
-	 * @param name the name of the trigger to create (required)
-	 * @param definition the {@link TriggerDefinition} expressed in the XD DSL (required)
-	 */
-	@RequestMapping(value = "", method = RequestMethod.POST)
-	@ResponseStatus(HttpStatus.CREATED)
-	@ResponseBody
-	public TriggerDefinitionResource save(@RequestParam("name") String name,
-			@RequestParam("definition") String definition,
-			@RequestParam(value = "deploy", defaultValue = "true") boolean deploy) {
-		final TriggerDefinition triggerDefinition = new TriggerDefinition(name, definition);
-		final TriggerDefinition savedTriggerDefinition = triggerDeployer.save(triggerDefinition);
-		final TriggerDefinitionResource result = definitionResourceAssembler.toResource(savedTriggerDefinition);
-		if (deploy) {
-			triggerDeployer.deploy(name);
-		}
-		return result;
+		return listValues(pageable, assembler);
 	}
 
 	/**
 	 * Request removal of an existing trigger.
 	 *
-	 * @param name the name of an existing trigger (required)
+	 * @param name
+	 *            the name of an existing trigger (required)
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.PUT, params = "deploy=false")
 	@ResponseStatus(HttpStatus.OK)
 	public void undeploy(@PathVariable("name") String name) {
-		throw new NotImplementedException("Removal of Triggers is not Implemented, yet.");
+		throw new NotImplementedException(
+				"Removal of Triggers is not Implemented, yet.");
+	}
+
+	protected TriggerDefinition definitionFactory(String name, String definition) {
+		return new TriggerDefinition(name, definition);
 	}
 }
-

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/XDController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/XDController.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.rest;
+
+import java.util.ArrayList;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.xd.dirt.core.BaseDefinition;
+import org.springframework.xd.dirt.stream.AbstractDeployer;
+import org.springframework.xd.dirt.stream.NoSuchDefinitionException;
+
+/**
+ * Base Class for XD Controllers.
+ * 
+ * @author Glenn Renfro
+ * @since 1.0
+ */
+
+@SuppressWarnings("rawtypes")
+public abstract class XDController<D extends BaseDefinition, V extends ResourceAssemblerSupport, T extends ResourceSupport> {
+
+	private AbstractDeployer<D> deployer;
+	private V resourceAssemblerSupport;
+
+
+	protected XDController(AbstractDeployer<D> deployer,
+			V resourceAssemblerSupport) {
+		this.deployer = deployer;
+		this.resourceAssemblerSupport = resourceAssemblerSupport;
+	}
+
+	/*
+	 * Request removal of an existing module.
+	 *
+	 * @param name the name of an existing module (required)
+	 */
+	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)
+	@ResponseStatus(HttpStatus.OK)
+	public void delete(@PathVariable("name") String name) {
+		deployer.delete(name);
+	}
+
+	/**
+	 * Request un-deployment of an existing named module.
+	 *
+	 * @param name
+	 *            the name of an existing module (required)
+	 */
+	@RequestMapping(value = "/{name}", method = RequestMethod.PUT, params = "deploy=false")
+	@ResponseStatus(HttpStatus.OK)
+	public void undeploy(@PathVariable("name") String name) {
+		getDeployer().undeploy(name);
+	}
+
+	/**
+	 * Request deployment of an existing named module.
+	 * 
+	 * @param name
+	 *            the name of an existing module (required)
+	 */
+	@RequestMapping(value = "/{name}", method = RequestMethod.PUT, params = "deploy=true")
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public void deploy(@PathVariable("name") String name) {
+		getDeployer().deploy(name);
+	}
+
+	/**
+	 * Retrieve information about a single {@link ResourceSupport}.
+	 * 
+	 * @param name
+	 *            the name of an existing tap (required)
+	 */
+	@SuppressWarnings("unchecked")
+	@RequestMapping(value = "/{name}", method = RequestMethod.GET)
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public ResourceSupport display(@PathVariable("name") String name) {
+		final D definition = getDeployer().findOne(name);
+		if (definition == null) {
+			throw new NoSuchDefinitionException(name,
+					"There is no definition named '%s'");
+		}
+		return getResourceAssemblerSupport().toResource(definition);
+	}
+
+	/**
+	 * List module definitions.
+	 */
+	@SuppressWarnings("unchecked")
+	public PagedResources<T> listValues(Pageable pageable,
+			PagedResourcesAssembler<D> assembler) {
+		Page<D> page = getDeployer().findAll(pageable);
+		if (page.hasContent()) {
+			return assembler.toResource(page, getResourceAssemblerSupport());
+		} else {
+			return new PagedResources<T>(new ArrayList<T>(), null);
+		}
+	}
+
+	/**
+	 * Create a new Module.
+	 * 
+	 * @param name
+	 *            The name of the module to create (required)
+	 * @param definition
+	 *            The module definition, expressed in the XD DSL (required)
+	 */
+	@RequestMapping(value = "", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	@ResponseBody
+	public T save(
+			@RequestParam("name") String name,
+			@RequestParam("definition") String definition,
+			@RequestParam(value = "deploy", defaultValue = "true") boolean deploy) {
+		final D moduleDefinition = definitionFactory(
+				name, definition);
+		final D savedModuleDefinition = getDeployer().save(moduleDefinition);
+		if (deploy) {
+				getDeployer().deploy(name);
+		}
+		@SuppressWarnings("unchecked")
+		final T result = (T) getResourceAssemblerSupport().toResource(
+				savedModuleDefinition);
+		return result;
+	}
+
+	public AbstractDeployer<D> getDeployer() {
+		return deployer;
+	}
+
+	public V getResourceAssemblerSupport() {
+		return resourceAssemblerSupport;
+	}
+
+	protected abstract D definitionFactory(String name,
+			String Definition);
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -68,6 +68,7 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 		if (repository.findOne(definition.getName()) != null) {
 			throwDefinitionAlreadyExistsException(definition);
 		}
+		streamParser.parse(definition.getName(), definition.getDefinition());
 		return repository.save(definition);
 	}
 
@@ -135,6 +136,11 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 		return streamParser.parse(name, config);
 	}
 
+	@Override
+	public void undeploy(String name) {
+
+	}
+
 	protected enum ErrorMessage{
 		nameEmptyError {
 			String getMessage(){
@@ -193,5 +199,16 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 		};
 
 		abstract String getMessage();
+	}
+
+	/*
+	 * Removes the module from the repository without doing an undeploy.
+	 */
+	public void remove(String name) {
+		D def = repository.findOne(name);
+		if (def == null) {
+			throwNoSuchDefinitionException(name);
+		}
+		repository.delete(name);
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDefinition.java
@@ -14,9 +14,6 @@ package org.springframework.xd.dirt.stream;
 
 import org.springframework.xd.dirt.core.BaseDefinition;
 
-
-import org.springframework.xd.dirt.core.BaseDefinition;
-
 /**
  * @author David Turanski
  * @author Gunnar Hillert

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDeployer.java
@@ -41,7 +41,7 @@ public class JobDeployer extends AbstractDeployer<JobDefinition> {
 		}
 		try {
 		if (getRepository().exists(name)) {
-			undeployJob(name);
+			undeploy(name);
 		}
 		getRepository().delete(name);
 		} catch (DSLException dslException) {
@@ -79,7 +79,7 @@ public class JobDeployer extends AbstractDeployer<JobDefinition> {
 		}
 	}
 
-	public void undeployJob(String name) {
+	public void undeploy(String name) {
 		JobDefinition job = getRepository().findOne(name);
 		if (job == null) {
 			throwNoSuchDefinitionException(name);
@@ -95,17 +95,5 @@ public class JobDeployer extends AbstractDeployer<JobDefinition> {
 		catch (MessageHandlingException ex) {
 			// Job is not deployed.
 		}
-
-	}
-
-	/*
-	 * Removes the module from the repository without doing an undeploy.
-	 */
-	public void remove(String name) {
-		JobDefinition def = getRepository().findOne(name);
-		if (def == null) {
-			throwNoSuchDefinitionException(name);
-		}
-		getRepository().delete(name);
 	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
@@ -82,7 +83,8 @@ public class JobsControllerIntegrationTests extends AbstractControllerIntegratio
 				post("/jobs").param("name", "job2").param("definition", "Job --cron='*/10 * * * * *'")
 						.accept(MediaType.APPLICATION_JSON)).andExpect(status().isCreated());
 
-		mockMvc.perform(get("/jobs").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+		mockMvc.perform(get("/jobs").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.content", Matchers.hasSize(2)))
 				.andExpect(jsonPath("$.content[0].name").value("job1"))
 				.andExpect(jsonPath("$.content[1].name").value("job2"));
@@ -124,20 +126,9 @@ public class JobsControllerIntegrationTests extends AbstractControllerIntegratio
 						.param("definition", "Job adsfa")
 						.accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isBadRequest());
-		
-		mockMvc.perform(get("/jobs").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk())
-					.andExpect(jsonPath("$.content", Matchers.hasSize(0)));
-	}
 
-	@Test
-	public void testInvalidDefinitionDelete() throws Exception {
-		mockMvc.perform(
-				post("/jobs").param("name", "job1")
-						.param("definition", "Job adsfa")
-						.param("deploy", "false")
-						.accept(MediaType.APPLICATION_JSON)).andExpect(
-				status().isCreated());
-		mockMvc.perform(delete("/jobs/{name}", "job1")).andExpect(
-				status().isOk());
+		mockMvc.perform(get("/jobs").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content", Matchers.hasSize(0)));
 	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationTests.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;


### PR DESCRIPTION
Get rid of boilerplate code.

Adding list to command

Now supporting Save command in XD Controller

Triggers now use XD-Controller

TapController is now using XD Controller.

Save now does a parse before "saving".

Added copyright and cleaned up the code.
