### PR TITLE
XD Log settings updated to work with boot.

### DIFF
--- a/config/xd-container-logger.properties
+++ b/config/xd-container-logger.properties
@@ -8,7 +8,7 @@ log4j.appender.file=org.apache.log4j.RollingFileAppender
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c:%L - %m%n
 
-log4j.appender.file.File=${xd.home}/logs/${xd.container}.log
+log4j.appender.file.File=${xd.home}/logs/container.log
 log4j.appender.file.Append=false
 log4j.appender.file.MaxFileSize=100KB
 

--- a/config/xd-singlenode-logger.properties
+++ b/config/xd-singlenode-logger.properties
@@ -10,7 +10,7 @@ log4j.appender.file=org.apache.log4j.RollingFileAppender
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c:%L - %m%n
 
-log4j.appender.file.File=${xd.home}/logs/admin.log
+log4j.appender.file.File=${xd.home}/logs/singlenode.log
 log4j.appender.file.Append=false
 log4j.appender.file.MaxFileSize=100KB
 

--- a/scripts/xd/xd-admin
+++ b/scripts/xd/xd-admin
@@ -181,7 +181,7 @@ if [ x"$XD_HOME" = x ] ; then
 fi
 
 # set app name etc. via SPRING_XD_OPTS
-SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogger.config=file:$XD_HOME/config/xd-container-logger.properties"
+SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-admin-logger.properties -Dxd.home=$XD_HOME"
 
 # Split up the JVM_OPTS And SPRING_XD_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/xd/xd-admin.bat
+++ b/scripts/xd/xd-admin.bat
@@ -95,7 +95,7 @@ if exist "%APP_HOME_LIB%" (
 if not exist "%XD_HOME%" (
     set XD_HOME=%APP_HOME%
 )
-set SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogger.config=file:$XD_HOME/config/xd-container-logger.properties"
+set SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:%XD_HOME%/config/xd-admin-logger.properties -Dxd.home=%XD_HOME%"
 
 @rem Execute xd-admin
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_OPTS% -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.AdminServerApplication %CMD_LINE_ARGS%

--- a/scripts/xd/xd-container
+++ b/scripts/xd/xd-container
@@ -181,7 +181,7 @@ if [ x"$XD_HOME" = x ] ; then
 fi
 
 # set app name etc. via SPRING_XD_OPTS
-SPRING_XD_OPTS="-Dspring.application.name=container -Dlogger.config=file:$XD_HOME/config/xd-container-logger.properties"
+SPRING_XD_OPTS="-Dspring.application.name=container -Dlogging.config=file:$XD_HOME/config/xd-container-logger.properties -Dxd.home=$XD_HOME"
 
 # Split up the JVM_OPTS And SPRING_XD_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/xd/xd-container.bat
+++ b/scripts/xd/xd-container.bat
@@ -95,7 +95,7 @@ if exist "%APP_HOME_LIB%" (
 if not exist "%XD_HOME%" (
     set XD_HOME=%APP_HOME%
 )
-set SPRING_XD_OPTS="-Dspring.application.name=container -Dlogger.config=file:$XD_HOME/config/xd-container-logger.properties"
+set SPRING_XD_OPTS="-Dspring.application.name=container -Dlogging.config=file:%XD_HOME%/config/xd-container-logger.properties -Dxd.home=%XD_HOME%"
 
 @rem Execute xd-container
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_OPTS% -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.LauncherApplication %CMD_LINE_ARGS%

--- a/scripts/xd/xd-singlenode
+++ b/scripts/xd/xd-singlenode
@@ -181,7 +181,7 @@ if [ x"$XD_HOME" = x ] ; then
 fi
 
 # set app name etc. via SPRING_XD_OPTS
-SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogger.config=file:$XD_HOME/config/xd-singlenode-logger.properties"
+SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-singlenode-logger.properties  -Dxd.home=$XD_HOME"
 
 # Split up the JVM_OPTS And SPRING_XD_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/xd/xd-singlenode.bat
+++ b/scripts/xd/xd-singlenode.bat
@@ -95,7 +95,7 @@ if exist "%APP_HOME_LIB%" (
 if not exist "%XD_HOME%" (
     set XD_HOME=%APP_HOME%
 )
-set SPRING_XD_OPTS="-Dspring.application.name=singlenode -Dlogger.config=file:$XD_HOME/config/xd-singlenode-logger.properties"
+set SPRING_XD_OPTS="-Dspring.application.name=singlenode -Dlogging.config=file:%XD_HOME%/config/xd-singlenode-logger.properties  -Dxd.home=%XD_HOME%"
 
 @rem Execute xd-singlenode
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_OPTS%  -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.SingleNodeApplication %CMD_LINE_ARGS%


### PR DESCRIPTION
- Boot requires xd.logging to identify log config files. Scripts were set to use xd.logger.  Thus they would not even log.
- Scripts did not contain the xd.home parameter so logs only wrote to the /logs directory.  Thus they never were written.
- Updated configurations to reasonable defaults.
  - admin was using container-logger.properties now using admin-logger.properties
  - single-node was writing to admin.log  now writing to singlenode.log
  - container would only write to .log because ${container} is not set.
- Updated .bat files replacing $ with % for env vars.  Thus the .bat files wouldn't log properly.
