### PR TITLE
XD-984 Create file to JDBC batch import module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -500,6 +500,7 @@ project('spring-xd-extension-jdbc') {
 	dependencies {
 		compile "org.springframework:spring-jdbc:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
+		compile "org.springframework.batch:spring-batch-infrastructure:$springBatchVersion"
 		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
 		runtime "org.springframework.integration:spring-integration-jdbc:$springIntegrationVersion"
 		runtime "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
@@ -985,7 +986,11 @@ project('modules.sink.splunk') {
 	}
 }
 
-
+project('modules.job.filejdbc') {
+	dependencies {
+		runtime(project(":spring-xd-extension-jdbc"))
+	}
+}
 
 project('spring-xd-ui') {
 	description = 'Spring XD UI'

--- a/config/batch-jdbc-import.properties
+++ b/config/batch-jdbc-import.properties
@@ -1,0 +1,15 @@
+# Setting for the JDBC batch import job module
+
+#driverClass=org.sqlite.JDBC
+#url=jdbc:sqlite:xd.db
+
+# Use the builtin batch HSQLDB as default
+driverClass=org.hsqldb.jdbcDriver
+url=jdbc:hsqldb:hsql://localhost:9101/xdjob
+username=sa
+
+# Whether to initialize the database on job creation, and the script to
+# run to do so.
+initializeDatabase=true
+initializerScript=init_batch_import.sql
+

--- a/config/init_batch_import.sql
+++ b/config/init_batch_import.sql
@@ -1,0 +1,7 @@
+-- Database initialization for the JDBC batch import job module
+-- This script is referenced in the batch-jdbc-import.properties
+
+-- uses stream name as table name by default
+-- column definitions are created from the "names" parameter used to configure the module
+drop table #table;
+create table #table (#columns);

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcBatchItemWriter.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcBatchItemWriter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.jdbc;
+
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.util.Assert;
+
+/**
+ * JdbcBatchItemWriter which is customized for use with the XD
+ * JDBC import job.
+ *
+ * Sets the SQL insert property based on the column names and table name
+ * supplied in the module configuration.
+ *
+ * @author Luke Taylor
+ */
+public class NamedColumnJdbcBatchItemWriter<T> extends JdbcBatchItemWriter<T> {
+	private String[] names;
+	private String tableName;
+
+	public void setColumnNames(String[] names) {
+		this.names = names;
+	}
+
+	public void setTableName(String tableName) {
+		this.tableName = tableName;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		Assert.notEmpty(names, "columnNames must be set");
+		StringBuilder columns = new StringBuilder();
+		StringBuilder namedParams = new StringBuilder();
+		for (String column : names) {
+			if (columns.length() > 0) {
+				columns.append(", ");
+				namedParams.append(", ");
+			}
+			columns.append(column);
+			namedParams.append(":").append(column.trim());
+		}
+		setSql("insert into " + tableName + "(" + columns.toString() + ") values (" + namedParams.toString() + ")");
+		super.afterPropertiesSet();
+	}
+}

--- a/extensions/spring-xd-extension-jdbc/src/test/java/org/springframework/xd/jdbc/SingleTableDatabaseInitializerTests.java
+++ b/extensions/spring-xd-extension-jdbc/src/test/java/org/springframework/xd/jdbc/SingleTableDatabaseInitializerTests.java
@@ -54,6 +54,7 @@ public class SingleTableDatabaseInitializerTests {
 	public void testBuildWithPlaceholders() throws Exception {
 		databaseInitializer.addScript(resourceLoader.getResource("db-schema-with-placeholder.sql"));
 		databaseInitializer.setTableName("DEMO");
+		databaseInitializer.setColumnNames(new String[] {"blah0", "blah1", "blah2"});
 		databaseInitializer.setIgnoreFailedDrops(true);
 		databaseInitializer.afterPropertiesSet();
 		Connection connection = db.getConnection();
@@ -65,6 +66,8 @@ public class SingleTableDatabaseInitializerTests {
 		}
 
 		assertTestDatabaseCreated("DEMO");
+		// Check a select with column names works
+		jdbcTemplate.execute("select blah0, blah1, blah2 from demo");
 	}
 
 	@Test

--- a/extensions/spring-xd-extension-jdbc/src/test/resources/org/springframework/xd/jdbc/db-schema-with-placeholder.sql
+++ b/extensions/spring-xd-extension-jdbc/src/test/resources/org/springframework/xd/jdbc/db-schema-with-placeholder.sql
@@ -1,2 +1,2 @@
 drop table #table;
-create table #table (NAME varchar(50) not null);
+create table #table (#columns);

--- a/modules/job/filejdbc/config/filejdbc.xml
+++ b/modules/job/filejdbc/config/filejdbc.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:batch="http://www.springframework.org/schema/batch"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+
+	<context:property-placeholder location="file:${XD_HOME}/config/${configProperties:batch-jdbc-import}.properties" ignore-resource-not-found="true"/>
+
+	<batch:job id="job" restartable="${restartable:false}">
+		<batch:step id="readResourcesStep">
+			<batch:tasklet>
+				<batch:chunk reader="multiResourceReader" writer="itemWriter" commit-interval="100"/>
+			</batch:tasklet>
+		</batch:step>
+	</batch:job>
+
+	<bean id="multiResourceReader" class="org.springframework.batch.item.file.MultiResourceItemReader" scope="step">
+		<property name="resources" value="${resources}"/>
+		<property name="delegate" ref="itemReader"/>
+	</bean>
+
+	<bean id="itemReader" class="org.springframework.batch.item.file.FlatFileItemReader" scope="step">
+		<property name="lineMapper">
+			<bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
+				<property name="lineTokenizer">
+					<bean class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
+						<property name="names" value="${names}"/>
+					</bean>
+				</property>
+				<property name="fieldSetMapper">
+					<bean class="org.springframework.xd.tuple.batch.TupleFieldSetMapper"/>
+				</property>
+			</bean>
+		</property>
+	</bean>
+
+	<bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+		<property name="driverClass" value="${driverClass}"/>
+		<property name="url" value="${url}"/>
+		<property name="username" value="${username:}"/>
+		<property name="password" value="${password:}"/>
+	</bean>
+
+	<bean id="dataSourceInitializer" class="org.springframework.jdbc.datasource.init.DataSourceInitializer">
+		<property name="databasePopulator" ref="databasePopulator"/>
+		<property name="dataSource" ref="dataSource"/>
+		<property name="enabled" value="${initializeDatabase:false}"/>
+	</bean>
+
+	<bean id="databasePopulator" class="org.springframework.xd.jdbc.SingleTableDatabaseInitializer">
+		<property name="scripts" value="file:${XD_HOME}/config/${initializerScript:init_batch_import.sql}"/>
+		<property name="ignoreFailedDrops" value="true"/>
+		<property name="tableName" value="${tableName:${xd.stream.name}}"/>
+		<property name="columnNames" value="${names}" />
+	</bean>
+
+	<bean id="itemWriter" class="org.springframework.xd.jdbc.NamedColumnJdbcBatchItemWriter">
+		<property name="dataSource" ref="dataSource"/>
+		<property name="tableName" value="${tableName:${xd.stream.name}}" />
+		<property name="columnNames" value="${names}" />
+		<property name="itemSqlParameterSourceProvider">
+			<bean class="org.springframework.xd.tuple.batch.TupleSqlParameterSourceProvider" />
+		</property>
+	</bean>
+
+</beans>


### PR DESCRIPTION
The module uses the same pattern for initialising the database as the
JDBC sink. The initialisation code has also been extended to allow the
the column definitions to be dynamically created from the "names"
parameter supplied to the batch job.
