### PR TITLE
XD-779 Send notifications as serialized Java Objects

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
@@ -129,7 +129,7 @@ public class JobPlugin extends AbstractPlugin {
 						DEFAULT_ACCEPTED_CONTENT_TYPES,
 						true);
 			}
-			MessageChannel notificationsChannel = module.getComponent("notifications", MessageChannel.class);
+			MessageChannel notificationsChannel = module.getComponent("serializedNotifications", MessageChannel.class);
 			if (notificationsChannel != null) {
 				registry.createOutbound(md.getGroup() + NOTIFICATION_CHANNEL_SUFFIX, notificationsChannel, true);
 			}

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/job-module-beans.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/job-module-beans.xml
@@ -44,4 +44,8 @@
 	</int:service-activator>
 
 	<int:channel id="notifications"/>
+	<int:payload-serializing-transformer id="serializePayloadToBytes"
+		input-channel="notifications" output-channel="serializedNotifications"/>
+	<int:channel id="serializedNotifications"/>
+
 </beans>


### PR DESCRIPTION
Works around a serialization issue with the JobExecution object. See Jira:

https://jira.springsource.org/browse/XD-779
