### PR TITLE
XD-1136 Fixing failure in HDFS sink  when undeploying and redeploying a ...

### DIFF
--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/AbstractHdfsWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/AbstractHdfsWriter.java
@@ -123,10 +123,10 @@ public abstract class AbstractHdfsWriter implements HdfsWriter {
 	}
 
 	protected int getCounterFromName(String shortName) {
-		Pattern pattern = Pattern.compile("([\\d+]{1,})");
+		Pattern pattern = Pattern.compile(baseFilename + "-([\\d+]{1,})");
 		Matcher matcher = pattern.matcher(shortName);
 		if (matcher.find()) {
-			return Integer.parseInt(matcher.group());
+			return Integer.parseInt(matcher.group(1));
 		}
 		return -1;
 	}


### PR DESCRIPTION
...stream
- problem was that file names or directories containing numbers interfered with
  creation of new file with numeric suffix for the stream
