### PR TITLE
XD-563 - fixed Gemfire examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,7 +200,7 @@ project('spring-xd-analytics') {
 project('spring-xd-dirt') {
 	description = 'Spring XD DIRT'
 	configurations {
-		[runtime,testRuntime]*.exclude group: 'org.codehaus.jackson'
+		//[runtime,testRuntime]*.exclude group: 'org.codehaus.jackson'
 	}
 	dependencies {
 
@@ -307,6 +307,7 @@ project ('spring-xd-gemfire-server') {
 	dependencies {
 		compile "commons-beanutils:commons-beanutils:$commonsBeanUtilsVersion"
 		compile "org.springframework.data:spring-data-gemfire:$springDataGemfireVersion"
+		compile project(':spring-xd-tuple')
 		runtime "log4j:log4j:$log4jVersion",
 				"org.slf4j:jcl-over-slf4j:$slf4jVersion",
 				"org.slf4j:slf4j-log4j12:$slf4jVersion"
@@ -438,6 +439,7 @@ project('spring-xd-hadoop') {
 		compile "org.springframework.data:spring-data-mongodb:$springDataMongoVersion"
 		compile ("org.springframework.data:spring-data-hadoop:$springDataHadoopVersion") {
 			exclude group: 'org.mortbay.jetty'
+			exclude group: 'org.codehaus.jackson'
 		}
 		// Needed for webhdfs sink
 		runtime ("org.mortbay.jetty:jetty-util:6.1.26")

--- a/modules/common/gemfire-client.xml
+++ b/modules/common/gemfire-client.xml
@@ -6,7 +6,7 @@
 		http://www.springframework.org/schema/gemfire http://www.springframework.org/schema/gemfire/spring-gemfire.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<gfe:client-cache id="client-cache" use-bean-factory-locator="false" />
+	<gfe:client-cache id="client-cache" use-bean-factory-locator="false" close="false"/>
 	<gfe:pool id="client-pool">
 		<gfe:server host="${gemfireHost:localhost}" port="${gemfirePort:40404}" />
 	</gfe:pool>

--- a/modules/sink/gemfire-json-server.xml
+++ b/modules/sink/gemfire-json-server.xml
@@ -11,7 +11,7 @@
 
 	<import resource="../common/gemfire-client.xml"/>
 
-	<int:transformer input-channel="input" output-channel="to.gemfire">
+	<int:transformer input-channel="input" output-channel="to.gemfire" method="toObject">
 		<bean class="org.springframework.integration.x.gemfire.JsonStringToObjectTransformer"/>
 	</int:transformer>
 

--- a/modules/source/gemfire-cq.xml
+++ b/modules/source/gemfire-cq.xml
@@ -23,5 +23,9 @@
 
 	<int:channel id="output"/>
 
-	<int-gfe:cq-inbound-channel-adapter channel="output" cq-listener-container="cqContainer" query="${query}" durable="false"/>
+	<int-gfe:cq-inbound-channel-adapter channel="to.transformer" 
+	cq-listener-container="cqContainer" query="${query}" durable="false" expression="newValue"/>
+	<int:transformer input-channel="to.transformer" output-channel="output" method="toString">
+		<bean class="org.springframework.integration.x.gemfire.JsonStringToObjectTransformer"/>
+	</int:transformer>
 </beans>

--- a/scripts/gemfire/gemfire-server
+++ b/scripts/gemfire/gemfire-server
@@ -158,7 +158,7 @@ if [ x"$GEMFIRE_HOME" = x ] ; then
     GEMFIRE_HOME=$APP_HOME
 fi
 # set GEMFIRE_HOME as system property via SPRING_GEMFIRE_SERVER_OPTS
-SPRING_GEMFIRE_SERVER_OPTS="-Dgemfire.home=$GEMFIRE_HOME -Dlog4j.configuration=file:///$GEMFIRE_HOME/config/gemfire-cacheserver-logger.properties"
+SPRING_GEMFIRE_SERVER_OPTS="-Dgemfire.home=$GEMFIRE_HOME -Dlog4j.configuration=file:///$APP_HOME/config/gemfire-cacheserver-logger.properties"
 
 # Split up the JVM_OPTS And SPRING_GEMFIRE_SERVER_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/gemfire/gemfire-server.bat
+++ b/scripts/gemfire/gemfire-server.bat
@@ -78,7 +78,7 @@ if not exist "%GEMFIRE_HOME%" (
 )
 
 @rem Execute gemfire-server
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% -Dgemfire.home=%GEMFIRE_HOME% -Dlog4j.configuration=file:///%GEMFIRE_HOME%/config/gemfire-cacheserver-logger.properties -classpath "%CLASSPATH%" org.springframework.xd.gemfire.CacheServer %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% -Dgemfire.home=%GEMFIRE_HOME% -Dlog4j.configuration=file:///%APP_HOME%/config/gemfire-cacheserver-logger.properties -classpath "%CLASSPATH%" org.springframework.xd.gemfire.CacheServer %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/gemfire/JsonStringToObjectTransformer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/gemfire/JsonStringToObjectTransformer.java
@@ -24,7 +24,7 @@ import com.gemstone.org.json.JSONObject;
  *
  */
 public class JsonStringToObjectTransformer {
-	public PdxInstance transform(String json) {
+	public PdxInstance toObject(String json) {
 		JSONObject jsonObject = null;
 		try {
 			jsonObject = new JSONObject(json);
@@ -32,5 +32,17 @@ public class JsonStringToObjectTransformer {
 			throw new MessageTransformationException(e.getMessage());
 		}
 		return JSONFormatter.fromJSON(jsonObject.toString());
+	}
+	
+	public String toString(Object obj) {
+		if (obj == null) {
+			return null;
+		}
+		if (obj instanceof PdxInstance) {
+			String json =  JSONFormatter.toJSON((PdxInstance)obj);
+			//de-pretty
+			return json.replaceAll("\\n\\s*", "").replaceAll("\\s*:\\s*", ":").trim();
+		}
+		return obj.toString();
 	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/gemfire/JsonStringToObjectTransformerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/gemfire/JsonStringToObjectTransformerTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.integration.x.gemfire;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.gemstone.gemfire.cache.CacheFactory;
+import com.gemstone.gemfire.pdx.PdxInstance;
+
+/**
+ * @author David Turanski
+ *
+ */
+public class JsonStringToObjectTransformerTests {
+	@Test
+	public void test() {
+		new CacheFactory().create();
+		JsonStringToObjectTransformer transformer = new JsonStringToObjectTransformer();
+		String json = "{\"symbol\":\"VMW\",\"price\":73}";
+		PdxInstance pdx = transformer.toObject(json);
+		assertEquals("VMW", pdx.getField("symbol"));
+		assertEquals(Byte.valueOf("73"), pdx.getField("price"));
+
+		String result = transformer.toString(pdx);
+		assertEquals(json, result);
+	}
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/json/TypedJsonMapperTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/json/TypedJsonMapperTests.java
@@ -25,8 +25,7 @@ import java.util.TreeSet;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
-
-import org.springframework.integration.x.json.TypedJsonMapper;
+import org.springframework.xd.tuple.DefaultTuple;
 import org.springframework.xd.tuple.Tuple;
 import org.springframework.xd.tuple.TupleBuilder;
 
@@ -98,11 +97,11 @@ public class TypedJsonMapperTests {
 
 	@Test
 	public void testMapSerialization() {
-		Map<String,String> map = new HashMap<String,String>();
-		map.put("foo","bar");
+		Map<String, String> map = new HashMap<String, String>();
+		map.put("foo", "bar");
 		byte[] bytes = mapper.toBytes(map);
-		Map<?,?> obj = (Map<?,?>)mapper.fromBytes(bytes);
-		assertEquals("bar",obj.get("foo"));
+		Map<?, ?> obj = (Map<?, ?>) mapper.fromBytes(bytes);
+		assertEquals("bar", obj.get("foo"));
 	}
 
 	@Test
@@ -110,8 +109,8 @@ public class TypedJsonMapperTests {
 		List<String> list = new LinkedList<String>();
 		list.add("foo");
 		byte[] bytes = mapper.toBytes(list);
-		List<?> obj = (List<?>)mapper.fromBytes(bytes);
-		assertEquals("foo",obj.get(0));
+		List<?> obj = (List<?>) mapper.fromBytes(bytes);
+		assertEquals("foo", obj.get(0));
 	}
 
 	@Test
@@ -119,8 +118,8 @@ public class TypedJsonMapperTests {
 		Set<String> set = new TreeSet<String>();
 		set.add("foo");
 		byte[] bytes = mapper.toBytes(set);
-		Set<?> obj = (Set<?>)mapper.fromBytes(bytes);
-		assertEquals("foo",obj.iterator().next());
+		Set<?> obj = (Set<?>) mapper.fromBytes(bytes);
+		assertEquals("foo", obj.iterator().next());
 	}
 
 	@Test
@@ -132,6 +131,38 @@ public class TypedJsonMapperTests {
 		assertEquals("bar", obj.getString("foo"));
 	}
 
+	@Test
+	public void testConvertSerializedStringToRequestedType() {
+		String json = "{\"symbol\":\"VMW\",\"price\":73}";
+		byte[] bytes = mapper.toBytes(json);
+		Object obj = mapper.fromBytes(bytes, DefaultTuple.class.getName());
+		assertTrue(obj instanceof Tuple);
+		Tuple t = (Tuple) obj;
+		assertEquals("VMW", t.getValue("symbol"));
+		assertEquals(73, t.getInt("price"));
+	}
+
+	@Test
+	public void testConvertSerializedObjectToRequestedType() {
+		Foo foo = new Foo("hello");
+		byte[] bytes = mapper.toBytes(foo);
+		Object obj = mapper.fromBytes(bytes, DefaultTuple.class.getName());
+		assertTrue(obj instanceof Tuple);
+		Tuple t = (Tuple) obj;
+		assertEquals("hello", t.getValue("bar"));
+	}
+
+	@Test
+	public void testConvertRawStringToRequestedType() {
+		String json = "{\"symbol\":\"VMW\",\"price\":73}";
+		byte[] bytes = json.getBytes();
+		Object obj = mapper.fromBytes(bytes, DefaultTuple.class.getName());
+		assertTrue(obj instanceof Tuple);
+		Tuple t = (Tuple) obj;
+		assertEquals("VMW", t.getValue("symbol"));
+		assertEquals(73, t.getInt("price"));
+	}
+
 	public static class Foo {
 		@JsonCreator
 		public Foo(@JsonProperty("bar") String val) {
@@ -140,5 +171,4 @@ public class TypedJsonMapperTests {
 
 		public String bar;
 	}
-
 }

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/JsonBytesToTupleConverterTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/JsonBytesToTupleConverterTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.springframework.xd.tuple;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author David Turanski
+ *
+ */
+public class JsonBytesToTupleConverterTests {
+	private JsonBytesToTupleConverter converter = new JsonBytesToTupleConverter();
+	@Test
+	public void testSimple() {
+		String json = "{\"symbol\":\"VMW\",\"price\":73}";
+		Tuple t = converter.convert(json.getBytes());
+		assertEquals("VMW",t.getValue("symbol"));
+	}
+}


### PR DESCRIPTION
Includes fix to gemfire-cq module to convert CQ event data.  Removes exclusion of org.codehaus.jackson for DIRT runtime (required by Gemfire Json classes).  Also includes some enhancements to TypedJsonMapper integrated with ChannelRegistry support 
