### PR TITLE
XD-716 Fix hang on posting to HTTP source

### DIFF
--- a/spring-xd-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
+++ b/spring-xd-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
@@ -19,6 +19,7 @@ package org.springframework.integration.x.http;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.isKeepAlive;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
+import static org.jboss.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
@@ -27,6 +28,7 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import org.jboss.netty.bootstrap.ServerBootstrap;
@@ -38,6 +40,7 @@ import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.channel.DefaultChannelPipeline;
+import org.jboss.netty.channel.ExceptionEvent;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
@@ -49,27 +52,65 @@ import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+import org.jboss.netty.handler.execution.ExecutionHandler;
+import org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor;
 
 import org.springframework.http.MediaType;
 import org.springframework.integration.MessageHeaders;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.util.Assert;
+
 
 /**
  * @author Mark Fisher
+ * @author Jennifer Hickey
  */
 public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
+
+	/**
+	 * Default max number of threads for the default {@link Executor}
+	 */
+	private static final int DEFAULT_CORE_POOL_SIZE = 16;
+
+	/**
+	 * Default max total size of queued events per channel for the default {@link Executor} (in bytes)
+	 */
+	private static final long DEFAULT_MAX_CHANNEL_MEMORY_SIZE = 1048576;
+
+	/**
+	 * Default max total size of queued events for the whole pool for the default {@link Executor} (in bytes)
+	 */
+	private static final long DEFAULT_MAX_TOTAL_MEMORY_SIZE = 1048576;
 
 	private final int port;
 
 	private volatile ServerBootstrap bootstrap;
 
+	private volatile ExecutionHandler executionHandler;
+
+	private volatile Executor executor = new OrderedMemoryAwareThreadPoolExecutor(DEFAULT_CORE_POOL_SIZE,
+			DEFAULT_MAX_CHANNEL_MEMORY_SIZE, DEFAULT_MAX_TOTAL_MEMORY_SIZE);
+
 	public NettyHttpInboundChannelAdapter(int port) {
 		this.port = port;
 	}
 
+	/**
+	 *
+	 * @param executor The {@link Executor} to use with the Netty {@link ExecutionHandler} in the pipeline. This allows
+	 *        any potential blocking operations done by message consumers to be removed from the I/O thread. The default
+	 *        executor is an {@link OrderedMemoryAwareThreadPoolExecutor}, which is highly recommended because it
+	 *        guarantees order of execution within a channel.
+	 */
+	public void setExecutor(Executor executor) {
+		Assert.notNull(executor, "A non-null executor is required");
+		this.executor = executor;
+	}
+
 	@Override
 	protected void doStart() {
+		executionHandler = new ExecutionHandler(executor);
 		bootstrap = new ServerBootstrap(new NioServerSocketChannelFactory(Executors.newCachedThreadPool(),
 				Executors.newCachedThreadPool()));
 		bootstrap.setOption("child.tcpNoDelay", true);
@@ -93,6 +134,7 @@ public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 			pipeline.addLast("aggregator", new HttpChunkAggregator(1024 * 1024));
 			pipeline.addLast("encoder", new HttpResponseEncoder());
 			pipeline.addLast("compressor", new HttpContentCompressor());
+			pipeline.addLast("executionHandler", executionHandler);
 			pipeline.addLast("handler", new Handler());
 			return pipeline;
 		}
@@ -105,6 +147,7 @@ public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 			HttpRequest request = (HttpRequest) e.getMessage();
 			ChannelBuffer content = request.getContent();
 			Charset charsetToUse = null;
+			HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
 			if (content.readable()) {
 				Map<String, String> messageHeaders = new HashMap<String, String>();
 				for (Entry<String, String> entry : request.getHeaders()) {
@@ -121,14 +164,24 @@ public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 				charsetToUse = charsetToUse == null ? Charset.forName("ISO-8859-1") : charsetToUse;
 				messageHeaders.put("requestPath", request.getUri());
 				messageHeaders.put("requestMethod", request.getMethod().toString());
-				sendMessage(MessageBuilder.withPayload(content.toString(charsetToUse)).copyHeaders(messageHeaders).build());
+				try {
+					sendMessage(MessageBuilder.withPayload(content.toString(charsetToUse)).copyHeaders(messageHeaders).build());
+				}
+				catch (Exception ex) {
+					logger.error("Error sending message", ex);
+					response = new DefaultHttpResponse(HTTP_1_1, INTERNAL_SERVER_ERROR);
+				}
 			}
-			writeResponse(request, e.getChannel());
+			writeResponse(request, response, e.getChannel());
 		}
 
