### PR TITLE
XD-645 Separate properties per transport

### DIFF
--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/container.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/container.xml
@@ -13,7 +13,6 @@
 	</beans>
 
 	<beans>
-		<import resource="classpath:/META-INF/spring-xd/internal/xd-common.xml"/>
 		<import
 			resource="classpath*:/META-INF/spring-xd/transports/${xd.transport}-container.xml" />
 

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/xd-common.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/xd-common.xml
@@ -3,18 +3,6 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-<!-- This should be imported by container and admin components which require a property placeholder. The raw bean config 
-allows an 'id' attribute, ensuring this is a single bean instance and may be imported multiple times -->
-
-	<bean id="xd.property.placeholder" class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
-		<property name="locations">
-			<list>
-				<value>file:${xd.home}/config/redis.properties</value>
-				<value>file:${xd.home}/config/rabbit.properties</value>
-			</list>
-		</property>
-	</bean>
-
 	<bean id="moduleRegistry" class="org.springframework.xd.dirt.module.FileModuleRegistry">
 		<constructor-arg value="${xd.home}/modules" />
 	</bean>

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/local-admin.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/local-admin.xml
@@ -7,6 +7,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
+	<import resource="local-common.xml" />
 	<import resource="classpath:/META-INF/spring-xd/internal/container.xml"/>
 	<import resource="classpath*:/META-INF/spring-xd/plugins/*.xml"/>
 

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/local-common.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/local-common.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<import resource="classpath:/META-INF/spring-xd/internal/xd-common.xml"/>
+
+	<bean id="local.property.placeholder" class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer" />
+</beans>

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/local-registry.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/local-registry.xml
@@ -9,7 +9,7 @@
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
-	<import resource="../internal/xd-common.xml"/>
+	<import resource="local-common.xml" />
 
 	<bean id="channelRegistry"
 		class="org.springframework.integration.x.channel.registry.LocalChannelRegistry">

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/rabbit-common.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/rabbit-common.xml
@@ -3,7 +3,11 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<import resource="classpath:/META-INF/spring-xd/internal/xd-common.xml"/>
+    <import resource="classpath:/META-INF/spring-xd/internal/xd-common.xml"/>
+
+	<bean id="rabbit.property.placeholder" class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
+		<property name="locations" value="file:${xd.home}/config/rabbit.properties"/>
+	</bean>
 
 	<bean id="rabbitConnectionFactory" class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory">
 		<constructor-arg index="0" value="${rabbit.hostname:localhost}"/>

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/redis-common.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/redis-common.xml
@@ -6,7 +6,11 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
-	<import resource="classpath:/META-INF/spring-xd/internal/xd-common.xml" />
+	<import resource="classpath:/META-INF/spring-xd/internal/xd-common.xml"/>
+
+	<bean id="redis.property.placeholder" class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
+		<property name="locations" value="file:${xd.home}/config/redis.properties"/>
+	</bean>
 
 	<bean id="redisConnectionFactory"
 		class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory">

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/container/PropertiesConfigurationTests-context.xml
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/container/PropertiesConfigurationTests-context.xml
@@ -7,6 +7,6 @@
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
-	<import resource="classpath:/META-INF/spring-xd/internal/xd-common.xml"/>
+	<import resource="classpath:/META-INF/spring-xd/transports/local-common.xml"/>
 	<import resource="ppc.xml"/>
 </beans>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/container/ppc.xml
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/container/ppc.xml
@@ -7,5 +7,5 @@
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.2.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.2.xsd">
 
-	<import resource="classpath:/META-INF/spring-xd/internal/xd-common.xml"/>
+	<import resource="classpath:/META-INF/spring-xd/transports/local-common.xml"/>
 </beans>


### PR DESCRIPTION
- Define specific PPCs for Redis, Rabbit, and Local
  transports
- Allows analytics parent context to have its own
  PPC
