### PR TITLE
XD-811 Add job launch REST endpoint

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDeploymentRequest.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDeploymentRequest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Luke Taylor
+ * @author Ilayaperumal Gopinathan
  */
 public class ModuleDeploymentRequest {
 
@@ -46,6 +47,8 @@ public class ModuleDeploymentRequest {
 	private final Map<String, String> parameters = new HashMap<String, String>();
 
 	private volatile boolean remove;
+
+	private volatile boolean launch;
 
 	public String getModule() {
 		return module;
@@ -109,6 +112,14 @@ public class ModuleDeploymentRequest {
 
 	public void setSinkChannelName(String sinkChannelName) {
 		this.sinkChannelName = sinkChannelName;
+	}
+
+	public boolean isLaunch() {
+		return launch;
+	}
+
+	public void setLaunch(boolean launch) {
+		this.launch = launch;
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleNotDeployedException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleNotDeployedException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.module;
+
+import org.springframework.xd.dirt.core.XDRuntimeException;
+
+/**
+ * Thrown when a module is not deployed but the deployment request expects the module is deployed
+ * 
+ * @author Ilayaperumal Gopinathan
+ */
+@SuppressWarnings("serial")
+public class ModuleNotDeployedException extends XDRuntimeException {
+
+	public ModuleNotDeployedException(String operation) {
+		super(operation + " can not be completed as the module is not already deployed.");
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
@@ -73,6 +73,20 @@ public class JobsController extends
 	}
 
 	/**
+	 * Send the request to launch Job. If the Job is not already deployed, then deploy and launch
+	 * 
+	 * @param name the name of the job
+	 * @param jobParameters the job parameters in JSON string
+	 */
+	@RequestMapping(value = "/{name}/launch", method = RequestMethod.PUT)
+	@ResponseStatus(HttpStatus.OK)
+	@ResponseBody
+	public void launchJob(@PathVariable("name") String name, @RequestParam(required = false) String jobParameters) {
+		final JobDeployer jobDeployer = (JobDeployer) getDeployer();
+		jobDeployer.launch(name, jobParameters);
+	}
+
+	/**
 	 * List job definitions.
 	 */
 	@RequestMapping(value = "", method = RequestMethod.GET)

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
@@ -214,6 +214,7 @@ public class AdminServer implements SmartLifecycle, InitializingBean {
 
 	@Override
 	public void stop() {
+		logger.info("Stopping AdminServer running on port " + this.getLocalPort());
 		try {
 			if (this.handlerTask != null) {
 				this.handlerTask.cancel(true);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -31,7 +31,7 @@ import org.springframework.xd.dirt.module.ModuleDeploymentRequest;
 /**
  * Abstract implementation of the @link {@link org.springframework.xd.dirt.core.ResourceDeployer} interface. It provides
  * the basic support for calling CrudRepository methods and sending deployment messages.
- *
+ * 
  * @author Luke Taylor
  * @author Mark Pollack
  * @author Eric Bottard
@@ -86,14 +86,14 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 				String.format("There is no %s definition named '%%s'", definitionKind));
 	}
 
-	protected void throwAlreadyDeployedException(String name) {
-		throw new AlreadyDeployedException(name,
-				String.format("The %s named '%%s' is already deployed", definitionKind));
-	}
-
 	protected void throwNotDeployedException(String name) {
 		throw new NotDeployedException(name, String.format("The %s named '%%s' is not currently deployed",
 				definitionKind));
+	}
+
+	protected void throwAlreadyDeployedException(String name) {
+		throw new AlreadyDeployedException(name,
+				String.format("The %s named '%%s' is already deployed", definitionKind));
 	}
 
 	@Override
@@ -130,7 +130,7 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 
 	/**
 	 * Provides basic deployment behavior, whereby running state of deployed definitions is not persisted.
-	 *
+	 * 
 	 * @return the definition object for the given name
 	 * @throws NoSuchDefinitionException if there is no definition by the given name
 	 */

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/deployers.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/deployers.xml
@@ -27,7 +27,7 @@
 	</bean>
 
 	<bean id="jobDeployer" class="org.springframework.xd.dirt.stream.JobDeployer">
-		<constructor-arg name="repository" ref="jobRepository" />
+		<constructor-arg name="repository" ref="jobDefinitionRepository" />
 		<constructor-arg name="messageSender" ref="deploymentMessageSender" />
 		<constructor-arg name="parser" ref="parser" />
 	</bean>

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/store/memory-admin.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/store/memory-admin.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<bean id="jobRepository" class="org.springframework.xd.dirt.stream.memory.InMemoryJobDefinitionRepository"/>
+	<bean id="jobDefinitionRepository" class="org.springframework.xd.dirt.stream.memory.InMemoryJobDefinitionRepository"/>
 	<bean id="streamDefinitionRepository" class="org.springframework.xd.dirt.stream.memory.InMemoryStreamDefinitionRepository"/>
 	<bean id="streamRepository" class="org.springframework.xd.dirt.stream.memory.InMemoryStreamRepository" />
 

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/store/redis-admin.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/store/redis-admin.xml
@@ -5,7 +5,7 @@
 
 	<import resource="../transports/redis-common.xml" />
 
-	<bean id="jobRepository"
+	<bean id="jobDefinitionRepository"
 		class="org.springframework.xd.dirt.stream.redis.RedisJobDefinitionRepository">
 		<constructor-arg ref="humanFriendlyRedisTemplate" />
 	</bean>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
@@ -72,18 +72,17 @@ public class JobsControllerIntegrationTests extends AbstractControllerIntegratio
 	@Before
 	public void before() {
 		Resource resource = mock(Resource.class);
-		ModuleDefinition jobDefinition = new ModuleDefinition(ModuleType.JOB.getTypeName(),
+		ModuleDefinition moduleJobDefinition = new ModuleDefinition(ModuleType.JOB.getTypeName(),
 				ModuleType.JOB.getTypeName(), resource);
-
 		when(resource.exists()).thenReturn(true);
-		ArrayList<ModuleDefinition> definitions = new ArrayList<ModuleDefinition>();
-		definitions.add(jobDefinition);
-		when(moduleRegistry.findDefinitions(ModuleType.JOB.getTypeName())).thenReturn(definitions);
-		when(moduleRegistry.findDefinitions("job1")).thenReturn(definitions);
-		when(moduleRegistry.findDefinitions("job2")).thenReturn(definitions);
-		when(moduleRegistry.lookup("job1", ModuleType.JOB.getTypeName())).thenReturn(jobDefinition);
-		when(moduleRegistry.lookup("job2", ModuleType.JOB.getTypeName())).thenReturn(jobDefinition);
-		when(moduleRegistry.lookup("job", ModuleType.JOB.getTypeName())).thenReturn(jobDefinition);
+		ArrayList<ModuleDefinition> moduleDefinitions = new ArrayList<ModuleDefinition>();
+		moduleDefinitions.add(moduleJobDefinition);
+		when(moduleRegistry.findDefinitions(ModuleType.JOB.getTypeName())).thenReturn(moduleDefinitions);
+		when(moduleRegistry.findDefinitions("job1")).thenReturn(moduleDefinitions);
+		when(moduleRegistry.findDefinitions("job2")).thenReturn(moduleDefinitions);
+		when(moduleRegistry.lookup("job1", ModuleType.JOB.getTypeName())).thenReturn(moduleJobDefinition);
+		when(moduleRegistry.lookup("job2", ModuleType.JOB.getTypeName())).thenReturn(moduleJobDefinition);
+		when(moduleRegistry.lookup("job", ModuleType.JOB.getTypeName())).thenReturn(moduleJobDefinition);
 	}
 
 	@Test
@@ -99,6 +98,16 @@ public class JobsControllerIntegrationTests extends AbstractControllerIntegratio
 				post("/jobs").param("name", "job5").param("definition", JOB_DEFINITION).accept(
 						MediaType.APPLICATION_JSON)).andExpect(status().isCreated());
 		verify(sender, times(1)).sendDeploymentRequests(eq("job5"), anyListOf(ModuleDeploymentRequest.class));
+	}
+
+	@Test
+	public void testSuccessfulJobLaunch() throws Exception {
+		mockMvc.perform(
+				post("/jobs").param("name", "joblaunch").param("definition", JOB_DEFINITION).accept(
+						MediaType.APPLICATION_JSON)).andExpect(status().isCreated());
+		mockMvc.perform(put("/jobs/{name}/launch", "joblaunch").accept(MediaType.APPLICATION_JSON)).andExpect(
+				status().isOk());
+		verify(sender, times(2)).sendDeploymentRequests(eq("joblaunch"), anyListOf(ModuleDeploymentRequest.class));
 	}
 
 	@Test

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/SingleNodeMainIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/SingleNodeMainIntegrationTests.java
@@ -155,7 +155,7 @@ public class SingleNodeMainIntegrationTests extends AbstractAdminMainIntegration
 
 	private void stopServer(SingleNodeServer server) {
 		server.getContainer().stop();
-		super.shutdown(server.getAdminServer());
+		server.getAdminServer().stop();
 	}
 
 	private void setBatchDBProperties() {

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/JobOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/JobOperations.java
@@ -38,6 +38,14 @@ public interface JobOperations extends ResourceOperations {
 	public void deployJob(String name, String dateFormat, String numberFormat, Boolean makeUnique);
 
 	/**
+	 * Launch a job that is already deployed
+	 * 
+	 * @param name the name of the job to launch
+	 * @param jobParameters the JSON string as jobParameters
+	 */
+	public void launchJob(String name, String jobParameters);
+
+	/**
 	 * List jobs known to the system.
 	 */
 	public PagedResources<JobDefinitionResource> list();

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/JobTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/JobTemplate.java
@@ -79,6 +79,14 @@ public class JobTemplate extends AbstractTemplate implements JobOperations {
 	}
 
 	@Override
+	public void launchJob(String name, String jobParameters) {
+		String uriTemplate = resources.get("jobs").toString() + "/{name}/launch";
+		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
+		values.add("jobParameters", jobParameters);
+		restTemplate.put(uriTemplate, values, Collections.singletonMap("name", name));
+	}
+
+	@Override
 	public void undeploy(String name) {
 		String uriTemplate = resources.get("jobs").toString() + "/{name}";
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
@@ -49,6 +49,8 @@ public class JobCommands implements CommandMarker {
 
 	private final static String DEPLOY_JOB = "job deploy";
 
+	private final static String LAUNCH_JOB = "job launch";
+
 	private final static String UNDEPLOY_JOB = "job undeploy";
 
 	private final static String DESTROY_JOB = "job destroy";
@@ -107,6 +109,14 @@ public class JobCommands implements CommandMarker {
 				throw new IllegalArgumentException("You must specify exactly one of 'name', 'all'");
 		}
 		return message;
+	}
+
+	@CliCommand(value = LAUNCH_JOB, help = "Launch previously deployed job")
+	public String launchJob(
+			@CliOption(key = { "", "name" }, help = "the name of the job to deploy", optionContext = "existing-job disable-string-converter") String name,
+			@CliOption(key = { "params" }, help = "the parameters for the job", unspecifiedDefaultValue = "") String jobParameters) {
+		jobOperations().launchJob(name, jobParameters);
+		return String.format("Successfully launched the job '%s'", name);
 	}
 
 	@CliCommand(value = UNDEPLOY_JOB, help = "Un-deploy existing job(s)")

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
@@ -99,6 +99,7 @@ public abstract class AbstractShellIntegrationTest {
 		System.setProperty("hsql.server.database", DEFAULT_HSQL_DATABASE);
 		server = SingleNodeMain.launchSingleNodeServer(options);
 		int port = server.getAdminServer().getLocalPort();
+		logger.info("Admin Server running on " + port);
 		waitForServerToBeReady(port);
 
 
@@ -135,8 +136,8 @@ public abstract class AbstractShellIntegrationTest {
 		shell.stop();
 		if (server != null) {
 			logger.info("Stopping Single Node Server");
-			// Stopping container will also stop the adminServer/and its parent context
-			// as the adminServer context is set as the parent context for the container
+			// Stopping container will also destroy the adminServer's parent context
+			// as the adminServer's parent context is set as the parent context for the container
 			// in case of SingleNodeMain server
 			server.getContainer().stop();
 		}

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobIntegrationTest.java
@@ -135,6 +135,24 @@ public abstract class AbstractJobIntegrationTest extends AbstractShellIntegratio
 		jobs.add(jobName);
 	}
 
+	/**
+	 * Launch a job that is already deployed
+	 */
+	protected void executeJobLaunch(String jobName, String jobParameters) {
+		CommandResult cr = executeCommand("job launch --name " + jobName + " --params " + jobParameters);
+		String prefix = "Successfully launched the job '";
+		assertEquals(prefix + jobName + "'", cr.getResult());
+	}
+
+	/**
+	 * Launch a job that is already deployed
+	 */
+	protected void executeJobLaunch(String jobName) {
+		CommandResult cr = executeCommand("job launch --name " + jobName);
+		String prefix = "Successfully launched the job '";
+		assertEquals(prefix + jobName + "'", cr.getResult());
+	}
+
 	protected void checkForJobInList(String jobName, String jobDescriptor) {
 		Table t = listJobs();
 		assertTrue(t.getRows().contains(new TableRow().addValue(1, jobName).addValue(2, jobDescriptor)));

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/JobCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/JobCommandTests.java
@@ -213,6 +213,30 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 		assertTrue("parameter2 should be identifying", parameter2.isIdentifying());
 	}
 
+	@Test
+	public void testLaunchJob() {
+		logger.info("Launch batch job");
+		executeJobCreate(MY_JOB, JOB_DESCRIPTOR);
+		checkForJobInList(MY_JOB, JOB_DESCRIPTOR);
+		executeJobLaunch(MY_JOB);
+	}
+
+	@Test
+	public void testLaunchNotDeployedJob() {
+		logger.info("Launch batch job that is not deployed");
+		executeJobCreate(MY_JOB, JOB_DESCRIPTOR, false);
+		executeJobLaunch(MY_JOB);
+	}
+
+	@Test
+	public void testLaunchJobWithParameters() {
+		logger.info("Launch batch job with typed parameters");
+		String myJobParams = "{\"-param1(long)\":\"12345\",\"param2(date)\":\"1990/10/03\"}";
+		executeJobCreate(MY_JOB, JOB_DESCRIPTOR);
+		checkForJobInList(MY_JOB, JOB_DESCRIPTOR);
+		executeJobLaunch(MY_JOB, myJobParams);
+	}
+
 	public static class JobParametersHolder {
 
 		private static Map<String, JobParameter> jobParameters = new ConcurrentHashMap<String, JobParameter>();

--- a/spring-xd-ui/app/views/batch.js
+++ b/spring-xd-ui/app/views/batch.js
@@ -198,8 +198,8 @@ function(_, Backbone, utils, conf, model, BatchDetail) {
             var job = extractJob(event);
             if (job) {
                 var jobParameters = prompt("Enter job parameters as JSON:", JSON.stringify({arg1:1, arg2:'bar'}));
-                jobParameters = encodeURIComponent(jobParameters);
-                job.launch().then(function() {
+                //jobParameters = encodeURIComponent(jobParameters);
+                job.launch(jobParameters).then(function() {
                     var detailsView = expanded[job.id];
                     if (detailsView) {
                         job.fetch().then(function() {

--- a/spring-xd-ui/app/xd.model.js
+++ b/spring-xd-ui/app/xd.model.js
@@ -157,28 +157,18 @@ function(Backbone, rest, entity, mime, hateoas, errorcode) {
         },
         idAttribute: 'name',
         launch: function(parameters) {
-            var streamName = 'jobLaunchTrigger' + new Date();
-            var streamDefinition = 'trigger ' + (parameters ? '--payload=\'' + parameters + '\'' : '') + ' > :job:' + this.id;
-            // for now must create a stream that triggers job and then delete stream
-           var createPromise = client({
-                path: URL_ROOT + 'streams',
-                params: { name : streamName, definition: streamDefinition },
-                method: 'POST',
+            var params = "";
+            if (parameters) {
+                params = parameters;
+			}
+            var createPromise = client({
+                path: URL_ROOT +  'jobs/' + this.id + '/launch',
+                params: { "jobParameters" : params } ,
+                method: 'PUT',
                 headers: ACCEPT_HEADER
             });
             
-            var deletePromise = createPromise.then(function() {
-                return client({
-                    path: URL_ROOT + 'streams/' + streamName,
-                    method: 'DELETE',
-                    headers: ACCEPT_HEADER
-                });
-
-            });
-            return deletePromise.then(function() {
-                // get the latest execution count for the job
-                return model.batchJobs.fetch({merge:true, update:true });
-            });
+            return model.batchJobs.fetch({merge:true, update:true });
         },
 
         parse: function(data) {


### PR DESCRIPTION
- Added /jobs/{jobName}/launch REST endpoint at
  JobsController
  - With job Parameters as request param
- Added launch property to ModuleDeploymentRequest
  - Send the jobLaunch request as ModuleDeploymentRequest
    by setting module launch property
  - Set ModuleDeploymentRequest's parameter with
    jobParameters
- Added handleLaunch() at ModuleDeployer
  - Currently, the handleLaunch is applicable only for JobPlugin
- Updated JobPlugin to send the job launch message
  - Send message with jobParameters to the job module's input channel
- Use beanName 'jobDefinitionRepository' instead of 'jobRepository'
  wherever we use job definition repository
  Added Shell commands to launch job
- Added launchJob JobOperation with jobName & jobParameters
- Updated UI to launch the job with/without jobParameters
- Added tests for JobsController & Job launch shell command
