### PR TITLE
XD-1110 Fix JobRepoTests

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobLocator.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobLocator.java
@@ -94,7 +94,7 @@ public class BatchJobLocator implements ListableJobLocator {
 		}
 	}
 
-	protected void delteJobName(String name) {
+	protected void deleteJobName(String name) {
 		jdbcTemplate.update(DELETE_JOB_NAME, name);
 		jdbcTemplate.update(DELETE_JOB_INCREMENTABLE, name);
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobRegistryBeanPostProcessor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobRegistryBeanPostProcessor.java
@@ -81,7 +81,7 @@ public class BatchJobRegistryBeanPostProcessor extends JobRegistryBeanPostProces
 	@Override
 	public void destroy() throws Exception {
 		Assert.notNull(jobName, "JobName should not be null");
-		jobLocator.delteJobName(jobName);
+		jobLocator.deleteJobName(jobName);
 		super.destroy();
 	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobRepoTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobRepoTests.java
@@ -101,6 +101,6 @@ public class JobRepoTests {
 			// we can ignore this. Just want to create a fake job instance.
 		}
 		assertTrue(repo.isJobInstanceExists(SIMPLE_JOB_NAME, new JobParameters()));
-		jobLocator.delteJobName(SIMPLE_JOB_NAME);
+		jobLocator.deleteJobName(SIMPLE_JOB_NAME);
 	}
 }


### PR DESCRIPTION
- Fixed JobRepoTests to use a test hsql database
  so that the batch repo is different from what XD runtime uses.
