### PR TITLE
XD-800 Namespaces for jobs are now supported by XD.

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
@@ -83,6 +83,8 @@ public class JobPlugin extends AbstractPlugin {
 
 	private static final String NOTIFICATION_CHANNEL_SUFFIX = "-notifications";
 
+	private static final String JOB_CHANNEL_PREFIX = "job:";
+
 	private final static Collection<MediaType> DEFAULT_ACCEPTED_CONTENT_TYPES = Collections.singletonList(MediaType.ALL);
 
 	@Override
@@ -125,7 +127,7 @@ public class JobPlugin extends AbstractPlugin {
 		if (registry != null) {
 			MessageChannel inputChannel = module.getComponent("input", MessageChannel.class);
 			if (inputChannel != null) {
-				registry.createInbound(md.getGroup(), inputChannel,
+				registry.createInbound(JOB_CHANNEL_PREFIX + md.getGroup(), inputChannel,
 						DEFAULT_ACCEPTED_CONTENT_TYPES,
 						true);
 			}
@@ -151,7 +153,7 @@ public class JobPlugin extends AbstractPlugin {
 	public void removeModule(Module module) {
 		ChannelRegistry registry = findRegistry(module);
 		if (registry != null) {
-			registry.deleteInbound(module.getDeploymentMetadata().getGroup());
+			registry.deleteInbound(JOB_CHANNEL_PREFIX + module.getDeploymentMetadata().getGroup());
 			registry.deleteOutbound(module.getDeploymentMetadata().getGroup() + NOTIFICATION_CHANNEL_SUFFIX);
 		}
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
@@ -41,13 +41,13 @@ import org.springframework.xd.module.ModuleType;
  * @author Glenn Renfro
  * @since 1.0
  */
-public class EnhancedStreamParser implements XDParser {
+public class XDStreamParser implements XDParser {
 
 	private CrudRepository<? extends BaseDefinition, String> repository;
 
 	private ModuleRegistry moduleRegistry;
 
-	public EnhancedStreamParser(CrudRepository<? extends BaseDefinition, String> repository,
+	public XDStreamParser(CrudRepository<? extends BaseDefinition, String> repository,
 			ModuleRegistry moduleRegistry) {
 		Assert.notNull(repository, "repository can not be null");
 		Assert.notNull(moduleRegistry, "moduleRegistry can not be null");
@@ -56,7 +56,7 @@ public class EnhancedStreamParser implements XDParser {
 		this.moduleRegistry = moduleRegistry;
 	}
 
-	public EnhancedStreamParser(ModuleRegistry moduleRegistry) {
+	public XDStreamParser(ModuleRegistry moduleRegistry) {
 		// no repository, will not be able to resolve substream/label references
 		Assert.notNull(moduleRegistry, "moduleRegistry can not be null");
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
@@ -209,6 +209,12 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 		if (!firstToken.isIdentifier()) {
 			raiseException(firstToken.startpos, XDDSLMessages.EXPECTED_CHANNEL_NAME, toString(firstToken));
 		}
+		if (peekToken(TokenKind.COLON, true)) {
+			Token suffixToken = eatToken(TokenKind.IDENTIFIER);
+			firstToken = new Token(TokenKind.IDENTIFIER, (firstToken.data + ":" + suffixToken.data).toCharArray(),
+					firstToken.startpos, suffixToken.endpos);
+		}
+
 		if (allowQualifiedChannel && peekToken(TokenKind.DOT, true)) {
 			// firstToken is actually a stream name
 			Token channelToken = eatToken(TokenKind.IDENTIFIER);

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/deployers.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/deployers.xml
@@ -9,7 +9,7 @@
 
 	<int:channel id="undeployChannel" />
 
-	<bean id="parser" class="org.springframework.xd.dirt.stream.EnhancedStreamParser">
+	<bean id="parser" class="org.springframework.xd.dirt.stream.XDStreamParser">
 		<constructor-arg ref="streamDefinitionRepository"/>
 		<constructor-arg name="moduleRegistry" ref="moduleRegistry"/>
 	</bean>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/Dependencies.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/Dependencies.java
@@ -28,7 +28,7 @@ import org.springframework.xd.analytics.metrics.core.GaugeRepository;
 import org.springframework.xd.analytics.metrics.core.RichGaugeRepository;
 import org.springframework.xd.dirt.module.ModuleRegistry;
 import org.springframework.xd.dirt.stream.DeploymentMessageSender;
-import org.springframework.xd.dirt.stream.EnhancedStreamParser;
+import org.springframework.xd.dirt.stream.XDStreamParser;
 import org.springframework.xd.dirt.stream.JobDefinitionRepository;
 import org.springframework.xd.dirt.stream.JobDeployer;
 import org.springframework.xd.dirt.stream.StreamDefinitionRepository;
@@ -95,7 +95,7 @@ public class Dependencies {
 
 	@Bean
 	public XDParser parser() {
-		return new EnhancedStreamParser(streamDefinitionRepository(),
+		return new XDStreamParser(streamDefinitionRepository(),
 				moduleRegistry());
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTestsConfig.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTestsConfig.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.xd.dirt.module.ModuleRegistry;
-import org.springframework.xd.dirt.stream.EnhancedStreamParser;
+import org.springframework.xd.dirt.stream.XDStreamParser;
 import org.springframework.xd.dirt.stream.JobDefinitionRepository;
 import org.springframework.xd.dirt.stream.JobDeployer;
 import org.springframework.xd.dirt.stream.XDParser;
@@ -39,7 +39,7 @@ public class JobsControllerIntegrationTestsConfig extends Dependencies {
 
 	@Bean
 	public JobDeployer jobDeployer() {
-		XDParser parser = new EnhancedStreamParser(
+		XDParser parser = new XDStreamParser(
 				jobDefinitionRepository(), moduleRegistry());
 
 		return new JobDeployer(jobDefinitionRepository(), triggerDefinitionRepository(),

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationWithRepositoryTestsConfig.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationWithRepositoryTestsConfig.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.xd.dirt.stream.DeploymentMessageSender;
-import org.springframework.xd.dirt.stream.EnhancedStreamParser;
+import org.springframework.xd.dirt.stream.XDStreamParser;
 import org.springframework.xd.dirt.stream.StreamDefinitionRepository;
 import org.springframework.xd.dirt.stream.StreamDeployer;
 import org.springframework.xd.dirt.stream.StreamRepository;
@@ -47,7 +47,7 @@ public class StreamsControllerIntegrationWithRepositoryTestsConfig extends
 
 	@Bean
 	public StreamDeployer streamDeployer() {
-		XDParser parser = new EnhancedStreamParser(
+		XDParser parser = new XDStreamParser(
 				streamDefinitionRepository(), moduleRegistry());
 
 		return new StreamDeployer(streamDefinitionRepository(),

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/TapsControllerIntegrationTestsConfig.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/TapsControllerIntegrationTestsConfig.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.xd.dirt.stream.DeploymentMessageSender;
-import org.springframework.xd.dirt.stream.EnhancedStreamParser;
+import org.springframework.xd.dirt.stream.XDStreamParser;
 import org.springframework.xd.dirt.stream.StreamDefinitionRepository;
 import org.springframework.xd.dirt.stream.TapDefinitionRepository;
 import org.springframework.xd.dirt.stream.TapDeployer;
@@ -55,7 +55,7 @@ public class TapsControllerIntegrationTestsConfig extends Dependencies {
 
 	@Bean
 	public TapDeployer tapDeployer() {
-		XDParser parser = new EnhancedStreamParser(
+		XDParser parser = new XDStreamParser(
 				tapDefinitionRepository(), moduleRegistry());
 		return new TapDeployer(tapDefinitionRepository(),
 				streamDefinitionRepository(), deploymentMessageSender(),

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/TriggersControllerIntegrationTestsConfig.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/TriggersControllerIntegrationTestsConfig.java
@@ -15,7 +15,7 @@ package org.springframework.xd.dirt.rest;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.xd.dirt.stream.EnhancedStreamParser;
+import org.springframework.xd.dirt.stream.XDStreamParser;
 import org.springframework.xd.dirt.stream.TriggerDefinitionRepository;
 import org.springframework.xd.dirt.stream.TriggerDeployer;
 import org.springframework.xd.dirt.stream.XDParser;
@@ -36,7 +36,7 @@ public class TriggersControllerIntegrationTestsConfig extends Dependencies {
 
 	@Bean
 	public TriggerDeployer triggerDeployer() {
-		XDParser parser = new EnhancedStreamParser(
+		XDParser parser = new XDStreamParser(
 				triggerDefinitionRepository(), moduleRegistry());
 
 		return new TriggerDeployer(triggerDefinitionRepository(),

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/EnhancedStreamParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/EnhancedStreamParserTests.java
@@ -41,11 +41,11 @@ import org.springframework.xd.module.ModuleType;
  */
 public class EnhancedStreamParserTests {
 
-	private EnhancedStreamParser parser;
+	private XDStreamParser parser;
 
 	@Before
 	public void setup() {
-		parser = new EnhancedStreamParser(moduleRegistry());
+		parser = new XDStreamParser(moduleRegistry());
 	}
 
 	@Test

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/TapDeployerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/TapDeployerTests.java
@@ -68,7 +68,7 @@ public class TapDeployerTests {
 		deployChannel = new DirectChannel();
 		undeployChannel = new PublishSubscribeChannel();
 		sender = new DeploymentMessageSender(deployChannel, undeployChannel);
-		XDParser parser = new EnhancedStreamParser(streamDefinitionRepository, moduleRegistry());
+		XDParser parser = new XDStreamParser(streamDefinitionRepository, moduleRegistry());
 		tapDeployer = new TapDeployer(repository, streamDefinitionRepository, sender, parser, tapInstanceRepository);
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.springframework.core.io.Resource;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.xd.dirt.module.ModuleRegistry;
-import org.springframework.xd.dirt.stream.EnhancedStreamParser;
+import org.springframework.xd.dirt.stream.XDStreamParser;
 import org.springframework.xd.dirt.stream.StreamDefinition;
 import org.springframework.xd.module.ModuleDefinition;
 import org.springframework.xd.module.ModuleType;
@@ -214,7 +214,7 @@ public class StreamConfigParserTests {
 	@Test
 	public void testInvalidModules() {
 		String config = "test | foo--x=13";
-		EnhancedStreamParser parser = new EnhancedStreamParser(testRepository, moduleRegistry());
+		XDStreamParser parser = new XDStreamParser(testRepository, moduleRegistry());
 		try {
 			parser.parse("t", config);
 			fail(config + " is invalid. Should throw exception");
@@ -559,6 +559,24 @@ public class StreamConfigParserTests {
 		StreamNode stream2 = ast.getStreamNodes().get(0);
 		assertEquals(
 				"[(ModuleNode:http)(ModuleNode:transform --a1=default)(ModuleNode:transform --b1=def)(ModuleNode:file)]",
+				stream2.stringify());
+	}
+
+	@Test
+	public void nameSpaceTest() {
+		StreamsNode ast = parse("trigger > :job:foo");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
+		assertEquals(
+				"[(ModuleNode:trigger)>(:job:foo)]",
+				stream2.stringify());
+	}
+
+	@Test
+	public void nameSpaceTestWithSpaces() {
+		StreamsNode ast = parse("trigger > :job:    too");
+		StreamNode stream2 = ast.getStreamNodes().get(0);
+		assertEquals(
+				"[(ModuleNode:trigger)>(:job:too)]",
 				stream2.stringify());
 	}
 


### PR DESCRIPTION
-[X] Basic Test to check Namespace support
-[X] now jobs are prefixed with job:

-[x] Test now check for spaces between prefix and suffix of the job namespace.

EnhancedStreamParser is now XDStreamParser.
