### PR TITLE
XD-599 Adding placeholders for spring-xd-hadoop sub-projects

### DIFF
--- a/spring-xd-hadoop/hadoop10/README.md
+++ b/spring-xd-hadoop/hadoop10/README.md
@@ -1,0 +1,3 @@
+## spring-xd-hadoop sub-project
+
+Placeholder for sub-project pulling in Hadoop distribution specific dependencies.

--- a/spring-xd-hadoop/hadoop11/README.md
+++ b/spring-xd-hadoop/hadoop11/README.md
@@ -1,0 +1,3 @@
+## spring-xd-hadoop sub-project
+
+Placeholder for sub-project pulling in Hadoop distribution specific dependencies.

--- a/spring-xd-hadoop/hadoop20/README.md
+++ b/spring-xd-hadoop/hadoop20/README.md
@@ -1,0 +1,3 @@
+## spring-xd-hadoop sub-project
+
+Placeholder for sub-project pulling in Hadoop distribution specific dependencies.

--- a/spring-xd-hadoop/phd1/README.md
+++ b/spring-xd-hadoop/phd1/README.md
@@ -1,0 +1,3 @@
+## spring-xd-hadoop sub-project
+
+Placeholder for sub-project pulling in Hadoop distribution specific dependencies.


### PR DESCRIPTION
The placeholder will fix an issue with the Gradle plug-in or Eclipse not being able to handle
the missing sub-project directories.
