### PR TITLE
XD-799 use routing-key-expression in rabbit sink.

### DIFF
--- a/modules/sink/rabbit.xml
+++ b/modules/sink/rabbit.xml
@@ -16,7 +16,7 @@
 	<int-amqp:outbound-channel-adapter id="input"
 			amqp-template="rabbitTemplate"
 			exchange-name="${exchange:}"
-			routing-key="${routingKey:${xd.stream.name}}"/>
+			routing-key-expression="${routingKey:'${xd.stream.name}'}"/>
 
 	<rabbit:template id="rabbitTemplate" connection-factory="connectionFactory"/>
 


### PR DESCRIPTION
The routingKey parameter can now be a SPEL expression, allowing for 
dynamic routing.
