### PR TITLE
XD-1146 Add Async Request/Response to MessageBus

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/LocalMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/LocalMessageBus.java
@@ -186,6 +186,18 @@ public class LocalMessageBus extends MessageBusSupport implements ApplicationCon
 		bridge(moduleOutputChannel, registeredChannel, "outbound." + registeredChannel.getComponentName());
 	}
 
+	@Override
+	public void bindRequestor(String name, MessageChannel requests, MessageChannel responses) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException("Auto-generated method stub");
+	}
+
+	@Override
+	public void bindResponder(String name, String requestorName, MessageChannel requests, MessageChannel responses) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException("Auto-generated method stub");
+	}
+
 	protected <T extends AbstractMessageChannel> T createSharedChannel(String name, Class<T> requiredType) {
 		try {
 			T channel = requiredType.newInstance();

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/MessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/MessageBus.java
@@ -101,4 +101,8 @@ public interface MessageBus {
 	 */
 	void unbindProducer(String name, MessageChannel channel);
 
+	void bindRequestor(String name, MessageChannel requests, MessageChannel responses);
+
+	void bindResponder(String name, String requestorName, MessageChannel requests, MessageChannel responses);
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/rabbit/RabbitMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/rabbit/RabbitMessageBus.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.x.rabbit;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.aopalliance.aop.Advice;
 import org.apache.commons.logging.Log;
@@ -31,7 +32,10 @@ import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.http.MediaType;
+import org.springframework.integration.amqp.AmqpHeaders;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
 import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
@@ -40,6 +44,7 @@ import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.mapping.AbstractHeaderMapper;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.x.bus.Binding;
 import org.springframework.integration.x.bus.MessageBus;
 import org.springframework.integration.x.bus.MessageBusSupport;
@@ -48,7 +53,9 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.SubscribableChannel;
+import org.springframework.util.AlternativeJdkIdGenerator;
 import org.springframework.util.Assert;
+import org.springframework.util.IdGenerator;
 
 /**
  * A {@link MessageBus} implementation backed by RabbitMQ.
@@ -71,6 +78,10 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 
 	private final DefaultAmqpHeaderMapper mapper;
 
+	private final IdGenerator idGenerator = new AlternativeJdkIdGenerator();
+
+	private final GenericApplicationContext autoDeclareContext = new GenericApplicationContext();
+
 	public RabbitMessageBus(ConnectionFactory connectionFactory, MultiTypeCodec<Object> codec) {
 		Assert.notNull(connectionFactory, "connectionFactory must not be null");
 		Assert.notNull(codec, "codec must not be null");
@@ -78,11 +89,13 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		this.rabbitTemplate.setConnectionFactory(connectionFactory);
 		this.rabbitTemplate.afterPropertiesSet();
 		this.rabbitAdmin = new RabbitAdmin(connectionFactory);
+		this.autoDeclareContext.refresh();
+		this.rabbitAdmin.setApplicationContext(this.autoDeclareContext);
 		this.rabbitAdmin.afterPropertiesSet();
 		this.mapper = new DefaultAmqpHeaderMapper();
 		this.mapper.setRequestHeaderNames(new String[] { AbstractHeaderMapper.STANDARD_REQUEST_HEADER_NAME_PATTERN,
 			ORIGINAL_CONTENT_TYPE_HEADER });
-		setCodec(codec);
+		this.setCodec(codec);
 	}
 
 	@Override
@@ -155,14 +168,58 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		doRegisterProducer(name, moduleOutputChannel, fanout);
 	}
 
-	private void doRegisterProducer(final String name, MessageChannel moduleOutputChannel, MessageHandler delegate) {
+	private void doRegisterProducer(final String name, MessageChannel moduleOutputChannel,
+			MessageHandler delegate) {
+		this.doRegisterProducer(name, moduleOutputChannel, delegate, null);
+	}
+
+	private void doRegisterProducer(final String name, MessageChannel moduleOutputChannel,
+			MessageHandler delegate, String replyTo) {
 		Assert.isInstanceOf(SubscribableChannel.class, moduleOutputChannel);
-		MessageHandler handler = new SendingHandler(delegate);
+		MessageHandler handler = new SendingHandler(delegate, replyTo);
 		EventDrivenConsumer consumer = new EventDrivenConsumer((SubscribableChannel) moduleOutputChannel, handler);
 		consumer.setBeanName("outbound." + name);
 		consumer.afterPropertiesSet();
 		addBinding(Binding.forProducer(moduleOutputChannel, consumer));
 		consumer.start();
+	}
+
+	@Override
+	public void bindRequestor(String name, MessageChannel requests, MessageChannel responses) {
+		if (logger.isInfoEnabled()) {
+			logger.info("declaring queues for requestor: " + name);
+		}
+		String queueName = name + ".requests";
+		this.rabbitAdmin.declareQueue(new Queue(queueName));
+		AmqpOutboundEndpoint queue = new AmqpOutboundEndpoint(rabbitTemplate);
+		queue.setRoutingKey(queueName); // uses default exchange
+		queue.setHeaderMapper(mapper);
+		queue.afterPropertiesSet();
+
+		String replyQueueName = name + ".responses." + this.idGenerator.generateId();
+		this.doRegisterProducer(name, requests, queue, replyQueueName);
+		Queue replyQueue = new Queue(replyQueueName, false, false, true); // auto-delete
+		this.rabbitAdmin.declareQueue(replyQueue);
+		// register with context so it will be redeclared after a connection failure
+		this.autoDeclareContext.getBeanFactory().registerSingleton(replyQueueName, replyQueue);
+		this.doRegisterConsumer(name, responses, Collections.singletonList(MediaType.ALL), replyQueue);
+	}
+
+	@Override
+	public void bindResponder(String name, String requestorName, MessageChannel requests, MessageChannel responses) {
+		if (logger.isInfoEnabled()) {
+			logger.info("declaring queue for responder: " + name + " (" + requestorName + ")");
+		}
+		Queue requestQueue = new Queue(requestorName + ".requests");
+		this.rabbitAdmin.declareQueue(requestQueue);
+		this.doRegisterConsumer(name, requests, Collections.singletonList(MediaType.ALL), requestQueue);
+
+		AmqpOutboundEndpoint replyQueue = new AmqpOutboundEndpoint(rabbitTemplate);
+		replyQueue.setBeanFactory(new DefaultListableBeanFactory());
+		replyQueue.setRoutingKeyExpression("headers['" + AmqpHeaders.REPLY_TO + "']");
+		replyQueue.setHeaderMapper(mapper);
+		replyQueue.afterPropertiesSet();
+		doRegisterProducer(name, responses, replyQueue);
 	}
 
 	@Override
@@ -174,8 +231,11 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 
 		private final MessageHandler delegate;
 
-		private SendingHandler(MessageHandler delegate) {
+		private final String replyTo;
+
+		private SendingHandler(MessageHandler delegate, String replyTo) {
 			this.delegate = delegate;
+			this.replyTo = replyTo;
 		}
 
 		@Override
@@ -183,6 +243,11 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 			// TODO: rabbit wire data pluggable format?
 			Message<?> messageToSend = transformPayloadForProducerIfNecessary(message,
 					MediaType.APPLICATION_OCTET_STREAM);
+			if (replyTo != null) {
+				messageToSend = MessageBuilder.fromMessage(messageToSend)
+						.setHeader(AmqpHeaders.REPLY_TO, this.replyTo)
+						.build();
+			}
 			this.delegate.handleMessage(messageToSend);
 		}
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/redis/RedisMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/redis/RedisMessageBus.java
@@ -131,6 +131,18 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 	}
 
 	@Override
+	public void bindRequestor(String name, MessageChannel requests, MessageChannel responses) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException("Auto-generated method stub");
+	}
+
+	@Override
+	public void bindResponder(String name, String requestorName, MessageChannel requests, MessageChannel responses) {
+		// TODO Auto-generated method stub
+		throw new UnsupportedOperationException("Auto-generated method stub");
+	}
+
+	@Override
 	public void destroy() {
 		stopBindings();
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/MasterSlavePlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/MasterSlavePlugin.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.plugins.stream;
+
+import org.springframework.integration.x.bus.MessageBus;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.util.Assert;
+import org.springframework.xd.module.DeploymentMetadata;
+import org.springframework.xd.module.Module;
+
+
+/**
+ * A plugin for modules that (perhaps in addition to normal 'input' and 'output' channels) has two pairs a request/reply
+ * channels where one instance can farm out work to other instances and collect responses.
+ * 
+ * @author Gary Russell
+ */
+public class MasterSlavePlugin extends StreamPlugin {
+
+	@Override
+	public void postProcessModule(Module module) {
+		super.postProcessModule(module); // may have normal input and output channels
+		MessageBus bus = findMessageBus(module);
+		bindRequestor(module, bus);
+		bindResponder(module, bus);
+	}
+
+	private void bindRequestor(Module module, MessageBus bus) {
+		DeploymentMetadata md = module.getDeploymentMetadata();
+		MessageChannel requests = module.getComponent("requests.out", MessageChannel.class);
+		if (requests != null) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("binding request/response channels [requests.out, responses.in] for " + module);
+			}
+			MessageChannel responses = module.getComponent("responses.in", MessageChannel.class);
+			Assert.notNull(responses);
+			String name = this.requestorName(md);
+			bus.bindRequestor(name, requests, responses);
+		}
+	}
+
+	private void bindResponder(Module module, MessageBus bus) {
+		DeploymentMetadata md = module.getDeploymentMetadata();
+		MessageChannel requests = module.getComponent("requests.in", MessageChannel.class);
+		if (requests != null) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("binding request/response channels [requests.in, responses.out] for " + module);
+			}
+			MessageChannel responses = module.getComponent("responses.out", MessageChannel.class);
+			Assert.notNull(responses);
+			String name = this.responderName(md);
+			// TODO: add the capability for a responder to be bound to a different requestor
+			String requestorName = this.requestorName(md);
+			bus.bindResponder(name, requestorName, requests, responses);
+		}
+	}
+
+	private String requestorName(DeploymentMetadata md) {
+		return md.getGroup() + "." + md.getIndex() + ".requestor";
+	}
+
+	private String responderName(DeploymentMetadata md) {
+		return md.getGroup() + "." + md.getIndex() + ".responder";
+	}
+
+	@Override
+	public void beforeShutdown(Module module) {
+		super.beforeShutdown(module);
+		DeploymentMetadata md = module.getDeploymentMetadata();
+		MessageBus bus = findMessageBus(module);
+		if (bus != null) {
+			MessageChannel channel = module.getComponent("requests.out", MessageChannel.class);
+			if (channel != null) {
+				bus.unbindProducer(this.requestorName(md), channel);
+			}
+			channel = module.getComponent("responses.in", MessageChannel.class);
+			if (channel != null) {
+				bus.unbindConsumer(this.requestorName(md), channel);
+			}
+			channel = module.getComponent("responses.out", MessageChannel.class);
+			if (channel != null) {
+				bus.unbindProducer(this.requestorName(md), channel);
+			}
+			channel = module.getComponent("requests.in", MessageChannel.class);
+			if (channel != null) {
+				bus.unbindConsumer(this.requestorName(md), channel);
+			}
+		}
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/StreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/StreamPlugin.java
@@ -87,7 +87,7 @@ public class StreamPlugin implements Plugin {
 		bindProducers(module, bus);
 	}
 
-	private MessageBus findMessageBus(Module module) {
+	protected final MessageBus findMessageBus(Module module) {
 		MessageBus messageBus = null;
 		try {
 			messageBus = module.getComponent(MessageBus.class);

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/MessageBusSupportTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/MessageBusSupportTests.java
@@ -253,6 +253,15 @@ public class MessageBusSupportTests {
 		@Override
 		public void bindProducer(String name, MessageChannel channel, boolean aliasHint) {
 		}
+
+		@Override
+		public void bindRequestor(String name, MessageChannel requests, MessageChannel responses) {
+		}
+
+		@Override
+		public void bindResponder(String name, String requestorName, MessageChannel requests, MessageChannel responses) {
+		}
+
 	}
 
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/RabbitMasterSlavePluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/RabbitMasterSlavePluginTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.plugins.stream;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.integration.channel.AbstractPollableChannel;
+import org.springframework.integration.channel.AbstractSubscribableChannel;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.integration.x.bus.MessageBus;
+import org.springframework.integration.x.bus.serializer.AbstractCodec;
+import org.springframework.integration.x.bus.serializer.CompositeCodec;
+import org.springframework.integration.x.bus.serializer.MultiTypeCodec;
+import org.springframework.integration.x.bus.serializer.kryo.PojoCodec;
+import org.springframework.integration.x.bus.serializer.kryo.TupleCodec;
+import org.springframework.integration.x.rabbit.RabbitMessageBus;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.xd.module.DeploymentMetadata;
+import org.springframework.xd.module.Module;
+import org.springframework.xd.module.ModuleDefinition;
+import org.springframework.xd.module.ModuleType;
+import org.springframework.xd.module.SimpleModule;
+import org.springframework.xd.test.rabbit.RabbitTestSupport;
+import org.springframework.xd.tuple.Tuple;
+
+
+/**
+ * 
+ * @author Gary Russell
+ */
+public class RabbitMasterSlavePluginTests {
+
+	@Rule
+	public RabbitTestSupport rabbitAvailableRule = new RabbitTestSupport();
+
+	@Test
+	public void testSimple() {
+		RabbitMessageBus bus = new RabbitMessageBus(rabbitAvailableRule.getResource(), getCodec());
+		MasterSlavePlugin plugin = new MasterSlavePlugin();
+
+		Module module = mock(Module.class);
+		when(module.getDeploymentMetadata()).thenReturn(new DeploymentMetadata("foo", 1));
+		when(module.getType()).thenReturn(ModuleType.processor);
+		when(module.getName()).thenReturn("testing");
+		when(module.getComponent(MessageBus.class)).thenReturn(bus);
+		AbstractSubscribableChannel requestsOut = new DirectChannel();
+		AbstractPollableChannel requestsIn = new QueueChannel();
+		AbstractSubscribableChannel responsesOut = new DirectChannel();
+		AbstractPollableChannel responsesIn = new QueueChannel();
+		when(module.getComponent("requests.out", MessageChannel.class)).thenReturn(requestsOut);
+		when(module.getComponent("requests.in", MessageChannel.class)).thenReturn(requestsIn);
+		when(module.getComponent("responses.out", MessageChannel.class)).thenReturn(responsesOut);
+		when(module.getComponent("responses.in", MessageChannel.class)).thenReturn(responsesIn);
+
+		plugin.postProcessModule(module);
+
+		requestsOut.send(new GenericMessage<>("foo"));
+		Message<?> request = requestsIn.receive(5000);
+		assertNotNull(request);
+
+		responsesOut.send(MessageBuilder.withPayload("bar").copyHeaders(request.getHeaders()).build());
+		assertNotNull(responsesIn.receive(5000));
+	}
+
+	@Test
+	public void testContextModule() {
+		ModuleDefinition definition = new ModuleDefinition("foo", ModuleType.processor, new ClassPathResource(
+				"RabbitMasterSlavePluginTests-context.xml", this.getClass()));
+		DeploymentMetadata metadata = new DeploymentMetadata("bar", 1);
+		Module module = new SimpleModule(definition, metadata);
+		RabbitMessageBus bus = new RabbitMessageBus(rabbitAvailableRule.getResource(), getCodec());
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.getBeanFactory().registerSingleton("bus", bus);
+		context.refresh();
+		module.setParentContext(context);
+		MasterSlavePlugin plugin = new MasterSlavePlugin();
+		module.initialize();
+		plugin.postProcessModule(module);
+
+		ApplicationContext moduleContext = TestUtils.getPropertyValue(module, "context", ApplicationContext.class);
+		MessageChannel requestsOut = moduleContext.getBean("requests.out", MessageChannel.class);
+		requestsOut.send(new GenericMessage<>("foo"));
+
+		PollableChannel responsesIn = moduleContext.getBean("responses.in", PollableChannel.class);
+		@SuppressWarnings("unchecked")
+		Message<String> response = (Message<String>) responsesIn.receive(5000);
+		assertNotNull(response);
+		assertThat(response.getPayload(), equalTo("FOO"));
+	}
+
+	@SuppressWarnings("unchecked")
+	protected MultiTypeCodec<Object> getCodec() {
+		Map<Class<?>, AbstractCodec<?>> codecs = new HashMap<Class<?>, AbstractCodec<?>>();
+		codecs.put(Tuple.class, new TupleCodec());
+		return new CompositeCodec(codecs, new PojoCodec());
+	}
+
+}

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/plugins/stream/RabbitMasterSlavePluginTests-context.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/plugins/stream/RabbitMasterSlavePluginTests-context.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+
+	<!--
+		Test master/slave module. Module instances are peers; one is the master. 
+		Modules may also have standard input/output channels.
+	-->
+
+	<!-- Module Master Part -->
+
+	<int:channel id="requests.out" />
+
+	<int:channel id="responses.in">
+		<int:queue />
+	</int:channel>
+
+	<!-- Module Slave Part -->	
+
+	<int:channel id="requests.in" />
+
+	<int:transformer input-channel="requests.in" output-channel="responses.out" expression="payload.toUpperCase()" />
+
+	<int:channel id="responses.out" />
+
+</beans>


### PR DESCRIPTION
**Initial commit for review only - but I would like feedback before proceeding much further**

Add async request/response support to the MessageBus.

Initially to support batch partitioning over supported
transports, but generally applicable.

Initial prototype.

Only a RabbitMQ implementatio at this time.
