### PR TITLE
XD-839: Add close() to parent contexts on shutdown

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/XDContainer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/XDContainer.java
@@ -30,6 +30,7 @@ import org.apache.log4j.RollingFileAppender;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -148,6 +149,7 @@ public class XDContainer implements SmartLifecycle, ApplicationContextAware {
 	public void stop() {
 		if (this.context != null) {
 			this.context.close();
+			((ConfigurableApplicationContext) context.getParent()).close();
 			if (logger.isInfoEnabled()) {
 				final String message = "Stopped container: " + this.jvmName;
 				final StringBuilder sb = new StringBuilder(LINE_SEPARATOR);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.integration.MessagingException;
@@ -225,6 +226,7 @@ public class AdminServer implements SmartLifecycle, InitializingBean {
 			logger.warn("Did not stop tomcat cleanly - " + e.getMessage());
 		}
 		this.webApplicationContext.destroy();
+		((ConfigurableApplicationContext) this.webApplicationContext.getParent()).close();
 	}
 
 


### PR DESCRIPTION
This overlaps with what Ilaya did on https://github.com/spring-projects/spring-xd/pull/279 but I guess it is the more elegant solution regarding the hsqldb bean (and there may be other beans that need to be disposed of as well)
