### PR TITLE
XD-908: Query aggregate count by number of points

### DIFF
--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCountResolution.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCountResolution.java
@@ -1,6 +1,11 @@
 package org.springframework.xd.analytics.metrics.core;
 
-import org.joda.time.*;
+import org.joda.time.DateTime;
+import org.joda.time.Days;
+import org.joda.time.Hours;
+import org.joda.time.Minutes;
+import org.joda.time.Months;
+import org.joda.time.ReadablePeriod;
 
 /**
  * The resolution options available for querying an aggregate counter.
@@ -17,5 +22,20 @@ public enum AggregateCountResolution {
 
 	private AggregateCountResolution(ReadablePeriod unitPeriod) {
 		this.unitPeriod = unitPeriod;
+	}
+
+	/**
+	 * Subtracts this resolution a given number of times from a supplied date.
+	 *
+	 * @param dt the date to subtract from
+	 * @param n the number of periods of this resolution to subtract
+	 * @return the resulting date in the past.
+	 */
+	public DateTime minus(DateTime dt, int n) {
+		DateTime start = dt;
+		for (int i = 0; i < n; i++) {
+			start = start.minus(unitPeriod);
+		}
+		return start;
 	}
 }

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCounterRepository.java
@@ -2,7 +2,6 @@
 package org.springframework.xd.analytics.metrics.core;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeField;
 import org.joda.time.Interval;
 
 /**
@@ -17,15 +16,40 @@ public interface AggregateCounterRepository extends CounterRepository {
 	 */
 	long increment(String name, long amount, DateTime dateTime);
 
+
+	/**
+	 * Query function which returns the last 'n' points for a particular resolution.
+	 *
+	 * @param name the counter to query
+	 * @param nCounts the number of data points to return
+	 * @param resolution the resolution at which the data should be returned (minute, hour, day, month)
+	 * @return an object containing an indexed array of the aggregate counts for the given query.
+	 */
+	AggregateCount getCounts(String name, int nCounts, AggregateCountResolution resolution);
+
 	/**
 	 * Query function to allow the counts for a specific interval to be retrieved.
 	 * 
 	 *
 	 * @param name the counter to query
-	 * @param interval the time interval to return data for. Includes start, excludes end.
-	 * @param resolution the resolution at which the data should be returned (minutes or hours)
+	 * @param interval the time interval to return data for. Includes start and end.
+	 * @param resolution the resolution at which the data should be returned (minute, hour, day, month)
 	 * @return an object containing an indexed array of the aggregate counts for the given query.
 	 */
 	AggregateCount getCounts(String name, Interval interval, AggregateCountResolution resolution);
+
+
+	/**
+	 * Queries by requesting a number of points, ending on the given date (inclusive).
+	 * The date may be null to use the current time, thus returning the last nCounts point
+	 * at the given resolution.
+	 *
+	 * @param name the counter to query
+	 * @param end the end of the query interval (inclusive). Cannot be null.
+	 * @param nCounts the number of data points to return
+	 * @param resolution the resolution at which the data should be returned (minute, hour, day, month)
+	 * @return an object containing an indexed array of the counts .
+	 */
+	AggregateCount getCounts(String name, int nCounts, DateTime end, AggregateCountResolution resolution);
 
 }

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounter.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounter.java
@@ -17,6 +17,7 @@
 package org.springframework.xd.analytics.metrics.memory;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,7 @@ import org.joda.time.Duration;
 import org.joda.time.Interval;
 
 import org.joda.time.Months;
+import org.springframework.util.Assert;
 import org.springframework.xd.analytics.metrics.core.AggregateCount;
 import org.springframework.xd.analytics.metrics.core.AggregateCountResolution;
 import org.springframework.xd.analytics.metrics.core.Counter;
