### PR TITLE
XD-666 Fix Conversion on Taps

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/channel/registry/LocalChannelRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/channel/registry/LocalChannelRegistry.java
@@ -41,13 +41,15 @@ import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.util.Assert;
 
 /**
- * A simple implementation of {@link ChannelRegistry} for in-process use. For inbound and outbound, creates a
- * {@link DirectChannel} or a {@link QueueChannel} depending on whether the binding is aliased or not then bridges the
- * passed {@link MessageChannel} to the channel which is registered in the given application context. If that channel
- * does not yet exist, it will be created. For tap, it adds a {@link WireTap} for an inbound channel whose name matches
- * the one provided. If no such inbound channel exists at the time of the method invocation, it will throw an Exception.
- * Otherwise the provided channel instance will receive messages from the wire tap on that inbound channel.
- *
+ * A simple implementation of {@link ChannelRegistry} for in-process use. For inbound and
+ * outbound, creates a {@link DirectChannel} or a {@link QueueChannel} depending on
+ * whether the binding is aliased or not then bridges the passed {@link MessageChannel} to
+ * the channel which is registered in the given application context. If that channel does
+ * not yet exist, it will be created. For tap, it adds a {@link WireTap} for an inbound
+ * channel whose name matches the one provided. If no such inbound channel exists at the
+ * time of the method invocation, it will throw an Exception. Otherwise the provided
+ * channel instance will receive messages from the wire tap on that inbound channel.
+ * 
  * @author David Turanski
  * @author Mark Fisher
  * @author Gary Russell
@@ -70,6 +72,7 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 	 */
 	private SharedChannelProvider<DirectChannel> directChannelProvider = new SharedChannelProvider<DirectChannel>(
 			DirectChannel.class) {
+
 		@Override
 		protected DirectChannel createSharedChannel(String name) {
 			return new DirectChannel();
@@ -77,10 +80,12 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 	};
 
 	/**
-	 * Used to create and customize {@link QueueChannel}s when the binding operation involves aliased names.
+	 * Used to create and customize {@link QueueChannel}s when the binding operation
+	 * involves aliased names.
 	 */
 	private SharedChannelProvider<QueueChannel> queueChannelProvider = new SharedChannelProvider<QueueChannel>(
 			QueueChannel.class) {
+
 		@Override
 		protected QueueChannel createSharedChannel(String name) {
 			QueueChannel queueChannel = new QueueChannel(queueSize);
@@ -109,8 +114,8 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 	}
 
 	/**
-	 * Determines whether any conversion logic is applied within the local transport. When false, objects pass through
-	 * without any modification; default true.
+	 * Determines whether any conversion logic is applied within the local transport. When
+	 * false, objects pass through without any modification; default true.
 	 */
 	public void setConvertWithinTransport(boolean convertWithinTransport) {
 		this.convertWithinTransport = convertWithinTransport;
@@ -122,9 +127,10 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 	}
 
 	/**
-	 * Looks up or creates a DirectChannel with the given name and creates a bridge from that channel to the provided
-	 * channel instance. Also registers a wire tap if the channel for the given name had been created. The target of the
-	 * wire tap is a publish-subscribe channel.
+	 * Looks up or creates a DirectChannel with the given name and creates a bridge from
+	 * that channel to the provided channel instance. Also registers a wire tap if the
+	 * channel for the given name had been created. The target of the wire tap is a
+	 * publish-subscribe channel.
 	 */
 	@Override
 	public void createInbound(String name, MessageChannel moduleInputChannel, Collection<MediaType> acceptedMediaTypes,
@@ -138,13 +144,13 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 	}
 
 	private AbstractMessageChannel lookupOrCreateSharedChannel(String name, boolean useQueues) {
-		return useQueues ? queueChannelProvider.lookupOrCreateSharedChannel(name) : directChannelProvider
-				.lookupOrCreateSharedChannel(name);
+		return useQueues ? queueChannelProvider.lookupOrCreateSharedChannel(name)
+				: directChannelProvider.lookupOrCreateSharedChannel(name);
 	}
 
 	/**
-	 * Looks up or creates a DirectChannel with the given name and creates a bridge to that channel from the provided
-	 * channel instance.
+	 * Looks up or creates a DirectChannel with the given name and creates a bridge to
+	 * that channel from the provided channel instance.
 	 */
 	@Override
 	public void createOutbound(String name, MessageChannel moduleOutputChannel, boolean aliasHint) {
@@ -155,8 +161,9 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 	}
 
 	/**
-	 * Looks up a wiretap for the inbound channel with the given name and creates a bridge from that wiretap's output
-	 * channel to the provided channel instance. Will throw an Exception if no such wiretap exists.
+	 * Looks up a wiretap for the inbound channel with the given name and creates a bridge
+	 * from that wiretap's output channel to the provided channel instance. Will throw an
+	 * Exception if no such wiretap exists.
 	 */
 	@Override
 	public void tap(String tapModule, String name, MessageChannel channel) {
@@ -171,7 +178,8 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 			throw new IllegalArgumentException("No tap channel exists for '" + name
 					+ "'. A tap is only valid for a registered inbound channel.");
 		}
-		bridge(tapChannel, channel, tapName + ".bridge", tapModule);
+		// TODO: media types needs to be passed in by Tap.
+		bridge(tapChannel, channel, tapName + "in.bridge", tapModule);
 	}
 
 	@Override
@@ -302,12 +310,13 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 	}
 
 	/**
-	 * Used to remember the bridging that was done, so it can be undone in {@link LocalChannelRegistry#deleteOutbound(String)}
-	 * .
-	 *
+	 * Used to remember the bridging that was done, so it can be undone in
+	 * {@link LocalChannelRegistry#deleteOutbound(String)} .
+	 * 
 	 * @author Eric Bottard
 	 */
 	private static class BridgeMetadata {
+
 		private final BridgeHandler handler;
 
 		private ConsumerEndpointFactoryBean cefb;
@@ -329,7 +338,7 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 
 	/**
 	 * Looks up or optionally creates a new channel to use.
-	 *
+	 * 
 	 * @author Eric Bottard
 	 */
 	private abstract class SharedChannelProvider<T extends AbstractMessageChannel> {

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/redis/RedisInboundChannelAdapter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/redis/RedisInboundChannelAdapter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2007-2012 the original author or authors
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ */
+
+package org.springframework.integration.x.redis;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.integration.Message;
+import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.support.converter.MessageConverter;
+import org.springframework.integration.support.converter.SimpleMessageConverter;
+import org.springframework.util.Assert;
+
+/**
+ * Clone of SI adapter allowing any object type.
+ * 
+ * @author Mark Fisher
+ * @author Oleg Zhurakousky
+ * @author Gary Russell
+ * @since 2.1
+ */
+public class RedisInboundChannelAdapter extends MessageProducerSupport {
+
+	private final RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+
+	private volatile MessageConverter messageConverter = new SimpleMessageConverter();
+
+	private volatile String[] topics;
+
+	private volatile RedisSerializer<?> serializer = new StringRedisSerializer();
+
+	public RedisInboundChannelAdapter(RedisConnectionFactory connectionFactory) {
+		Assert.notNull(connectionFactory, "connectionFactory must not be null");
+		this.container.setConnectionFactory(connectionFactory);
+	}
+
+	public void setSerializer(RedisSerializer<?> serializer) {
+		Assert.notNull(serializer, "'serializer' must not be null");
+		this.serializer = serializer;
+	}
+
+	public void setTopics(String... topics) {
+		this.topics = topics;
+	}
+
+	public void setMessageConverter(MessageConverter messageConverter) {
+		Assert.notNull(messageConverter, "messageConverter must not be null");
+		this.messageConverter = messageConverter;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "redis:inbound-channel-adapter";
+	}
+
+	@Override
+	protected void onInit() {
+		super.onInit();
+		Assert.notEmpty(this.topics, "at least one topis is required for subscription");
+		MessageListenerDelegate delegate = new MessageListenerDelegate();
+		MessageListenerAdapter adapter = new MessageListenerAdapter(delegate);
+		adapter.setSerializer(this.serializer);
+		List<ChannelTopic> topicList = new ArrayList<ChannelTopic>();
+		for (String topic : this.topics) {
+			topicList.add(new ChannelTopic(topic));
+		}
+		adapter.afterPropertiesSet();
+		this.container.addMessageListener(adapter, topicList);
+		this.container.afterPropertiesSet();
+	}
+
+	@Override
+	protected void doStart() {
+		super.doStart();
+		this.container.start();
+	}
+
+	@Override
+	protected void doStop() {
+		super.doStop();
+		this.container.stop();
+	}
+
+	private Message<?> convertMessage(Object object) {
+		return this.messageConverter.toMessage(object);
+	}
+
+	private class MessageListenerDelegate {
+
+		@SuppressWarnings("unused")
+		public void handleMessage(Object object) {
+			sendMessage(convertMessage(object));
+		}
+	}
+
+}


### PR DESCRIPTION
The channel registries did not apply conversion logic to taps.

This meant that, for the Redis transport, the internal transport
headers were included in the tapped data and, for Rabbit, the
content type was incorrect.

Apply the same logic to taps that is applied to inbound.
