### PR TITLE
XD-987: HDFS to mongo export job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,9 +73,9 @@ ext {
 	springBatchAdminMgrVersion = '1.3.0.M1'
 	springShellVersion = '1.1.0.M1'
 	springIntegrationSplunkVersion = '1.0.0.M1'
-	springDataMongoVersion = '1.1.1.RELEASE'
+	springDataMongoVersion = '1.3.2.RELEASE'
 	springDataRedisVersion = '1.1.0.RELEASE'
-	springDataCommonsVersion = '1.6.0.M1'
+	springDataCommonsVersion = '1.6.2.RELEASE'
 	springDataGemfireVersion = '1.3.2.RELEASE'
 	tomcatJdbcPoolVersion = '7.0.42'
 	reactorVersion = '1.0.0.RC1'
@@ -492,6 +492,15 @@ project('spring-xd-extension-splunk') {
 	dependencies {
 		compile "org.springframework.integration:spring-integration-splunk:$springIntegrationSplunkVersion"
 		runtime "com.splunk:splunk:1.2.0"
+	}
+}
+
+project('spring-xd-extension-mongodb') {
+	description = 'Spring XD Mongodb'
+	dependencies {
+		compile project(':spring-xd-tuple')
+		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
+		compile "org.springframework.data:spring-data-mongodb:$springDataMongoVersion"
 	}
 }
 
@@ -992,6 +1001,12 @@ project('modules.job.filejdbc') {
 	}
 }
 
+project('modules.job.hdfsmongodb') {
+	dependencies {
+		runtime(project(":spring-xd-extension-mongodb"))
+	}
+}
+
 project('spring-xd-ui') {
 	description = 'Spring XD UI'
 	// Run the jasmine tests from commandline using phantomJS
@@ -1358,3 +1373,4 @@ task wrapper(type: Wrapper) {
 	gradleVersion = "1.6"
 	scriptFile= "gradle/build_xd"
 }
+

--- a/config/batch-mongo-import.properties
+++ b/config/batch-mongo-import.properties
@@ -1,0 +1,3 @@
+host=localhost
+port=27017
+databaseName=xd

--- a/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/FieldSetConverter.java
+++ b/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/FieldSetConverter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.batch.item.mongodb;
+package org.springframework.xd.mongodb;
 
 import java.util.HashSet;
 import java.util.Properties;

--- a/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/MongoItemWriter.java
+++ b/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/MongoItemWriter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.batch.item.mongodb;
+package org.springframework.xd.mongodb;
 
 import java.util.List;
 

--- a/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/TupleWriteConverter.java
+++ b/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/TupleWriteConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.mongodb;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.Assert;
+import org.springframework.xd.tuple.Tuple;
+
+/**
+ * @author Luke Taylor
+ */
+public class TupleWriteConverter implements Converter<Tuple,DBObject> {
+	private String idField = null;
+
+	/**
+	 * Set the tuple field name which will be used as the Mongo _id.
+	 * If not set, the id property of the tuple will be used.
+	 *
+	 * @param idField the name of the field to use as the identity in MongoDB.
+	 */
+	public void setIdField(String idField) {
+		Assert.hasText("idField cannot be empty");
+		this.idField = idField;
+	}
+
+	@Override
+	public DBObject convert(Tuple source) {
+		DBObject dbo = new BasicDBObject();
+		for (int i=0; i < source.getFieldCount(); i++) {
+			String name = source.getFieldNames().get(i);
+			if (name.equals(idField)) {
+				dbo.put("_id", source.getValue(i));
+			}
+			else {
+				dbo.put(name, source.getValue(i));
+			}
+		}
+		if (dbo.get("_id") == null) {
+			dbo.put("_id", source.getId().toString());
+		}
+		return dbo;
+	}
+}
+

--- a/modules/job/hdfsmongodb/config/hdfsmongodb.xml
+++ b/modules/job/hdfsmongodb/config/hdfsmongodb.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:hdp="http://www.springframework.org/schema/hadoop"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:batch="http://www.springframework.org/schema/batch"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
+		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+
+	<context:property-placeholder location="file:${XD_HOME}/config/${configProperties:batch-mongo-import}.properties" ignore-resource-not-found="true"/>
+
+	<batch:job id="job" restartable="${restartable:false}">
+		<batch:step id="readResourcesStep">
+			<batch:tasklet>
+				<batch:chunk reader="multifileReader" writer="itemWriter" commit-interval="100"/>
+			</batch:tasklet>
+		</batch:step>
+	</batch:job>
+
+	<bean id="multifileReader" class="org.springframework.batch.item.file.MultiResourceItemReader" scope="step">
+		<property name="resources" value="${resources}"/>
+		<property name="delegate" ref="itemReader"/>
+	</bean>
+
+	<bean id="itemReader" class="org.springframework.batch.item.file.FlatFileItemReader" scope="step">
+		<property name="lineMapper">
+			<bean class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
+				<property name="lineTokenizer">
+					<bean class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
+						<property name="names" value="${names}" />
+					</bean>
+				</property>
+				<property name="fieldSetMapper">
+					<bean class="org.springframework.xd.tuple.batch.TupleFieldSetMapper"/>
+				</property>
+			</bean>
+		</property>
+	</bean>
+
+	<bean id="itemWriter" class="org.springframework.xd.mongodb.MongoItemWriter">
+		<constructor-arg>
+			<bean class="org.springframework.data.mongodb.core.MongoTemplate">
+				<constructor-arg ref="mongoDbFactory" />
+				<constructor-arg ref="mappingConverter"/>
+			</bean>
+		</constructor-arg>
+		<property name="collectionName" value="${collectionName:${xd.stream.name}}" />
+	</bean>
+
+	<bean id="hadoopFs" class="org.springframework.data.hadoop.fs.FileSystemFactoryBean">
+		<property name="configuration" ref="hadoopConfiguration"/>
+	</bean>
+
+	<hdp:configuration register-url-handler="false" properties-location="file:${XD_HOME}/config/hadoop.properties"/>
+	<hdp:resource-loader id="hadoopResourceLoader"/>
+	<mongo:db-factory dbname="${databaseName:xd}" host="${host}" port="${port}"/>
+
+	<mongo:mapping-converter>
+		<mongo:custom-converters>
+			<mongo:converter>
+				<bean class="org.springframework.xd.mongodb.TupleWriteConverter">
+					<property name="idField" value="${idField:null}"/>
+				</bean>
+			</mongo:converter>
+		</mongo:custom-converters>
+	</mongo:mapping-converter>
+
+	<bean id="defaultResourceLoader" class="org.springframework.data.hadoop.fs.CustomResourceLoaderRegistrar">
+		<property name="loader" ref="hadoopResourceLoader"/>
+	</bean>
+
+</beans>


### PR DESCRIPTION
Create
- spring-xd-extension-mongodb
- hdfsmongodb module

Move existing mongo code from hadoop extension to new mongodb one.
Add new TupleItemWriter which allows a specific identity field to be
chosen if required instead of the generated Tuple UUID.