@@ -60,6 +62,12 @@ class InMemoryAggregateCounter extends Counter {
 
 	public InMemoryAggregateCounter(String name) {
 		super(name);
+	}
+
+	public AggregateCount getCounts(int nCounts, DateTime endDate, AggregateCountResolution resolution) {
+		Assert.notNull(endDate, "endDate must not be null");
+
+		return getCounts(new Interval(resolution.minus(endDate, nCounts-1), endDate), resolution);
 	}
 
 	public AggregateCount getCounts(Interval interval, AggregateCountResolution resolution) {

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounterRepository.java
@@ -17,6 +17,7 @@
 package org.springframework.xd.analytics.metrics.memory;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -61,8 +62,18 @@ public class InMemoryAggregateCounterRepository extends AbstractInMemoryReposito
 	}
 
 	@Override
+	public AggregateCount getCounts(String name, int nCounts, AggregateCountResolution resolution) {
+		return getOrCreate(name).getCounts(nCounts, new DateTime(), resolution);
+	}
+
+	@Override
 	public AggregateCount getCounts(String name, Interval interval, AggregateCountResolution resolution) {
 		return getOrCreate(name).getCounts(interval, resolution);
+	}
+
+	@Override
+	public AggregateCount getCounts(String name, int nCounts, DateTime end, AggregateCountResolution resolution) {
+		return getOrCreate(name).getCounts(nCounts, end, resolution);
 	}
 
 	private synchronized InMemoryAggregateCounter getOrCreate(String name) {

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterRepository.java
@@ -17,6 +17,7 @@
 package org.springframework.xd.analytics.metrics.redis;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,6 +31,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.util.Assert;
 import org.springframework.xd.analytics.metrics.core.AggregateCount;
 import org.springframework.xd.analytics.metrics.core.AggregateCountResolution;
 import org.springframework.xd.analytics.metrics.core.AggregateCounterRepository;
@@ -104,6 +106,17 @@ public class RedisAggregateCounterRepository extends RedisCounterRepository impl
 		if (newValue == amount) {
 			setOperations.add(bookkeepingKey, key);
 		}
+	}
+
+	@Override
+	public AggregateCount getCounts(String name, int nCounts, AggregateCountResolution resolution) {
+		return getCounts(name, nCounts, new DateTime(), resolution);
+	}
+
+	public AggregateCount getCounts(String name, int nCounts, DateTime endDate, AggregateCountResolution resolution) {
+		Assert.notNull(endDate, "endDate cannot be null");
+
+		return getCounts(name, new Interval(resolution.minus(endDate, nCounts-1), endDate), resolution);
 	}
 
 	/**

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractAggregateCounterTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractAggregateCounterTests.java
@@ -80,6 +80,11 @@ public abstract class AbstractAggregateCounterTests {
 
 		counts = aggregateCounterRepository.getCounts(counterName, new Interval(end.minusDays(30), end), AggregateCountResolution.day).getCounts();
 		assertEquals(31, counts.length);
+
+		counts = aggregateCounterRepository.getCounts(counterName, 60, end, AggregateCountResolution.day).getCounts();
+		assertEquals(60, counts.length);
+		assertEquals(8, counts[0]);
+		assertEquals(67, counts[59]);
 	}
 
 	@Test
@@ -101,6 +106,10 @@ public abstract class AbstractAggregateCounterTests {
 		// Check a query for twelve months past
 		counts = aggregateCounterRepository.getCounts(counterName, new Interval(end.minusMonths(11), end), AggregateCountResolution.month).getCounts();
 		assertEquals(12, counts.length);
+
+		counts = aggregateCounterRepository.getCounts(counterName, 3, end, AggregateCountResolution.month).getCounts();
+		assertEquals(3, counts.length);
+		assertEquals(6, counts[2]);
 	}
 
 	@Test

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersController.java
@@ -17,13 +17,8 @@
 package org.springframework.xd.dirt.rest.metrics;
 
 import org.joda.time.DateTime;
-import org.joda.time.Days;
-import org.joda.time.Hours;
 import org.joda.time.Interval;
 
-import org.joda.time.Minutes;
-import org.joda.time.Months;
-import org.joda.time.ReadablePeriod;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;


### PR DESCRIPTION
Adds an extra query method to the AggregateCounterRepository which takes
a date and the number of points prior to it which are required. If no
date is supplied, it will return the previous n points from the current
time.
