### PR TITLE
XD-752 Avoid duplicate job name entry into JobRegistry

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobAlreadyExistsException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobAlreadyExistsException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.plugins.job;
+
+import org.springframework.xd.dirt.core.XDRuntimeException;
+
+
+/**
+ * 
+ * @author Ilayaperumal Gopinathan
+ */
+@SuppressWarnings("serial")
+public class BatchJobAlreadyExistsException extends XDRuntimeException {
+
+	/**
+	 * @param message exception message
+	 */
+	public BatchJobAlreadyExistsException(String message) {
+		super(message);
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobRegistryBeanPostProcessor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobRegistryBeanPostProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.plugins.job;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.batch.core.configuration.support.JobRegistryBeanPostProcessor;
+
+
+/**
+ * JobRegistryBeanPostProcessor that processes Job bean with name {@link JobPlugin#JOB_BEAN_ID}
+ * 
+ * @author Ilayaperumal Gopinathan
+ */
+public class BatchJobRegistryBeanPostProcessor extends JobRegistryBeanPostProcessor {
+
+	private JobRegistry jobRegistry;
+
+	private String groupName;
+
+	@Override
+	public void setJobRegistry(JobRegistry jobRegistry) {
+		this.jobRegistry = jobRegistry;
+		super.setJobRegistry(jobRegistry);
+	}
+
+	@Override
+	public void setGroupName(String groupName) {
+		this.groupName = groupName;
+		super.setGroupName(groupName);
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) {
+		// Make sure we only post-process the Job bean from the job module's batch job
+		if (bean instanceof Job && beanName.equals(JobPlugin.JOB_BEAN_ID)) {
+			Job job = (Job) bean;
+			// the job name at the JobRegistry will be <groupName>.<batchJobId>
+			String jobName = this.groupName + JobPlugin.JOB_NAME_DELIMITER + job.getName();
+			if (!jobRegistry.getJobNames().contains(jobName)) {
+				super.postProcessAfterInitialization(bean, beanName);
+			}
+			else {
+				// Currently there is no way to get to this as the job module's batch job configuration
+				// schema won't allow multiple ids with JobPlugin.JOB_BEAN_ID ("job")
+				throw new BatchJobAlreadyExistsException("Batch Job with the name " + jobName + " already exists");
+			}
+		}
+		return bean;
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobFactoryBean.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobFactoryBean.java
@@ -39,8 +39,6 @@ public class JobFactoryBean implements FactoryBean<Job> {
 
 	private final JobRegistry registry;
 
-	private static String JOB_NAME_DELIMITER = ".";
-
 	/**
 	 * Instantiate the {@link JobFactoryBean} with the provided {@link JobRegistry} and the name of the {@link Job}.
 	 * 
@@ -53,7 +51,7 @@ public class JobFactoryBean implements FactoryBean<Job> {
 		Assert.hasText(jobName, "The jobName must not be empty.");
 		Assert.hasText(jobSuffix, "The jobSuffix must not be empty.");
 		this.registry = registry;
-		this.jobKeyInRegistry = jobName + JOB_NAME_DELIMITER + jobSuffix;
+		this.jobKeyInRegistry = jobName + JobPlugin.JOB_NAME_DELIMITER + jobSuffix;
 	}
 
 	/**
@@ -69,7 +67,7 @@ public class JobFactoryBean implements FactoryBean<Job> {
 			job = registry.getJob(this.jobKeyInRegistry);
 		}
 		catch (NoSuchJobException e) {
-			throw new IllegalStateException(String.format("No Batch Job found in registry"
+			throw new IllegalStateException(String.format("No Batch Job found in registry "
 					+ "for the provided key '%s'.", this.jobKeyInRegistry));
 		}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
@@ -79,6 +79,8 @@ public class JobPlugin extends AbstractPlugin {
 
 	public static final String JOB_BEAN_ID = "job";
 
+	public static final String JOB_NAME_DELIMITER = ".";
+
 	private final static Collection<MediaType> DEFAULT_ACCEPTED_CONTENT_TYPES = Collections.singletonList(MediaType.ALL);
 
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminMain.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminMain.java
@@ -49,11 +49,11 @@ public class AdminMain {
 	}
 
 	/**
-	 * Parse command line options from a String array into a type safe ContainerOptions class. If any options are not
-	 * valid, an InvalidCommandLineArgumentException exception is thrown
+	 * Parse command line options from a String array into a type safe AdminOptions class. If any options are not valid,
+	 * an InvalidCommandLineArgumentException exception is thrown
 	 * 
 	 * @param args command line arguments
-	 * @return type safe ContainerOptions if all command line arguments are valid
+	 * @return type safe AdminOptions if all command line arguments are valid
 	 * @throws InvalidCommandLineArgumentException if there is an invalid command line argument
 	 */
 	public static AdminOptions parseOptions(String[] args) {
@@ -71,11 +71,11 @@ public class AdminMain {
 	}
 
 	/**
-	 * Parse command line options from a String array into a type safe ContainerOptions class. if any options are not
-	 * valid, a help message is displayed and System.exit is called. If the help option is passed, display the usage.
+	 * Parse command line options from a String array into a type safe AdminOptions class. if any options are not valid,
+	 * a help message is displayed and System.exit is called. If the help option is passed, display the usage.
 	 * 
 	 * @param args command line arguments
-	 * @return type safe ContainerOptions if all command line arguments are valid
+	 * @return type safe AdminOptions if all command line arguments are valid
 	 */
 	private static AdminOptions parseCommandLineOptions(String[] args) {
 		AdminOptions options = new AdminOptions();

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/job-module-beans.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/job-module-beans.xml
@@ -7,7 +7,7 @@
 		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<bean id="registrar" class="org.springframework.batch.core.configuration.support.JobRegistryBeanPostProcessor">
+	<bean id="registrar" class="org.springframework.xd.dirt.plugins.job.BatchJobRegistryBeanPostProcessor">
 		<property name="jobRegistry" ref="jobRegistry"/>
 		<property name="groupName" value="${xd.stream.name}"/>
 	</bean>


### PR DESCRIPTION
- Added BatchJobRegistryBeanPostProcessor
  - this extends JobRgistryBeanPostProcessor
  - to process only the bean with name "job" (batch job id)
