### PR TITLE
Fix XD-629: create tap channel for module ending with sink channel

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/channel/registry/LocalChannelRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/channel/registry/LocalChannelRegistry.java
@@ -146,7 +146,8 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 
 	/**
 	 * Looks up or creates a DirectChannel with the given name and creates a bridge to that channel from the provided
-	 * channel instance.
+	 * channel instance. Also registers a wire tap if the outbound channel is an alias since a module using a sink
+	 * channel implies there is no subequent module that would normally create the tap.
 	 */
 	@Override
 	public void createOutbound(String name, MessageChannel moduleOutputChannel, boolean aliasHint) {
@@ -154,6 +155,9 @@ public class LocalChannelRegistry extends ChannelRegistrySupport implements Appl
 		Assert.notNull(moduleOutputChannel, "channel must not be null");
 		AbstractMessageChannel registeredChannel = lookupOrCreateSharedChannel(name, aliasHint);
 		bridge(moduleOutputChannel, registeredChannel, registeredChannel.getComponentName() + ".out.bridge");
+		if (aliasHint) {
+			createSharedTapChannelIfNecessary(registeredChannel);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Consider:

```
myhttp = http | transform | filter > :foo
```

Without the change here there is no tap channel created for the filter module as it is normally created when the sink is deployed.  By recognizing a module with an aliased output channel we know there is no real sink so create the tap channel when building the output channel for that module.
