### PR TITLE
XD-633 Rabbit Source Improvements

### DIFF
--- a/modules/source/rabbit.xml
+++ b/modules/source/rabbit.xml
@@ -15,7 +15,8 @@
 
 	<int-amqp:inbound-channel-adapter
 			auto-startup="false"
-			queue-names="${queue}" channel="output" connection-factory="connectionFactory"/>
+			queue-names="${queues:${xd.stream.name}}"
+			channel="output" connection-factory="connectionFactory"/>
 
 	<rabbit:connection-factory id="connectionFactory" host="${host:${rabbit.hostname}}" port="${port:${rabbit.port}}"/>
 


### PR DESCRIPTION
- Make the stream name the default queue.
- Change the parameter to `queues` (from `queue`) since a list of queues is supported.
