### PR TITLE
XD-900 Phase I

### DIFF
--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/stream/spel-context.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/stream/spel-context.xml
@@ -5,10 +5,14 @@
 
 	<bean id="integrationEvaluationContext" class="org.springframework.integration.config.IntegrationEvaluationContextFactoryBean">
 		<property name="propertyAccessors">
-			<list>
-				<bean class="org.springframework.xd.tuple.spel.TuplePropertyAccessor" />
-				<bean class="org.springframework.integration.json.JsonPropertyAccessor" />
-			</list>
+			<map>
+				<entry key="tuplePA">
+					<bean class="org.springframework.xd.tuple.spel.TuplePropertyAccessor" />
+				</entry>
+				<entry key="jsonPA">
+					<bean class="org.springframework.integration.json.JsonPropertyAccessor" />
+				</entry>
+			</map>
 		</property>
 	</bean>
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/SpelContextTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/SpelContextTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.stream;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+
+/**
+ * 
+ * @author Gary Russell
+ */
+public class SpelContextTests {
+
+	@Test
+	public void testEvaluationContextFB() {
+		AbstractApplicationContext ctx = new ClassPathXmlApplicationContext(
+				"/META-INF/spring-xd/plugins/stream/spel-context.xml");
+		StandardEvaluationContext evalCtx = ctx.getBean(StandardEvaluationContext.class);
+		assertEquals(4, evalCtx.getPropertyAccessors().size());
+		ctx.close();
+	}
+}


### PR DESCRIPTION
**DO NOT MERGE UNTIL https://github.com/spring-projects/spring-integration/pull/899 IS MERGED/DEPLOYED**

This is phase I (of II); the SI PR will break the XD build once merged/built/deployed.

This PR must be merged soon after the SI PR (which will be sometime tomorrow).

PropertyAccessors are now inheritable.

PropertyAccessors provided to the IntegrationEvaluationContextFactoryBean
are now named, to enable normal bean inheritance/override semantics.

This commit changes spel-context.xml to configure a Map instead of a List
of accessors.

Phase II will elevate the factory bean to the parent (module common)
context.
