### PR TITLE
XD-1019 + Default RetryAdvice to Rabbit MessageBus

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/rabbit/RabbitMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/rabbit/RabbitMessageBus.java
@@ -18,12 +18,14 @@ package org.springframework.integration.x.rabbit;
 
 import java.util.Collection;
 
+import org.aopalliance.aop.Advice;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.FanoutExchange;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.config.StatelessRetryOperationsInterceptorFactoryBean;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -111,6 +113,8 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 			listenerContainer.setConcurrentConsumers(this.concurrentConsumers);
 		}
 		listenerContainer.setQueues(queue);
+		Advice advice = new StatelessRetryOperationsInterceptorFactoryBean().getObject();
+		listenerContainer.setAdviceChain(new Advice[] { advice });
 		listenerContainer.afterPropertiesSet();
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(listenerContainer);
 		DirectChannel bridgeToModuleChannel = new DirectChannel();

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/AbstractMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/AbstractMessageBusTests.java
@@ -50,7 +50,7 @@ import org.springframework.xd.tuple.Tuple;
  */
 public abstract class AbstractMessageBusTests {
 
-	private static final Collection<MediaType> ALL = Collections.singletonList(MediaType.ALL);
+	protected static final Collection<MediaType> ALL = Collections.singletonList(MediaType.ALL);
 
 	@Test
 	public void testClean() throws Exception {

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/rabbit/RabbitMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/rabbit/RabbitMessageBusTests.java
@@ -16,10 +16,22 @@
 
 package org.springframework.integration.x.rabbit;
 
-import org.junit.Rule;
+import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.x.bus.AbstractMessageBusTests;
 import org.springframework.integration.x.bus.MessageBus;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.MessagingException;
 import org.springframework.xd.test.rabbit.RabbitTestSupport;
 
 /**
@@ -30,10 +42,31 @@ public class RabbitMessageBusTests extends AbstractMessageBusTests {
 	@Rule
 	public RabbitTestSupport rabbitAvailableRule = new RabbitTestSupport();
 
-	@SuppressWarnings("unchecked")
 	@Override
 	protected MessageBus getMessageBus() throws Exception {
 		return new RabbitMessageBus(rabbitAvailableRule.getResource(), getCodec());
 	}
+
+	@Test
+	public void testSendAndReceiveBad() throws Exception {
+		MessageBus messageBus = getMessageBus();
+		DirectChannel moduleOutputChannel = new DirectChannel();
+		DirectChannel moduleInputChannel = new DirectChannel();
+		messageBus.bindProducer("foo.0", moduleOutputChannel, false);
+		messageBus.bindConsumer("foo.0", moduleInputChannel, ALL, false);
+		Message<?> message = MessageBuilder.withPayload("foo").setHeader(MessageHeaders.CONTENT_TYPE, "foo/bar").build();
+		final CountDownLatch latch = new CountDownLatch(3);
+		moduleInputChannel.subscribe(new MessageHandler() {
+
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				latch.countDown();
+				throw new RuntimeException("foo");
+			}
+		});
+		moduleOutputChannel.send(message);
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
+	}
+
 
 }


### PR DESCRIPTION
Add default advice - 3 attempts and log when exhausted.

This is a "quick" fix - default advice (3 attempts and no recovery - log failed message).
