### PR TITLE
Add legacy profile to rabbit xml

### DIFF
--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/rabbit-common.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/rabbit-common.xml
@@ -6,4 +6,15 @@
 
 	<import resource="classpath:/META-INF/spring-xd/internal/xd-common.xml" />
 
+	<beans profile="legacy">
+		<bean id="rabbitConnectionFactory"
+			class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory">
+			<constructor-arg index="0" value="${rabbit.hostname:localhost}" />
+			<constructor-arg index="1" value="${rabbit.port:5672}" />
+			<property name="username" value="${rabbit.username:guest}" />
+			<property name="password" value="${rabbit.password:guest}" />
+			<property name="virtualHost" value="${rabbit.vhost:/}" />
+		</bean>
+	</beans>
+
 </beans>


### PR DESCRIPTION
Should reset the rabbit transport to work properly with the
ols *Server mains.

This is just the first step, but probably a good idea to merge it
while I work on the bigger task of removing the legacy profile
completely.
