### PR TITLE
XD-1103: Add explicit Tomcat DataSource to jdbc sink

### DIFF
--- a/modules/sink/jdbc/config/jdbc.properties
+++ b/modules/sink/jdbc/config/jdbc.properties
@@ -1,0 +1,29 @@
+options.tableName.description = The database table to which the data will be written. Default is the stream name.
+options.tableName.type = String
+
+options.columns.description = The database columns to map the data to.
+options.columns.default = payload
+options.columns.type = String
+
+options.initializeDatabase.description = Whether the database initialization script should be run.
+options.initializeDatabase.default = true
+options.initializeDatabase.type = boolean
+
+options.initializerScript.description = The name of the SQL script (in /config) to run if 'initializeDatabase' is set.
+options.initializerScript.default = init_db.sql
+options.initalizerScript.type = String
+
+options.driverClass.description = The JDBC driver to use.
+options.driverClass.type = String
+
+options.url.description = The JDBC URL for the database.
+options.url.type = String
+
+options.username.description = The JDBC username.
+options.username.type = String
+
+options.password.description = The JDBC password.
+options.password.type = String
+
+options.inputType.description = How this module should interpret messages it consumes.
+options.inputType.type = org.springframework.http.MediaType

--- a/modules/sink/jdbc/config/jdbc.xml
+++ b/modules/sink/jdbc/config/jdbc.xml
@@ -18,19 +18,19 @@
 	<channel id="values" />
 
 	<int-jdbc:outbound-channel-adapter
-		query="insert into ${tablename:${xd.stream.name}} (#{transformer.columns}) values(#{transformer.values})"
+		query="insert into ${tableName:${xd.stream.name}} (#{transformer.columns}) values(#{transformer.values})"
 		data-source="dataSource" channel="values" />
 
 	<beans:bean id="transformer"
 		class="org.springframework.xd.jdbc.JdbcMessagePayloadTransformer">
-		<beans:property name="columnNames" value="${columns:payload}" />
+		<beans:property name="columnNames" value="${columns}" />
 	</beans:bean>
 
 	<beans:bean id="dataSourceInitializer"
 		class="org.springframework.jdbc.datasource.init.DataSourceInitializer">
 		<beans:property name="databasePopulator" ref="databasePopulator" />
 		<beans:property name="dataSource" ref="dataSource" />
-		<beans:property name="enabled" value="${initializeDatabase:true}" />
+		<beans:property name="enabled" value="${initializeDatabase}" />
 	</beans:bean>
 
 	<beans:bean id="databasePopulator"
@@ -38,16 +38,17 @@
 		<beans:property name="scripts"
 			value="${xd.config.home}/${initializerScript:init_db.sql}" />
 		<beans:property name="ignoreFailedDrops" value="true" />
-		<beans:property name="tableName" value="${tablename:${xd.stream.name}}" />
+		<beans:property name="tableName" value="${tableName:${xd.stream.name}}" />
 	</beans:bean>
 
 	<context:annotation-config/>
 
-	<bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource" xmlns="http://www.springframework.org/schema/beans">
-		<property name="driverClass" value="${driverClass:spring.datasource.driverClass}"/>
-		<property name="url" value="${url:spring.datasource.url}"/>
-		<property name="username" value="${username:spring.datasource.username}"/>
-		<property name="password" value="${password:spring.datasource.password}"/>
+	<bean id="dataSource" class="org.apache.tomcat.jdbc.pool.DataSource" destroy-method="close" xmlns="http://www.springframework.org/schema/beans">
+		<property name="driverClassName" value="${driverClass:${spring.datasource.driverClassName}}"/>
+		<property name="url" value="${url:${spring.datasource.url}}"/>
+		<property name="username" value="${username:${spring.datasource.username}}"/>
+		<property name="password" value="${password:${spring.datasource.password}}"/>
+		<property name="initialSize" value="0" />
 	</bean>
 
 	<context:property-placeholder

--- a/src/test/scripts/jdbc_tests
+++ b/src/test/scripts/jdbc_tests
@@ -22,7 +22,7 @@ echo -e "\n\n Test 1. tail | jdbc stream with pre-initialized database"
 
 sqlite3 $DB_FILE 'create table blah (col1 varchar, col2 varchar, col3 varchar)'
 
-create_stream jdbc1 "tail --lines=10 --name=$TEST_DIR/jdbc1.data --fileDelay=1000 | jdbc --driverClass=org.sqlite.JDBC --username='' --password='' --url=jdbc:sqlite:$DB_FILE --initializeDatabase=false --columns=col1,col2,col3 --tablename=blah"
+create_stream jdbc1 "tail --lines=10 --name=$TEST_DIR/jdbc1.data --fileDelay=1000 | jdbc --driverClass=org.sqlite.JDBC --username='' --password='' --url=jdbc:sqlite:$DB_FILE --initializeDatabase=false --columns=col1,col2,col3 --tableName=blah"
 
 # Add some data to the file
 echo '{"col1":"x", "col2":"y", "col3":"z"}' >> $TEST_DIR/jdbc1.data


### PR DESCRIPTION
This provides pooling for the sink without the problems found by using the
corresponding boot annotated configuration class, which was ignoring 
DSL-supplied options.

Also changes "tablename" property to "tableName"
