### PR TITLE
Fix JobExecutionInfoResourceAssembler

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobExecutionInfoResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobExecutionInfoResourceAssembler.java
@@ -35,7 +35,7 @@ public class JobExecutionInfoResourceAssembler extends
 
 	@Override
 	public JobExecutionInfoResource toResource(JobExecutionInfo entity) {
-		return createResourceWithId(entity.getName(), entity);
+		return createResourceWithId(entity.getExecutionId(), entity);
 	}
 
 	@Override


### PR DESCRIPTION
- Use executionId instead of job name as resourceId
