### PR TITLE
XD-732: JSON Property Access

### DIFF
--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/spel/JsonPropertyAccessor.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/spel/JsonPropertyAccessor.java
@@ -16,12 +16,19 @@
 
 package org.springframework.xd.tuple.spel;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
 import org.springframework.expression.AccessException;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypedValue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ContainerNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 
 /**
@@ -74,12 +81,92 @@ public class JsonPropertyAccessor implements PropertyAccessor {
 
 	@Override
 	public boolean canWrite(EvaluationContext context, Object target, String name) throws AccessException {
-		throw new UnsupportedOperationException("Auto-generated method stub");
+		if (target instanceof ArrayNode) {
+			ArrayNode new_name = (ArrayNode) target;
+			Integer index = maybeIndex(name);
+			return new_name.has(index);
+		}
+		else if (target instanceof ObjectNode) {
+			return true;
+		}
+		else {
+			throw new AssertionError("Can't happen");
+		}
 	}
 
 	@Override
 	public void write(EvaluationContext context, Object target, String name, Object newValue) throws AccessException {
-		throw new UnsupportedOperationException("Auto-generated method stub");
+		ContainerNode<?> container = (ContainerNode<?>) target;
+		JsonNode wrapped = wrap(newValue, container);
+
+		if (target instanceof ArrayNode) {
+			ArrayNode array = (ArrayNode) target;
+			array.set(Integer.parseInt(name), wrapped);
+		}
+		else if (target instanceof ObjectNode) {
+			ObjectNode hash = (ObjectNode) target;
+			hash.set(name, wrapped);
+		}
+		else {
+			throw new AccessException(String.format("Can't set property '%s' on object '%s'", name, target));
+		}
 	}
 
+	private JsonNode wrap(Object raw, ContainerNode<?> factory) {
+		if (raw instanceof JsonNode) {
+			return (JsonNode) raw;
+		}
+		else if (raw instanceof String) {
+			return factory.textNode((String) raw);
+		}
+		else if (raw instanceof Byte) {
+			return factory.numberNode((Byte) raw);
+		}
+		else if (raw instanceof Short) {
+			return factory.numberNode((Short) raw);
+		}
+		else if (raw instanceof Character) {
+			return factory.textNode(raw.toString());
+		}
+		else if (raw instanceof Integer) {
+			return factory.numberNode((Integer) raw);
+		}
+		else if (raw instanceof Long) {
+			return factory.numberNode((Long) raw);
+		}
+		else if (raw instanceof Float) {
+			return factory.numberNode((Float) raw);
+		}
+		else if (raw instanceof Double) {
+			return factory.numberNode((Double) raw);
+		}
+		else if (raw instanceof BigInteger) {
+			return factory.numberNode((BigInteger) raw);
+		}
+		else if (raw instanceof BigDecimal) {
+			return factory.numberNode((BigDecimal) raw);
+		}
+		else if (raw == null) {
+			return factory.nullNode();
+		}
+		else if (raw instanceof Object[]) {
+			Object[] array = (Object[]) raw;
+			ArrayNode result = factory.arrayNode();
+			for (Object o : array) {
+				result.add(wrap(o, factory));
+			}
+			return result;
+		}
+		else if (raw instanceof Map) {
+			@SuppressWarnings("unchecked")
+			Map<String, ?> map = (Map<String, ?>) raw;
+			ObjectNode result = factory.objectNode();
+			for (String key : map.keySet()) {
+				result.set(key, wrap(map.get(key), factory));
+			}
+			return result;
+		}
+		else
+			throw new IllegalArgumentException();
+	}
 }


### PR DESCRIPTION
NOTE: This PR will require changes (see comments below) and should not be merged yet.

Not sure about the exception to reset cache trick (see eg https://github.com/markfisher/spring-xd/commit/b6e828f4944f4ba5ad358ee35d176f13c695bfd2)

Not sure about whether we want to support write either, and if so, whether to only support write of JsonNode or what I attempted (this has shortcomings, like can't write primitive array). But this code seems very cumbersome, Jackson must have this somewhere...

Also, put that in tuple project for lack of a better place but... maybe in x.integration, given that this story emerged b/c of exposing the EvaluationContext in SI?
