### PR TITLE
Fix Test Reports for Skipped Tests

### DIFF
--- a/spring-xd-test/src/main/java/org/springframework/xd/test/AbstractExternalResourceTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/AbstractExternalResourceTestSupport.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.fail;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -96,6 +97,7 @@ public abstract class AbstractExternalResourceTestSupport<R> implements TestRule
 
 				@Override
 				public void evaluate() throws Throwable {
+					Assume.assumeTrue(false);
 				}
 			};
 		}


### PR DESCRIPTION
When a test was skipped because, say, Redis was not available
the tests showed as passed in the test report. They should
show as ignored.

Add a call to Assume.

Report now shows:

Test        Duration    Result
testDelete      -   ignored
testFindAll     -   ignored
testInitialState    -   ignored
testSave        -   ignored

Vs:

Test        Duration    Result
testDelete      0s  passed
testFindAll     0s  passed
testInitialState    0s  passed
testSave        0s  passed
