### PR TITLE
XD-722 Batch - Add notification channel support

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
@@ -81,8 +81,9 @@ public class JobPlugin extends AbstractPlugin {
 
 	public static final String JOB_NAME_DELIMITER = ".";
 
-	private final static Collection<MediaType> DEFAULT_ACCEPTED_CONTENT_TYPES = Collections.singletonList(MediaType.ALL);
+	private static final String NOTIFICATION_CHANNEL_SUFFIX = "-notifications";
 
+	private final static Collection<MediaType> DEFAULT_ACCEPTED_CONTENT_TYPES = Collections.singletonList(MediaType.ALL);
 
 	@Override
 	public void configureProperties(Module module) {
@@ -122,11 +123,15 @@ public class JobPlugin extends AbstractPlugin {
 		ChannelRegistry registry = findRegistry(module);
 		DeploymentMetadata md = module.getDeploymentMetadata();
 		if (registry != null) {
-			MessageChannel channel = module.getComponent("input", MessageChannel.class);
-			if (channel != null) {
-				registry.createInbound(md.getGroup(), channel,
+			MessageChannel inputChannel = module.getComponent("input", MessageChannel.class);
+			if (inputChannel != null) {
+				registry.createInbound(md.getGroup(), inputChannel,
 						DEFAULT_ACCEPTED_CONTENT_TYPES,
 						true);
+			}
+			MessageChannel notificationsChannel = module.getComponent("notifications", MessageChannel.class);
+			if (notificationsChannel != null) {
+				registry.createOutbound(md.getGroup() + NOTIFICATION_CHANNEL_SUFFIX, notificationsChannel, true);
 			}
 		}
 	}
@@ -147,9 +152,9 @@ public class JobPlugin extends AbstractPlugin {
 		ChannelRegistry registry = findRegistry(module);
 		if (registry != null) {
 			registry.deleteInbound(module.getDeploymentMetadata().getGroup());
+			registry.deleteOutbound(module.getDeploymentMetadata().getGroup() + NOTIFICATION_CHANNEL_SUFFIX);
 		}
 	}
-
 
 	@Override
 	public List<String> componentPathsSelector(Module module) {

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/job-module-beans.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/job-module-beans.xml
@@ -37,11 +37,11 @@
 	<int:channel id="jobLaunchingChannel"/>
 
 	<int:service-activator id="jobLaunchingMessageHandler" method="launch"
-		input-channel="jobLaunchingChannel" output-channel="logger">
+		input-channel="jobLaunchingChannel" output-channel="notifications">
 		<bean class="org.springframework.batch.integration.launch.JobLaunchingMessageHandler">
 			<constructor-arg ref="jobLauncher"/>
 		</bean>
 	</int:service-activator>
 
-	<int:logging-channel-adapter id="logger" level="INFO" log-full-message="true"/>
+	<int:channel id="notifications"/>
 </beans>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
@@ -95,7 +95,7 @@ public class JobPluginTests {
 		SortedSet<String> names = new TreeSet<String>();
 		names.addAll(Arrays.asList(moduleBeans));
 
-		assertTrue(names.size() > 9);
+		assertTrue(names.size() > 8);
 
 		assertTrue(names.contains("jobTriggerBean"));
 		assertTrue(names.contains("registrar"));
@@ -103,9 +103,8 @@ public class JobPluginTests {
 		assertTrue(names.contains("jobLaunchRequestTransformer"));
 		assertTrue(names.contains("jobLaunchingMessageHandler"));
 		assertTrue(names.contains("input"));
-		assertTrue(names.contains("logger"));
 		assertTrue(names.contains("jobLaunchingChannel"));
-		assertTrue(names.contains("logger.adapter"));
+		assertTrue(names.contains("notifications"));
 	}
 
 	/**


### PR DESCRIPTION
- Adds a notification (output) channel to the channel registry

The following steps should illustrate the added behavior

```
xd> job create --name myjobname --definition "job"
xd> stream create --name jobnotifications --definition ":myjobname-notifications > log"
xd> stream create --name webinput --definition "http > :myjobname"
```

Jira: https://jira.springsource.org/browse/XD-722
