### PR TITLE
XD-1158 Added scripts to exercise jms and mqtt.

### DIFF
--- a/src/test/scripts/mqtt_stream_tests
+++ b/src/test/scripts/mqtt_stream_tests
@@ -11,7 +11,7 @@ set -e
 
 echo -e '*** Test 1. mqtt | file stream\n'
 
-create_stream 'mqttSourceTest' 'mqtt | file --dir=/tmp/xdtest/basic' 'false'
+create_stream 'mqttSourceTest' 'mqtt --url='tcp://localhost:1883' --topics='xd.mqtt.test' | file --dir=/tmp/xdtest/basic' 'false'
 deploy_stream 'mqttSourceTest'
 
 mqtt_post_data_and_check_result() {


### PR DESCRIPTION
- For the jms tests the tester sends a http message to an activemq instance at localhost 8161.
  So for this test you will need to install activemq.
- For the mqtt tests the XD is still using the mqtt M1 release that has a bug.  The current
  workaround is to reference the snapshot instead.
  - So in your build.gradle file replace springIntegrationMQTTVersion = '4.0.0.M1' with springIntegrationMQTTVersion = '4.0.0.BUILD-SNAPSHOT'
  - then run a ./gradlew clean dist
  - If you haven't already install the mqtt plugin to RabbitMQ.  The instructions are located here: https://www.rabbitmq.com/mqtt.html
