### PR TITLE
XD-1132 Support Topics in JMS Source

### DIFF
--- a/modules/source/jms/config/jms.xml
+++ b/modules/source/jms/config/jms.xml
@@ -13,7 +13,11 @@
 
 	<int-jms:message-driven-channel-adapter id="jmsSource"
 		auto-startup="false"
-		destination-name="${queue:${xd.stream.name}}"
+		destination-name="${destination:${xd.stream.name}}"
+		pub-sub-domain="${pubSub:false}"
+		subscription-durable="${durableSubscription:false}"
+		durable-subscription-name="#{'${subscriptionName:}' == '' ? null : '${subscriptionName:}'}"
+		client-id="#{'${clientId:}' == '' ? null : '${clientId:}'}"
 		channel="output"
 		connection-factory="connectionFactory"/>
 


### PR DESCRIPTION
 Rename 'queue' property to 'destination'
 Add four new properties (default):
- pubSub (false)
- durableSubscription (false)
- subscriptionName (null)
- clientId (null)

Update the AmqBrokerAndTest test class to support sending to
topics.

Update `Sources` page on Wiki.
