### PR TITLE
XD-915e: Apply to jms source module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,10 +311,6 @@ project('spring-xd-dirt') {
 		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 		compile "log4j:log4j:$log4jVersion"
 		compile "org.springframework.integration:spring-integration-amqp:$springIntegrationVersion"
-		compile ("org.apache.activemq:activemq-core:5.6.0") {
-			exclude group: 'org.mortbay.jetty'
-			exclude group: 'org.fusesource.fuse-extra'
-		}
 		compile "org.springframework.integration:spring-integration-event:$springIntegrationVersion"
 		compile "org.springframework.integration:spring-integration-groovy:$springIntegrationVersion"
 		compile "org.springframework.integration:spring-integration-jmx:$springIntegrationVersion"
@@ -358,7 +354,6 @@ project('spring-xd-dirt') {
 		compile ("org.springframework.integration:spring-integration-mqtt:1.0.0.BUILD-SNAPSHOT") {
 			exclude group: 'org.springframework.integration'
 		}
-		compile "org.springframework.integration:spring-integration-jms:$springIntegrationVersion"
 
 		// Splunk also needed for o.s.i.x
 		compile "org.springframework.integration:spring-integration-splunk:$springIntegrationSplunkVersion"
@@ -378,6 +373,15 @@ project('spring-xd-dirt') {
 		testCompile ("org.mockito:mockito-core:$mockitoVersion") {
 			exclude group:'org.hamcrest'
 		}
+
+		// The following two because of AmqBrokerAndTest
+		testCompile ("org.apache.activemq:activemq-core:5.6.0") {
+			exclude group: 'org.mortbay.jetty'
+			exclude group: 'org.fusesource.fuse-extra'
+		}
+		testCompile "org.springframework:spring-jms:$springVersion"
+
+
 	}
 
     apply plugin:'application'
@@ -773,6 +777,18 @@ project('modules.source.syslog-tcp') {
 project('modules.source.syslog-udp') {
 	dependencies {
 		runtime "org.springframework.integration:spring-integration-syslog:$springIntegrationVersion"
+	}
+}
+
+project('modules.source.jms') {
+	dependencies {
+		runtime "org.springframework.integration:spring-integration-jms:$springIntegrationVersion"
+		runtime ("org.apache.activemq:activemq-core:5.6.0") {
+			exclude group: 'org.mortbay.jetty'
+			exclude group: 'org.fusesource.fuse-extra'
+			exclude group: 'org.slf4j'
+		}
+
 	}
 }
 

--- a/modules/source/jms/config/jms.xml
+++ b/modules/source/jms/config/jms.xml
@@ -9,7 +9,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
-	<import resource="../common/jms-${provider:activemq}-infrastructure-context.xml"/>
+	<import resource="../../../common/jms-${provider:activemq}-infrastructure-context.xml"/>
 
 	<int-jms:message-driven-channel-adapter id="jmsSource"
 		auto-startup="false"


### PR DESCRIPTION
Caveat: won't work if container runs in eclipse, as the eclipse classpath also has test dependencies that conflict, for some reason.

Runs fine in the final product though (gradle dist + run from distro directory)

I'm pretty sure we could cut some more dependencies, but...

```
ebottard@ebottard-mbp  ~/Documents/projects/spring-xd   XD-915e   ll build/dist/spring-xd/xd/modules/source/jms/lib
total 10904
-rw-r--r--  1 ebottard  staff  3960030  4 oct 21:02 activemq-core-5.6.0.jar
-rw-r--r--  1 ebottard  staff   147874  4 oct 21:02 activemq-protobuf-1.1.jar
-rw-r--r--  1 ebottard  staff   212453  4 oct 21:02 commons-net-2.2.jar
-rw-r--r--  1 ebottard  staff    20220  4 oct 21:02 geronimo-j2ee-management_1.1_spec-1.0.1.jar
-rw-r--r--  1 ebottard  staff    32359  4 oct 21:02 geronimo-jms_1.1_spec-1.1.1.jar
-rw-r--r--  1 ebottard  staff    50139  4 oct 21:02 hawtbuf-1.9.jar
-rw-r--r--  1 ebottard  staff   106114  4 oct 21:02 hawtdispatch-1.9.jar
-rw-r--r--  1 ebottard  staff    77973  4 oct 21:02 hawtdispatch-transport-1.9.jar
-rw-r--r--  1 ebottard  staff   178961  4 oct 21:02 jasypt-1.8.jar
-rw-r--r--  1 ebottard  staff   185149  4 oct 21:02 kahadb-5.6.0.jar
-rw-r--r--  1 ebottard  staff   111444  4 oct 21:02 mqtt-client-1.0.jar
-rw-r--r--  1 ebottard  staff   163464  4 oct 21:02 org.osgi.core-4.1.0.jar
-rw-r--r--  1 ebottard  staff   105440  4 oct 21:02 spring-integration-jms-3.0.0.BUILD-SNAPSHOT.jar
-rw-r--r--  1 ebottard  staff   205271  4 oct 21:02 spring-jms-3.2.2.RELEASE.jar
```
