### PR TITLE
XD-816: Reactivate composite streams

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDeploymentRequest.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDeploymentRequest.java
@@ -47,6 +47,8 @@ public class ModuleDeploymentRequest {
 
 	private volatile boolean remove;
 
+	private volatile boolean deployable = true;
+
 	public String getModule() {
 		return module;
 	}
@@ -109,6 +111,14 @@ public class ModuleDeploymentRequest {
 
 	public void setSinkChannelName(String sinkChannelName) {
 		this.sinkChannelName = sinkChannelName;
+	}
+
+	public void tagAsUndeployable() {
+		this.deployable = false;
+	}
+
+	public boolean isDeployable() {
+		return this.deployable;
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -31,7 +31,7 @@ import org.springframework.xd.dirt.module.ModuleDeploymentRequest;
 /**
  * Abstract implementation of the @link {@link org.springframework.xd.dirt.core.ResourceDeployer} interface. It provides
  * the basic support for calling CrudRepository methods and sending deployment messages.
- *
+ * 
  * @author Luke Taylor
  * @author Mark Pollack
  * @author Eric Bottard
@@ -79,6 +79,11 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 	protected void throwNoSuchDefinitionException(String name) {
 		throw new NoSuchDefinitionException(name,
 				String.format("There is no %s definition named '%%s'", definitionKind));
+	}
+
+	protected void throwDefinitionNotDeployable(String name) {
+		throw new NoSuchDefinitionException(name,
+				String.format("The %s named '%%s' cannot be deployed", definitionKind));
 	}
 
 	protected void throwNoSuchDefinitionException(String name, String definitionKind) {
@@ -130,7 +135,7 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 
 	/**
 	 * Provides basic deployment behavior, whereby running state of deployed definitions is not persisted.
-	 *
+	 * 
 	 * @return the definition object for the given name
 	 * @throws NoSuchDefinitionException if there is no definition by the given name
 	 */
@@ -143,6 +148,13 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 		}
 
 		final List<ModuleDeploymentRequest> requests = parse(name, definition.getDefinition());
+
+		for (ModuleDeploymentRequest moduleDeploymentRequest : requests) {
+			if (!moduleDeploymentRequest.isDeployable()) {
+				throwDefinitionNotDeployable(name);
+			}
+		}
+
 		sendDeploymentRequests(name, requests);
 		return definition;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
@@ -137,7 +137,7 @@ public class XDStreamParser implements XDParser {
 		if (type == null) {
 			throw new NoSuchModuleException(name);
 		}
-		return verifyModuleOfTypeExists(name, type);
+		return verifyModuleOfTypeExists(request, name, type);
 	}
 
 	private ModuleType getNamedChannelModuleType(ModuleDeploymentRequest request, int lastIndex) {
@@ -146,7 +146,12 @@ public class XDStreamParser implements XDParser {
 		int index = request.getIndex();
 		if (request.getSourceChannelName() != null) {
 			if (index == lastIndex) {
-				type = ModuleType.SINK.getTypeName();
+				if (request.getSinkChannelName() != null) {
+					type = ModuleType.PROCESSOR.getTypeName();
+				}
+				else {
+					type = ModuleType.SINK.getTypeName();
+				}
 			}
 			else {
 				type = ModuleType.PROCESSOR.getTypeName();
@@ -160,13 +165,20 @@ public class XDStreamParser implements XDParser {
 				type = ModuleType.PROCESSOR.getTypeName();
 			}
 		}
-		return (type == null) ? null : verifyModuleOfTypeExists(moduleName, type);
+		return (type == null) ? null : verifyModuleOfTypeExists(request, moduleName, type);
 	}
 
-	private ModuleType verifyModuleOfTypeExists(String moduleName, String type) {
+	private ModuleType verifyModuleOfTypeExists(ModuleDeploymentRequest request, String moduleName, String type) {
 		ModuleDefinition def = moduleRegistry.lookup(moduleName, type);
 		if (def == null || def.getResource() == null) {
-			throw new NoSuchModuleException(moduleName);
+			List<ModuleDefinition> definitions = moduleRegistry.findDefinitions(moduleName);
+			if (definitions == null || definitions.size() == 0) {
+				throw new NoSuchModuleException(moduleName);
+			}
+			// The module is known but this doesn't seem to be a standard stream,
+			// assume it is a composite module stream that isn't deployable by itself
+			request.tagAsUndeployable();
+			return ModuleType.getModuleTypeByTypeName(definitions.get(0).getType());
 		}
 		return ModuleType.getModuleTypeByTypeName(def.getType());
 	}

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandTemplate.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandTemplate.java
@@ -99,7 +99,8 @@ public class StreamCommandTemplate extends AbstractCommandTemplate {
 	 * Destroy all streams that were created using the 'create' method. Commonly called in a @After annotated method
 	 */
 	public void destroyCreatedStreams() {
-		for (String streamname : streams) {
+		for (int s = streams.size() - 1; s >= 0; s--) {
+			String streamname = streams.get(s);
 			CommandResult cr = executeCommand("stream destroy --name " + streamname);
 			assertTrue("Failure to destory stream " + streamname + ".  CommandResult = " + cr.toString(),
 					cr.isSuccess());


### PR DESCRIPTION
Very simple changes.  A module deployment request can be tagged as undeployable. Rather than checking for correct stream structure up front it checks when deploy occurs. This enables composed modules to be defined and live in the system as long as no-one tries to deploy them. The PR is mostly tests - the tests show the new functionality that is possible.
