### PR TITLE
Provide per-project AnyEdit rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,8 @@ configure(javaProjects()) { subproject ->
 	// Include project specific settings
 	task eclipseSettings(type: Copy) {
 		from rootProject.files(
-			"src/eclipse/org.eclipse.jdt.ui.prefs")
+			"src/eclipse/org.eclipse.jdt.ui.prefs",
+			"src/eclipse/de.loskutov.anyedit.AnyEditTools.prefs")
 		into project.file('.settings/')
 	}
 

--- a/src/eclipse/de.loskutov.anyedit.AnyEditTools.prefs
+++ b/src/eclipse/de.loskutov.anyedit.AnyEditTools.prefs
@@ -1,0 +1,16 @@
+activeContentFilterList=*.makefile,makefile,*.Makefile,Makefile,Makefile.*,*.mk,MANIFEST.MF
+addNewLine=true
+convertActionOnSaave=AnyEdit.CnvrtSpacesToTabs
+eclipse.preferences.version=1
+ignoreBlankLinesWhenTrimming=false
+inActiveContentFilterList=
+javaTabWidthForJava=true
+org.eclipse.jdt.ui.editor.tab.width=2
+projectPropsEnabled=true
+removeTrailingSpaces=true
+replaceAllSpaces=false
+replaceAllTabs=false
+saveAndAddLine=false
+saveAndConvert=true
+saveAndTrim=true
+useModulo4Tabs=false


### PR DESCRIPTION
If we're going to use AnyEdit, we might as well go the extra mile and make sure that everyone uses the settings.
