### PR TITLE
XD-636 Header Leakage in Rabbit Transport

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/rabbit/RabbitChannelRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/rabbit/RabbitChannelRegistry.java
@@ -112,6 +112,15 @@ public class RabbitChannelRegistry extends ChannelRegistrySupport implements Dis
 				return transformInboundIfNecessary(requestMessage, acceptedMediaTypes);
 			}
 
+			@Override
+			protected boolean shouldCopyRequestHeaders() {
+				/*
+				 *  we've already copied the headers so no need for the ARPMH to do
+				 *  it, and we don't want the content-type restored if absent.
+				 */
+				return false;
+			}
+
 		};
 		convertingBridge.setOutputChannel(moduleInputChannel);
 		convertingBridge.setBeanName(name + ".convert.bridge");

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/channel/registry/AbstractChannelRegistryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/channel/registry/AbstractChannelRegistryTests.java
@@ -18,6 +18,7 @@ package org.springframework.integration.x.channel.registry;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -99,7 +100,25 @@ public abstract class AbstractChannelRegistryTests {
 		Message<?> inbound = moduleInputChannel.receive(5000);
 		assertNotNull(inbound);
 		assertEquals("foo", inbound.getPayload());
+		assertNull(inbound.getHeaders().get(ChannelRegistrySupport.ORIGINAL_CONTENT_TYPE_HEADER));
 		assertEquals("foo/bar", inbound.getHeaders().get(MessageHeaders.CONTENT_TYPE));
+	}
+
+	@Test
+	public void testSendAndReceiveNoOriginalContentType() throws Exception {
+		ChannelRegistry registry = getRegistry();
+		DirectChannel moduleOutputChannel = new DirectChannel();
+		QueueChannel moduleInputChannel = new QueueChannel();
+		registry.createOutbound("bar.0", moduleOutputChannel, false);
+		registry.createInbound("bar.0", moduleInputChannel, ALL, false);
+		Message<?> message = MessageBuilder.withPayload("foo")
+				.build();
+		moduleOutputChannel.send(message);
+		Message<?> inbound = moduleInputChannel.receive(5000);
+		assertNotNull(inbound);
+		assertEquals("foo", inbound.getPayload());
+		assertNull(inbound.getHeaders().get(ChannelRegistrySupport.ORIGINAL_CONTENT_TYPE_HEADER));
+		assertNull(inbound.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
 	protected abstract Collection<?> getBridges(ChannelRegistry registry);


### PR DESCRIPTION
The `ARPMH` used in the rabbit transport copied the request headers.

This caused the internal transport content-type header to be
restored when there was no original content-type. It also caused
the internal `originalContentType` header to be restored.
