### PR TITLE
XD-71: Switch to more efficient UUID impl in Tuple

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ ext {
 	mockitoVersion = '1.9.5'
 	javaxMailVersion = '1.5.0'
 	kryoVersion = '2.22'
+	uuidVersion = '3.2'
 	singleNodeServerProcess = new SingleNodeServerProcess()
 }
 
@@ -829,6 +830,7 @@ project('spring-xd-tuple') {
 		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
 		compile "org.springframework.batch:spring-batch-infrastructure:$springBatchVersion"
 		compile "org.springframework:spring-jdbc:$springVersion"
+		compile "com.eaio.uuid:uuid:$uuidVersion"
 		testCompile ("org.mockito:mockito-core:$mockitoVersion") {
 			exclude group:'org.hamcrest'
 		}

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/DefaultTuple.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/DefaultTuple.java
@@ -16,6 +16,8 @@
 
 package org.springframework.xd.tuple;
 
+import com.eaio.uuid.UUIDGen;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,7 +81,7 @@ public class DefaultTuple implements Tuple {
 		this.names = new ArrayList<String>(names);
 		this.values = new ArrayList<Object>(values); // shallow copy
 		this.formattingConversionService = formattingConversionService;
-		this.id = UUID.randomUUID();
+		this.id = new UUID(UUIDGen.newTime(), UUIDGen.getClockSeqAndNode());
 		this.timestamp = Long.valueOf(System.currentTimeMillis());
 	}
 


### PR DESCRIPTION
Use the com.eaio implementation instead of the default JDK UUID generator.
