### PR TITLE
XD-664 file has .out suffix by default

### DIFF
--- a/modules/sink/file.xml
+++ b/modules/sink/file.xml
@@ -26,6 +26,6 @@
 		mode="APPEND"
 		charset="${charset:UTF-8}"
 		directory="${dir:/tmp/xd/output/}"
-		filename-generator-expression="'${name:${xd.stream.name}}'"/>
+		filename-generator-expression="'${name:${xd.stream.name}}.${suffix:out}'"/>
 
 </beans:beans>


### PR DESCRIPTION
.out is the default, but I also expose a configurable "suffix" parameter

the only possible quirk is that if an empty string were passed, there would still be a dot at the end of the file name

if we want to allow no suffix at all, then we probably need to modify the SpEL expression to be a bit more sophisticated with ternary logic checking for the empty suffix
