### PR TITLE
XD-810 Fix stream deletion disconnecting named channel from all streams

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/StreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/StreamPlugin.java
@@ -147,21 +147,17 @@ public class StreamPlugin implements Plugin {
 	}
 
 	private void removeInbound(Module module, ChannelRegistry registry) {
-		DeploymentMetadata md = module.getDeploymentMetadata();
-		if (isChannelPubSub(md.getInputChannelName())) {
-			MessageChannel inputChannel = module.getComponent("input", MessageChannel.class);
-			if (inputChannel != null) {
-				registry.deleteInbound(md.getInputChannelName(), inputChannel);
-			}
-		}
-		else {
-			registry.deleteInbound(module.getDeploymentMetadata().getInputChannelName());
-
+		MessageChannel inputChannel = module.getComponent("input", MessageChannel.class);
+		if (inputChannel != null) {
+			registry.deleteInbound(module.getDeploymentMetadata().getInputChannelName(), inputChannel);
 		}
 	}
 
 	private void removeOutbound(Module module, ChannelRegistry registry) {
-		registry.deleteOutbound(module.getDeploymentMetadata().getOutputChannelName());
+		MessageChannel outputChannel = module.getComponent("output", MessageChannel.class);
+		if (outputChannel != null) {
+			registry.deleteOutbound(module.getDeploymentMetadata().getOutputChannelName(), outputChannel);
+		}
 		registry.deleteOutbound(getTapChannelName(module));
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/channel/registry/AbstractChannelRegistryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/channel/registry/AbstractChannelRegistryTests.java
@@ -155,8 +155,8 @@ public abstract class AbstractChannelRegistryTests {
 		// when other tap stream is deleted
 		registry.deleteInbound("tap:baz.http", module2InputChannel);
 		// Clean up as StreamPlugin would
-		registry.deleteInbound("baz.0");
-		registry.deleteOutbound("baz.0");
+		registry.deleteInbound("baz.0", moduleInputChannel);
+		registry.deleteOutbound("baz.0", moduleOutputChannel);
 		registry.deleteOutbound("tap:baz.http");
 		assertTrue(getBridges(registry).isEmpty());
 	}
@@ -222,8 +222,8 @@ public abstract class AbstractChannelRegistryTests {
 		// when other tap stream is deleted
 		registry.deleteInbound("tap:baz.http", module2InputChannel);
 		// Clean up as StreamPlugin would
-		registry.deleteInbound("baz.0");
-		registry.deleteOutbound("baz.0");
+		registry.deleteInbound("baz.0", moduleInputChannel);
+		registry.deleteOutbound("baz.0", moduleOutputChannel);
 		registry.deleteOutbound("tap:baz.http");
 		assertTrue(getBridges(registry).isEmpty());
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
@@ -89,8 +89,8 @@ public class StreamPluginTests {
 		verify(registry).createOutboundPubSub(eq("tap:foo.testing"), any(DirectChannel.class));
 		plugin.beforeShutdown(module);
 		plugin.removeModule(module);
-		verify(registry).deleteInbound("foo.0");
-		verify(registry).deleteOutbound("foo.1");
+		verify(registry).deleteInbound("foo.0", input);
+		verify(registry).deleteOutbound("foo.1", output);
 		verify(registry).deleteOutbound("tap:foo.testing");
 	}
 

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandTemplate.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandTemplate.java
@@ -107,6 +107,18 @@ public class StreamCommandTemplate extends AbstractCommandTemplate {
 	}
 
 	/**
+	 * Destroy a specific stream
+	 *
+	 * @param stream The stream to destroy
+	 */
+	public void destroyStream(String stream) {
+		CommandResult cr = executeCommand("stream destroy --name " + stream);
+		assertTrue("Failure to destory stream " + stream + ".  CommandResult = " + cr.toString(),
+				cr.isSuccess());
+		streams.remove(stream);
+	}
+
+	/**
 	 * Undeploy the given stream name
 	 * 
 	 * @param streamname name of the stream.

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandTests.java
@@ -277,4 +277,30 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 		assertEquals("DRACARYS!", sink3.getContents());
 	}
 
+	@Test
+	public void testNamedChannels() throws Exception {
+		HttpSource source = newHttpSource();
+		HttpSource source2 = newHttpSource();
+		HttpSource source3 = newHttpSource();
+		FileSink sink = newFileSink().binary(true);
+		stream().create("stream1", "%s > :foo", source);
+		stream().create("stream2", "%s > :foo", source2);
+		stream().create("stream3", ":foo > %s", sink);
+
+		source.ensureReady().postData("Dracarys!");
+		source2.ensureReady().postData("testing");
+
+		assertTrue(sink.waitForContents("Dracarys!testing", 1000));
+
+		stream().destroyStream("stream2");
+
+		source.ensureReady().postData("stillup");
+		assertTrue(sink.waitForContents("Dracarys!testingstillup", 1000));
+
+		stream().create("stream4", "%s > :foo", source3);
+		source3.ensureReady().postData("newstream");
+		assertTrue(sink.waitForContents("Dracarys!testingstillupnewstream", 1000));
+
+		stream().destroyStream("stream3");
+	}
 }

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/FileSink.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/FileSink.java
@@ -64,6 +64,30 @@ public class FileSink extends DisposableFileSupport {
 		return FileCopyUtils.copyToString(fileReader);
 	}
 
+	/**
+	 * Wait at most {@code timeout} ms for the contents of the file to equal the specified contents.
+	 *
+	 * @param contents The expected file contents
+	 * @param timeout The amount of time to wait for the contents to appear in the file
+	 * @return true if contents were found before timeout
+	 * @throws IOException
+	 */
+	public boolean waitForContents(String contents, int timeout) throws IOException {
+		boolean passes = false;
+		for (long currentTime = System.currentTimeMillis(); System.currentTimeMillis() - currentTime < timeout;) {
+			if (contents.equals(getContents())) {
+				passes = true;
+				break;
+			}
+			try {
+				Thread.sleep(100);
+			}
+			catch (InterruptedException e) {
+			}
+		}
+		return passes;
+	}
+
 	@Override
 	protected String toDSL() {
 		String fileName = file.getName();


### PR DESCRIPTION
- On module removal, delete only the bridges bw
  the named channel and the module's input/output
  channels, instead of all named channel bridges
