### PR TITLE
XD-875 Shutdown admin-server cleanly

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
@@ -218,8 +218,7 @@ public class AdminServer implements SmartLifecycle, InitializingBean {
 			if (this.handlerTask != null) {
 				this.handlerTask.cancel(true);
 			}
-			// This will likely trigger an exception, but the 'clean' shutdown code is hanging.
-			tomcat.destroy();
+			this.shutdownCleanly();
 			this.running = false;
 		}
 		catch (LifecycleException e) {

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
@@ -124,8 +124,10 @@ public abstract class AbstractShellIntegrationTest {
 	public static void shutdown() {
 		if (server != null) {
 			logger.info("Stopping Single Node Server");
+			// Stopping container will also stop the adminServer/and its parent context
+			// as the adminServer context is set as the parent context for the container
+			// in case of SingleNodeMain server
 			server.getContainer().stop();
-			server.getAdminServer().stop();
 		}
 		logger.info("Stopping XD Shell");
 		shell.stop();


### PR DESCRIPTION
- Re-used the shutdownCleanly() on AdminServer stop()
- Fixed AbstractShellIntegrationTests' adminServer stop
  - Removed explicit adminServer stop() call that hangs
    as the container.stop() would have already stopped
    the admin server while closing its parent context
