### PR TITLE
XD-1078 Add "spring-xd-exec" directory

### DIFF
--- a/spring-xd-exec/README.md
+++ b/spring-xd-exec/README.md
@@ -1,0 +1,1 @@
+Directory is used by the *Spring XD Exec* Gradle module.


### PR DESCRIPTION
Without the `spring-xd-exec` directory, Spring XD cannot be imported into STS using STS' Gradle support.

Jira: https://jira.springsource.org/browse/XD-1078
