### PR TITLE
XD-1053: Add 'http get' command to shell

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ def moduleProjects() {
 }
 
 ext {
-	jackson1Version = '1.9.9'
+	jackson1Version = '1.9.13'
 	jacksonVersion = '2.2.2'
 	jsonPathVersion = '0.8.1'
 	junitVersion = '4.11'
@@ -857,7 +857,7 @@ project('spring-xd-rest-client') {
 		compile "org.springframework:spring-web:$springVersion"
 		compile project(':spring-xd-rest-domain')
 		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		compile 'org.codehaus.jackson:jackson-core-asl:1.9.13'
+		compile "org.codehaus.jackson:jackson-core-asl:$jackson1Version"
 	 compile "joda-time:joda-time:$jodaTimeVersion"
 	}
 }
@@ -874,7 +874,7 @@ project('spring-xd-rest-domain') {
 		}
 		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
 		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		compile 'org.codehaus.jackson:jackson-core-asl:1.9.13'
+		compile "org.codehaus.jackson:jackson-core-asl:$jackson1Version"
 	}
 }
 
@@ -1174,7 +1174,7 @@ project('spring-xd-shell') {
 	}
 
 	test {
-	     exclude '**/MailCommand*'
+		exclude '**/MailCommand*'
 	}
 
 	dependencies {
@@ -1191,7 +1191,8 @@ project('spring-xd-shell') {
 		testCompile "uk.co.modular-it:hamcrest-date:$hamcrestDateVersion"
 		runtime "org.slf4j:jcl-over-slf4j:$slf4jVersion",
 				"org.slf4j:slf4j-log4j12:$slf4jVersion",
-				"log4j:log4j:$log4jVersion"
+				"log4j:log4j:$log4jVersion",
+				"org.codehaus.jackson:jackson-mapper-asl:$jackson1Version"
 		testCompile "com.icegreen:greenmail:1.3.1b"
 		testCompile "commons-io:commons-io:2.3"
 


### PR DESCRIPTION
Updates Jackson to 1.9.13 and adds an explicit jackson-mapper-asl
to shell to prevent a 1.8.\* version being pulled in transitively.
