### PR TITLE
XD-1096 Part1 Update Batch Job DTO classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -852,6 +852,9 @@ project('spring-xd-rest-domain') {
 		compile ("org.springframework.hateoas:spring-hateoas:$springHATEOASVersion") {
 			exclude module: "spring-asm"
 		}
+		compile ("org.springframework.batch:spring-batch-admin-manager:$springBatchAdminMgrVersion") {
+			exclude group: 'org.springframework.integration'
+		}
 		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 		compile 'org.codehaus.jackson:jackson-core-asl:1.9.13'
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
@@ -21,6 +21,8 @@ import org.springframework.hateoas.EntityLinks;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.xd.rest.client.domain.BatchJobExecutionInfo;
+import org.springframework.xd.rest.client.domain.BatchJobInfo;
 import org.springframework.xd.rest.client.domain.JobDefinitionResource;
 import org.springframework.xd.rest.client.domain.ModuleDefinitionResource;
 import org.springframework.xd.rest.client.domain.RuntimeContainerInfoResource;
@@ -53,6 +55,8 @@ public class AdminController {
 		XDRuntime xdRuntime = new XDRuntime();
 		xdRuntime.add(entityLinks.linkFor(StreamDefinitionResource.class).withRel("streams"));
 		xdRuntime.add(entityLinks.linkFor(JobDefinitionResource.class).withRel("jobs"));
+		xdRuntime.add(entityLinks.linkFor(BatchJobInfo.class).withRel("batch/jobs"));
+		xdRuntime.add(entityLinks.linkFor(BatchJobExecutionInfo.class).withRel("batch/executions"));
 		xdRuntime.add(entityLinks.linkFor(ModuleDefinitionResource.class).withRel("modules"));
 		xdRuntime.add(entityLinks.linkFor(RuntimeModuleInfoResource.class).withRel("runtime/modules"));
 		xdRuntime.add(entityLinks.linkFor(RuntimeContainerInfoResource.class).withRel("runtime/containers"));

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.TimeZone;
 
 import org.springframework.batch.admin.service.JobService;
-import org.springframework.batch.admin.web.JobExecutionInfo;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -33,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.xd.rest.client.domain.BatchJobExecutionInfo;
 
 /**
  * Controller for batch job executions.
@@ -43,7 +43,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  */
 @Controller
 @RequestMapping("/batch/executions")
-@ExposesResourceFor(JobExecutionInfo.class)
+@ExposesResourceFor(BatchJobExecutionInfo.class)
 public class BatchJobExecutionsController {
 
 	private JobService jobService;
@@ -74,12 +74,12 @@ public class BatchJobExecutionsController {
 	@RequestMapping(value = { "" }, method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public Collection<JobExecutionInfo> list(@RequestParam(defaultValue = "0") int startJobExecution,
+	public Collection<BatchJobExecutionInfo> list(@RequestParam(defaultValue = "0") int startJobExecution,
 			@RequestParam(defaultValue = "20") int pageSize) {
 
-		Collection<JobExecutionInfo> result = new ArrayList<JobExecutionInfo>();
+		Collection<BatchJobExecutionInfo> result = new ArrayList<BatchJobExecutionInfo>();
 		for (JobExecution jobExecution : jobService.listJobExecutions(startJobExecution, pageSize)) {
-			result.add(new JobExecutionInfo(jobExecution, timeZone));
+			result.add(new BatchJobExecutionInfo(jobExecution, timeZone));
 		}
 		return result;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
@@ -26,7 +26,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.batch.admin.service.JobService;
 import org.springframework.batch.admin.web.JobExecutionInfo;
-import org.springframework.batch.admin.web.JobInfo;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.batch.core.launch.NoSuchJobException;
@@ -42,7 +41,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.xd.dirt.job.NoSuchBatchJobException;
-import org.springframework.xd.dirt.plugins.job.ExpandedJobInfo;
+import org.springframework.xd.rest.client.domain.BatchJobInfo;
+import org.springframework.xd.rest.client.domain.ExpandedJobInfo;
+
 
 /**
  * Controller for batch jobs and job instances, job executions on a given batch job.
@@ -54,7 +55,7 @@ import org.springframework.xd.dirt.plugins.job.ExpandedJobInfo;
  */
 @Controller
 @RequestMapping("/batch/jobs")
-@ExposesResourceFor(JobInfo.class)
+@ExposesResourceFor(BatchJobInfo.class)
 public class BatchJobsController {
 
 	private static Log logger = LogFactory.getLog(BatchJobsController.class);
@@ -87,10 +88,10 @@ public class BatchJobsController {
 	@RequestMapping(value = "", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
 	@ResponseBody
-	public Collection<JobInfo> jobs(@RequestParam(defaultValue = "0") int startJob,
+	public Collection<BatchJobInfo> jobs(@RequestParam(defaultValue = "0") int startJob,
 			@RequestParam(defaultValue = "20") int pageSize) {
 		Collection<String> names = jobService.listJobs(startJob, pageSize);
-		List<JobInfo> jobs = new ArrayList<JobInfo>();
+		List<BatchJobInfo> jobs = new ArrayList<BatchJobInfo>();
 		for (String name : names) {
 			String displayName = name.substring(0, name.length() - ".job".length());
 			jobs.add(internalGetJobInfo(displayName, name));

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobExecutionsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobExecutionsControllerIntegrationTests.java
@@ -111,7 +111,7 @@ public class BatchJobExecutionsControllerIntegrationTests extends AbstractContro
 		mockMvc.perform(
 				get("/batch/executions").param("startJobExecution", "0").param("pageSize", "20").accept(
 						MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andExpect(
-				jsonPath("$", Matchers.hasSize(2))).andExpect(jsonPath("$[*].id", contains(0, 3))).andExpect(
+				jsonPath("$", Matchers.hasSize(2))).andExpect(jsonPath("$[*].executionId", contains(0, 3))).andExpect(
 				jsonPath("$[*].jobExecution[*].stepExecutions", Matchers.hasSize(3))).andExpect(
 				jsonPath("$[*].jobId", contains(0, 2))).andExpect(jsonPath("$[*].jobExecution[*].id", contains(0, 3))).andExpect(
 				jsonPath("$[*].jobExecution[*].jobParameters.parameters.param1.value", contains("test", "test"))).andExpect(

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDTemplate.java
@@ -89,6 +89,8 @@ public class SpringXDTemplate extends AbstractTemplate implements SpringXDOperat
 		XDRuntime xdRuntime = restTemplate.getForObject(baseURI, XDRuntime.class);
 		resources.put("streams", URI.create(xdRuntime.getLink("streams").getHref()));
 		resources.put("jobs", URI.create(xdRuntime.getLink("jobs").getHref()));
+		resources.put("batch/jobs", URI.create(xdRuntime.getLink("batch/jobs").getHref()));
+		resources.put("batch/executions", URI.create(xdRuntime.getLink("batch/executions").getHref()));
 		resources.put("runtime/containers", URI.create(xdRuntime.getLink("runtime/containers").getHref()));
 		resources.put("runtime/modules", URI.create(xdRuntime.getLink("runtime/modules").getHref()));
 		resources.put("modules", URI.create(xdRuntime.getLink("modules").getHref()));

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/BatchJobExecutionInfo.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/BatchJobExecutionInfo.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.rest.client.domain;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import org.springframework.batch.admin.web.JobParametersExtractor;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.converter.DefaultJobParametersConverter;
+import org.springframework.batch.core.converter.JobParametersConverter;
+import org.springframework.hateoas.ResourceSupport;
+
+
+/**
+ * Represents Batch job execution info.
+ * 
+ * @author Dave Syer
+ * @author Ilayaperumal Gopinathan
+ * @since 1.0
+ */
+public class BatchJobExecutionInfo extends ResourceSupport {
+
+	private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+
+	private SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss");
+
+	private SimpleDateFormat durationFormat = new SimpleDateFormat("HH:mm:ss");
+
+	private Long executionId;
+
+	private int stepExecutionCount;
+
+	private Long jobId;
+
+	private String jobName;
+
+	private String startDate = "";
+
+	private String startTime = "";
+
+	private String duration = "";
+
+	private JobExecution jobExecution;
+
+	private Properties jobParameters;
+
+	private String jobParametersString;
+
+	private boolean restartable = false;
+
+	private boolean abandonable = false;
+
+	private boolean stoppable = false;
+
+	private JobParametersConverter converter = new DefaultJobParametersConverter();
+
+	private final TimeZone timeZone;
+
+	public BatchJobExecutionInfo(JobExecution jobExecution, TimeZone timeZone) {
+
+		this.jobExecution = jobExecution;
+		this.timeZone = timeZone;
+		this.executionId = jobExecution.getId();
+		this.jobId = jobExecution.getJobId();
+		this.stepExecutionCount = jobExecution.getStepExecutions().size();
+		this.jobParameters = converter.getProperties(jobExecution.getJobParameters());
+		this.jobParametersString = new JobParametersExtractor().fromJobParameters(jobExecution.getJobParameters());
+
+		JobInstance jobInstance = jobExecution.getJobInstance();
+		if (jobInstance != null) {
+			this.jobName = jobInstance.getJobName();
+			BatchStatus status = jobExecution.getStatus();
+			this.restartable = status.isGreaterThan(BatchStatus.STOPPING) && status.isLessThan(BatchStatus.ABANDONED);
+			this.abandonable = status.isGreaterThan(BatchStatus.STARTED) && status != BatchStatus.ABANDONED;
+			this.stoppable = status.isLessThan(BatchStatus.STOPPING);
+		}
+		else {
+			this.jobName = "?";
+		}
+
+		// Duration is always in GMT
+		durationFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+		// The others can be localized
+		timeFormat.setTimeZone(timeZone);
+		dateFormat.setTimeZone(timeZone);
+		if (jobExecution.getStartTime() != null) {
+			this.startDate = dateFormat.format(jobExecution.getStartTime());
+			this.startTime = timeFormat.format(jobExecution.getStartTime());
+			Date endTime = jobExecution.getEndTime() != null ? jobExecution.getEndTime() : new Date();
+			this.duration = durationFormat.format(new Date(endTime.getTime() - jobExecution.getStartTime().getTime()));
+		}
+
+	}
+
+	public TimeZone getTimeZone() {
+		return timeZone;
+	}
+
+	public String getName() {
+		return jobName;
+	}
+
+	public Long getExecutionId() {
+		return executionId;
+	}
+
+	public int getStepExecutionCount() {
+		return stepExecutionCount;
+	}
+
+	public Long getJobId() {
+		return jobId;
+	}
+
+	public String getStartDate() {
+		return startDate;
+	}
+
+	public String getStartTime() {
+		return startTime;
+	}
+
+	public String getDuration() {
+		return duration;
+	}
+
+	public JobExecution getJobExecution() {
+		return jobExecution;
+	}
+
+	public boolean isRestartable() {
+		return restartable;
+	}
+
+	public boolean isAbandonable() {
+		return abandonable;
+	}
+
+	public boolean isStoppable() {
+		return stoppable;
+	}
+
+	public String getJobParametersString() {
+		return jobParametersString;
+	}
+
+	public Properties getJobParameters() {
+		return jobParameters;
+	}
+}

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/BatchJobInfo.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/BatchJobInfo.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.rest.client.domain;
+
+import org.springframework.hateoas.ResourceSupport;
+
+
+/**
+ * Represents Batch job info.
+ * 
+ * @author Dave Syer
+ * @author Ilayaperumal Gopinathan
+ * @since 1.0
+ */
+public class BatchJobInfo extends ResourceSupport {
+
+	private final String name;
+
+	private final int executionCount;
+
+	private boolean launchable = false;
+
+	private boolean incrementable = false;
+
+	private final Long jobInstanceId;
+
+	public BatchJobInfo(String name, int executionCount) {
+		this(name, executionCount, false);
+	}
+
+	public BatchJobInfo(String name, int executionCount, boolean launchable) {
+		this(name, executionCount, null, launchable, false);
+	}
+
+	public BatchJobInfo(String name, int executionCount, boolean launchable, boolean incrementable) {
+		this(name, executionCount, null, launchable, incrementable);
+	}
+
+	public BatchJobInfo(String name, int executionCount, Long jobInstanceId, boolean launchable, boolean incrementable) {
+		super();
+		this.name = name;
+		this.executionCount = executionCount;
+		this.jobInstanceId = jobInstanceId;
+		this.launchable = launchable;
+		this.incrementable = incrementable;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getExecutionCount() {
+		return executionCount;
+	}
+
+	public Long getJobInstanceId() {
+		return jobInstanceId;
+	}
+
+	public boolean isLaunchable() {
+		return launchable;
+	}
+
+	public boolean isIncrementable() {
+		return incrementable;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+}

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/ExpandedJobInfo.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/ExpandedJobInfo.java
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.plugins.job;
+package org.springframework.xd.rest.client.domain;
 
 import org.springframework.batch.admin.web.JobExecutionInfo;
-import org.springframework.batch.admin.web.JobInfo;
 import org.springframework.batch.core.ExitStatus;
 
 /**
- * A job info for batch jobs that provides more details than the base {@link JobInfo}
+ * A job info for batch jobs that provides more details than the base {@link BatchJobInfo}
  * 
  * @author Andrew Eisenberg
  */
-public class ExpandedJobInfo extends JobInfo {
+public class ExpandedJobInfo extends BatchJobInfo {
 
 	private String jobParameters;
 

--- a/spring-xd-ui/templates/jobs/executions.tpl
+++ b/spring-xd-ui/templates/jobs/executions.tpl
@@ -14,7 +14,7 @@
 			<tbody>
 				<% for (var i in executions) { %>
 					<tr>
-						<td><%= executions[i].id %></td>
+						<td><%= executions[i].executionId %></td>
 						<td><%= executions[i].name.substring(0, executions[i].name.lastIndexOf(".")) %></td>
 						<td><%= executions[i].startDate + ' ' + executions[i].startTime +  ' ' + executions[i].timeZone %></td>
 						<td><%= executions[i].stepExecutionCount %></td>


### PR DESCRIPTION
- Update BatchJobInfo and BatchJobExecutionInfo to extend
  HATEOAS ResourceSupport

Note: Currently, "/batch/executions" and "/batch/jobs" links are added to XDRuntime but the BatchJobExecutionInfo and BatchJobInfo resource links are not update.
