### PR TITLE
XD-889 Change default admin port

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/AdminOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/AdminOptions.java
@@ -38,8 +38,8 @@ public class AdminOptions extends AbstractOptions {
 		super(defaultTransport, defaultAnalytics);
 	}
 
-	@Option(name = "--" + HTTP_PORT, usage = "Http port for the REST API server (default: 8088)", metaVar = "<httpPort>")
-	protected int httpPort = 8088;
+	@Option(name = "--" + HTTP_PORT, usage = "Http port for the REST API server (default: 9393)", metaVar = "<httpPort>")
+	protected int httpPort = 9393;
 
 	@Option(name = "--" + STORE, usage = "How to persist admin data (default: redis)")
 	protected Store store = Store.redis;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/SingleNodeMainIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/SingleNodeMainIntegrationTests.java
@@ -114,7 +114,7 @@ public class SingleNodeMainIntegrationTests extends AbstractAdminMainIntegration
 	public void testConfigurationOverridesSystemProperties() {
 
 		System.setProperty(XDPropertyKeys.XD_ANALYTICS, "redis");
-		System.setProperty(XDPropertyKeys.XD_HTTP_PORT, "8088");
+		System.setProperty(XDPropertyKeys.XD_HTTP_PORT, "9393");
 		System.setProperty(XDPropertyKeys.XD_STORE, "redis");
 		setBatchDBProperties();
 		SingleNodeServer server = SingleNodeMain.launchSingleNodeServer(

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/options/AdminOptionsTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/options/AdminOptionsTests.java
@@ -61,7 +61,7 @@ public class AdminOptionsTests {
 		assertEquals(Analytics.redis, opts.getAnalytics());
 		assertEquals(Store.redis, opts.getStore());
 		assertEquals(HadoopDistro.hadoop10, opts.getHadoopDistro());
-		assertEquals(8088, (int) opts.getHttpPort());
+		assertEquals(9393, (int) opts.getHttpPort());
 		assertEquals(8778, (int) opts.getJmxPort());
 		assertEquals(false, (boolean) opts.isJmxEnabled());
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/options/SingleNodeOptionsTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/options/SingleNodeOptionsTests.java
@@ -102,7 +102,7 @@ public class SingleNodeOptionsTests {
 		assertEquals(Analytics.memory, opts.getAnalytics());
 		assertEquals(Store.memory, opts.getStore());
 		assertEquals(HadoopDistro.hadoop10, opts.getHadoopDistro());
-		assertEquals(8088, (int) opts.getHttpPort());
+		assertEquals(9393, (int) opts.getHttpPort());
 		assertEquals(8778, (int) opts.getJmxPort());
 		assertEquals(false, opts.isJmxEnabled());
 

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/Target.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/Target.java
@@ -38,7 +38,7 @@ public class Target {
 
 	public static final String DEFAULT_HOST = "localhost";
 
-	public static final int DEFAULT_PORT = 8088;
+	public static final int DEFAULT_PORT = 9393;
 
 	public static final String DEFAULT_TARGET = DEFAULT_SCHEME + "://" + DEFAULT_HOST + ":" + DEFAULT_PORT + "/";
 

--- a/spring-xd-ui/app/xd.conf.js
+++ b/spring-xd-ui/app/xd.conf.js
@@ -26,7 +26,7 @@
 define(function() {
     'use strict';
 
-    var URL_ROOT = 'http://localhost:8088/';
+    var URL_ROOT = 'http://localhost:9393/';
     var conf = {
         urlRoot: URL_ROOT,
         moduleRoot: URL_ROOT + 'modules/',

--- a/spring-xd-ui/app/xd.model.js
+++ b/spring-xd-ui/app/xd.model.js
@@ -28,7 +28,7 @@ function(Backbone, rest, entity, mime, hateoas, errorcode) {
     // set up the rest client
     // this is a copy from router
     var ACCEPT_HEADER = { 'Accept': 'application/json' };
-    var URL_ROOT = 'http://localhost:8088/';
+    var URL_ROOT = 'http://localhost:9393/';
     var client = rest.chain(errorcode, { code: 400 }).chain(mime).chain(hateoas).chain(entity);
 
 

--- a/spring-xd-ui/app/xd.router.js
+++ b/spring-xd-ui/app/xd.router.js
@@ -31,7 +31,7 @@ function(_, $, when, rest, entity, mime, hateoas, errorcode, Backbone, conf, uti
 
     // set up the rest client
     var ACCEPT_HEADER = { 'Accept': 'application/json' };
-    var URL_ROOT = 'http://localhost:8088/';
+    var URL_ROOT = 'http://localhost:9393/';
     var client = rest.chain(errorcode, { code: 400 }).chain(mime).chain(hateoas).chain(entity);
 
     var ajax = {};

--- a/spring-xd-ui/test/spec/xd.model.spec.js
+++ b/spring-xd-ui/test/spec/xd.model.spec.js
@@ -57,7 +57,7 @@ define(['xd.model'], function(model) {
 		it('jobs should have a correct url', function() {
 			var query = model.get('jobs');
 			var url = query.getUrl();
-			expect(url).toBe('http://localhost:8088/jobs');
+			expect(url).toBe('http://localhost:9393/jobs');
 		});
 		it('jobs should have correct pagination', function() {
 			var query = model.get('jobs');


### PR DESCRIPTION
- Changed default admin port from "8080" to "8088"
- Updated the UI with the default port "8088"
- Fixed the tests that use the default port "8080"
