### PR TITLE
XD-1070,XD1071 filehdfs job module fixes

### DIFF
--- a/modules/job/filehdfs.xml
+++ b/modules/job/filehdfs.xml
@@ -42,6 +42,8 @@
 		</property>
 		<property name="baseFilename" value="${filename:${xd.stream.name}}"/>
 		<property name="rolloverThresholdInBytes" value="${rollover:1000000}"/>
+		<property name="basePath" value="${basePath:/data/}"/>
+		<property name="fileSuffix" value="${suffix:log}"/>
 	</bean>
 
 	<bean id="hadoopFs" class="org.springframework.data.hadoop.fs.FileSystemFactoryBean">

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/HdfsTextItemWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/HdfsTextItemWriter.java
@@ -70,12 +70,14 @@ public class HdfsTextItemWriter<T> extends AbstractHdfsItemWriter<T> implements 
 			name = new Path(getFileName());
 			// If it doesn't exist, create it. If it exists, return false
 			if (getFileSystem().createNewFile(name)) {
+				logger.debug("Created new HDFS file " + name.getName());
 				found = true;
 				this.resetBytesWritten();
 				this.fsDataOutputStream = this.getFileSystem().append(name);
 			}
 			else {
 				if (this.getBytesWritten() >= getRolloverThresholdInBytes()) {
+					logger.debug("Rolling over new file");
 					close();
 					incrementCounter();
 				}
@@ -90,9 +92,7 @@ public class HdfsTextItemWriter<T> extends AbstractHdfsItemWriter<T> implements 
 	/**
 	 * Simple not optimized copy
 	 */
-	public void copy(byte[] in, FSDataOutputStream out) throws IOException {
-		Assert.notNull(in, "No input byte array specified");
-		Assert.notNull(out, "No OutputStream specified");
+	private void copy(byte[] in, FSDataOutputStream out) throws IOException {
 		out.write(in);
 		incrementBytesWritten(in.length);
 	}
@@ -122,8 +122,9 @@ public class HdfsTextItemWriter<T> extends AbstractHdfsItemWriter<T> implements 
 		}
 	}
 
-
+	@Override
 	public void close() {
+		logger.debug("Closing output stream");
 		if (fsDataOutputStream != null) {
 			IOUtils.closeStream(fsDataOutputStream);
 		}
@@ -142,6 +143,5 @@ public class HdfsTextItemWriter<T> extends AbstractHdfsItemWriter<T> implements 
 	public void afterPropertiesSet() throws Exception {
 		Assert.notNull(lineAggregator, "A LineAggregator must be provided.");
 	}
-
 
 }


### PR DESCRIPTION
- Add basePath and fileSuffix parameters to module
- Create basePath if necessary
- Improved rollover counter naming in the case where multiple jobs may
  be using the same base path.
- Extend AbstractItemStreamWriter so HDFS stream is closed when job ends
