### PR TITLE
XD-1111 deleteAll from RedisContainerRuntimeInformationRepository

### DIFF
--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractShellIntegrationTest {
 
 	@AfterClass
 	public static void shutdown() {
-		runtimeInformationRepository.deleteAll();
+		runtimeInformationRepository.delete(application.getContainerContext().getId());
 		logger.info("Stopping XD Shell");
 		shell.stop();
 		if (application != null) {


### PR DESCRIPTION
 in @AfterClass seems to do the trick.
