### PR TITLE
XD-988: Batch export from HDFS to JDBC.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -992,6 +992,12 @@ project('modules.job.filejdbc') {
 	}
 }
 
+project('modules.job.hdfsjdbc') {
+	dependencies {
+		runtime(project(":spring-xd-extension-jdbc"))
+	}
+}
+
 project('spring-xd-ui') {
 	description = 'Spring XD UI'
 	// Run the jasmine tests from commandline using phantomJS

--- a/modules/job/hdfsjdbc/config/hdfsjdbc.xml
+++ b/modules/job/hdfsjdbc/config/hdfsjdbc.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:hdp="http://www.springframework.org/schema/hadoop"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:batch="http://www.springframework.org/schema/batch"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+
+	<context:property-placeholder location="file:${XD_HOME}/config/${configProperties:batch-jdbc-import}.properties" ignore-resource-not-found="true"/>
+
+	<batch:job id="job" restartable="${restartable:false}">
+		<batch:step id="readResourcesStep">
+			<batch:tasklet>
+				<batch:chunk reader="multifileReader" writer="itemWriter" commit-interval="100"/>
+			</batch:tasklet>
+		</batch:step>
+	</batch:job>
+
+	<bean id="multifileReader" class="org.springframework.batch.item.file.MultiResourceItemReader" scope="step">
+		<property name="resources" value="${resources}"/>
+		<property name="delegate" ref="itemReader"/>
+	</bean>
+
+	<bean id="itemReader" class="org.springframework.batch.item.file.FlatFileItemReader" scope="step">
+		<property name="lineMapper">
+			<bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
+				<property name="lineTokenizer">
+					<bean class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
+						<property name="names" value="${names}"/>
+					</bean>
+				</property>
+				<property name="fieldSetMapper">
+					<bean class="org.springframework.xd.tuple.batch.TupleFieldSetMapper"/>
+				</property>
+			</bean>
+		</property>
+	</bean>
+
+	<bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+		<property name="driverClass" value="${driverClass}"/>
+		<property name="url" value="${url}"/>
+		<property name="username" value="${username:}"/>
+		<property name="password" value="${password:}"/>
+	</bean>
+
+<!-- Database must be pre-created for now, due to issue SHDP-201 (see not in XD-988)
+		<bean id="dataSourceInitializer" class="org.springframework.jdbc.datasource.init.DataSourceInitializer">
+			<property name="databasePopulator" ref="databasePopulator"/>
+			<property name="dataSource" ref="dataSource"/>
+			<property name="enabled" value="${initializeDatabase:false}"/>
+		</bean>
+
+		<bean id="databasePopulator" class="org.springframework.xd.jdbc.SingleTableDatabaseInitializer">
+			<property name="scripts" value="file:${XD_HOME}/config/${initializerScript:init_batch_import.sql}"/>
+			<property name="ignoreFailedDrops" value="true"/>
+			<property name="tableName" value="${tableName:${xd.stream.name}}"/>
+			<property name="columnNames" value="${names}" />
+		</bean>
+-->
+		<bean id="itemWriter" class="org.springframework.xd.jdbc.NamedColumnJdbcBatchItemWriter">
+			<property name="dataSource" ref="dataSource"/>
+			<property name="tableName" value="${tableName:${xd.stream.name}}" />
+			<property name="columnNames" value="${names}" />
+			<property name="itemSqlParameterSourceProvider">
+				<bean class="org.springframework.xd.tuple.batch.TupleSqlParameterSourceProvider" />
+			</property>
+		</bean>
+
+		<bean id="hadoopFs" class="org.springframework.data.hadoop.fs.FileSystemFactoryBean">
+			<property name="configuration" ref="hadoopConfiguration"/>
+		</bean>
+
+		<hdp:configuration register-url-handler="false" properties-location="file:${XD_HOME}/config/hadoop.properties"/>
+		<hdp:resource-loader id="hadoopResourceLoader"/>
+
+		<bean id="defaultResourceLoader" class="org.springframework.data.hadoop.fs.CustomResourceLoaderRegistrar">
+			<property name="loader" ref="hadoopResourceLoader"/>
+		</bean>
+
+	</beans>


### PR DESCRIPTION
Note the issue with Spring HADOOP (SHDP-201) which prevents the easy use
of both HDFS and file resources in the same module, thus preventing the
use of the same DB initialization code from the file->JBDC module. This
is commented out for now and relies on manually pre-creating the
database table.