-		private void writeResponse(HttpRequest request, Channel channel) {
+		@Override
+		public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) throws Exception {
+			throw new RuntimeException(e.getCause());
+		}
+
+		private void writeResponse(HttpRequest request, HttpResponse response, Channel channel) {
 			boolean keepAlive = isKeepAlive(request);
-			HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
 			if (keepAlive) {
 				response.setHeader(CONTENT_LENGTH, response.getContent().readableBytes());
 				response.setHeader(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);

--- a/spring-xd-http/src/test/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapterTests.java
+++ b/spring-xd-http/src/test/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapterTests.java
@@ -20,9 +20,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -38,11 +44,14 @@ import org.springframework.integration.MessagingException;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.test.util.SocketUtils;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+
 
 /**
  * @author Mark Fisher
  * @author David Turanski
+ * @author Jennifer Hickey
  */
 public class NettyHttpInboundChannelAdapterTests {
 
@@ -114,4 +123,74 @@ public class NettyHttpInboundChannelAdapterTests {
 		assertEquals(MediaType.TEXT_PLAIN_VALUE, message.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 	}
 
+	@Test(expected = HttpServerErrorException.class)
+	public void testErrorResponse() throws URISyntaxException {
+		DirectChannel channel = new DirectChannel();
+		channel.subscribe(new MessageHandler() {
+
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				throw new RuntimeException();
+			}
+		});
+		int port = SocketUtils.findAvailableServerSocket();
+		NettyHttpInboundChannelAdapter adapter = new NettyHttpInboundChannelAdapter(port);
+		adapter.setOutputChannel(channel);
+		adapter.start();
+		RestTemplate template = new RestTemplate();
+		URI uri1 = new URI("http://localhost:" + port + "/test1");
+		template.postForEntity(uri1, "foo", Object.class);
+	}
+
+	@Test
+	public void testCustomExecutor() throws Exception {
+		final List<Message<?>> messages = new ArrayList<Message<?>>();
+		final Set<String> threadNames = new HashSet<String>();
+		final CountDownLatch latch = new CountDownLatch(1);
+		DirectChannel channel = new DirectChannel();
+		channel.subscribe(new MessageHandler() {
+
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				threadNames.add(Thread.currentThread().getName());
+				messages.add(message);
+				latch.countDown();
+			}
+		});
+		int port = SocketUtils.findAvailableServerSocket();
+		NettyHttpInboundChannelAdapter adapter = new NettyHttpInboundChannelAdapter(port);
+		adapter.setOutputChannel(channel);
+		adapter.setExecutor(Executors.newFixedThreadPool(1, new ThreadFactory() {
+
+			@Override
+			public Thread newThread(Runnable r) {
+				return new Thread(r, "executor-test");
+			}
+		}));
+		adapter.start();
+		RestTemplate template = new RestTemplate();
+		URI uri1 = new URI("http://localhost:" + port + "/test1");
+		URI uri2 = new URI("http://localhost:" + port + "/test2");
+		ResponseEntity<?> response1 = template.postForEntity(uri1, "foo", Object.class);
+		ResponseEntity<?> response2 = template.postForEntity(uri2, "bar", Object.class);
+		assertEquals(HttpStatus.OK, response1.getStatusCode());
+		assertEquals(HttpStatus.OK, response2.getStatusCode());
+		assertTrue(latch.await(1, TimeUnit.SECONDS));
+		// Ensure messages were received on the single thread with custom name
+		assertEquals(Collections.singleton("executor-test"), threadNames);
+		assertEquals(2, messages.size());
+		Message<?> message1 = messages.get(0);
+		Message<?> message2 = messages.get(1);
+		assertEquals("foo", message1.getPayload());
+		assertEquals("bar", message2.getPayload());
+		assertEquals("/test1", message1.getHeaders().get("requestPath"));
+		assertEquals("/test2", message2.getHeaders().get("requestPath"));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testNullExecutor() {
+		int port = SocketUtils.findAvailableServerSocket();
+		NettyHttpInboundChannelAdapter adapter = new NettyHttpInboundChannelAdapter(port);
+		adapter.setExecutor(null);
+	}
 }


### PR DESCRIPTION
- Make NettyHttpInboundChannelAdapter return Http
  500 response if Message Consumer throws Exception
- Prevent Exception initializing Lettuce conn on I/O
  thread by adding an ExecutionHandler to the
  pipeline
