### PR TITLE
Ensure Boot defaults available for MVC

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
@@ -46,7 +45,6 @@ import org.springframework.xd.rest.client.util.RestTemplateMessageConverterUtil;
  * @author Gunnar Hillert
  */
 @Configuration
-@EnableWebMvc
 @EnableHypermediaSupport
 @EnableSpringDataWebSupport
 @ComponentScan(excludeFilters = @Filter(Configuration.class))


### PR DESCRIPTION
RestConfiguration doesn't need to @EnableWebMvc and (at least with
current snapshots of Boot) it also has the effect of disabling the
/error page for browser clients.
