### PR TITLE
XD-702 Fix stackoverflow when creating stream with it's name equal to an...

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
@@ -67,11 +67,11 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 		tokenStreamLength = tokenStream.size();
 		tokenStreamPointer = 0;
 		StreamsNode ast = eatStreams();
-		// Check if the stream name is same as that of any of it's module name
-		// Throw DSLException as allowing this causes the parser to lookup for the stream indefinitely.
+		// Check if the stream name is same as that of any of its modules' names
+		// Throw DSLException as allowing this causes the parser to lookup the stream indefinitely.
 		for (StreamNode streamNode : ast.getStreamNodes()) {
 			if (streamNode.getModule(name) != null) {
-				throw new DSLException(stream, stream.indexOf(name), XDDSLMessages.AMBIGUOUS_STREAM_NAME, name);
+				throw new DSLException(stream, stream.indexOf(name), XDDSLMessages.STREAM_NAME_MATCHING_MODULE_NAME, name);
 			}
 		}
 		if (moreTokens()) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/XDDSLMessages.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/XDDSLMessages.java
@@ -67,7 +67,7 @@ public enum XDDSLMessages {
 	// CANNOT_USE_SUBSTREAM_WITH_SINK(ERROR,128,"cannot use substream with source channel"), //
 	AMBIGUOUS_MODULE_NAME(ERROR, 129,
 			"ambiguous module name ''{0}'' in stream named ''{1}'', appears at both position {2} and {3}"),
-	AMBIGUOUS_STREAM_NAME(ERROR, 130, "Stream name ''{0}'' same as that of it's module name is not allowed.");
+	STREAM_NAME_MATCHING_MODULE_NAME(ERROR, 130, "Stream name ''{0}'' same as that of its modules' names is not allowed.");
 
 	private Kind kind;
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -71,12 +71,12 @@ public class StreamConfigParserTests {
 		assertEquals("Streams[mystream = foo][mystream = (ModuleNode:foo:11>14)]", ast.stringify(true));
 	}
 
-	// Test if the DSLException thrown when the stream name is same as that of any of it's module's name.
+	// Test if the DSLException thrown when the stream name is same as that of any of its modules' names.
 	@Test
 	public void testInvalidStreamName() {
 		String streamName = "bar";
 		String stream = "foo | bar";
-		checkForParseError(streamName, stream, XDDSLMessages.AMBIGUOUS_STREAM_NAME, stream.indexOf(streamName), streamName);
+		checkForParseError(streamName, stream, XDDSLMessages.STREAM_NAME_MATCHING_MODULE_NAME, stream.indexOf(streamName), streamName);
 	}
 	
 	// Pipes are used to connect modules
@@ -690,7 +690,6 @@ public class StreamConfigParserTests {
 			fail("expected to fail but parsed " + sn.stringify());
 		}
 		catch (DSLException e) {
-			e.printStackTrace();
 			assertEquals(msg, e.getMessageCode());
 			assertEquals(pos, e.getPosition());
 			if (inserts != null) {
@@ -707,7 +706,6 @@ public class StreamConfigParserTests {
 			fail("expected to fail but parsed " + sn.stringify());
 		}
 		catch (DSLException e) {
-			e.printStackTrace();
 			assertEquals(msg, e.getMessageCode());
 			assertEquals(pos, e.getPosition());
 			if (inserts != null) {


### PR DESCRIPTION
...y of it's module's name.
- Added a check at StreamConfigParser to throw DSLException if the stream
  name matches any of it's module's name
  - Added StreamConfigParser test to check this scenario
