### PR TITLE
XD-1171 Assign unique id for launcher

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/XDContainer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/XDContainer.java
@@ -97,7 +97,7 @@ public class XDContainer implements SmartLifecycle {
 
 
 	public String getId() {
-		return (this.context != null) ? this.context.getId() : "";
+		return this.id;
 	}
 
 	public String getHostName() {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/LauncherApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/LauncherApplication.java
@@ -50,6 +50,7 @@ public class LauncherApplication {
 
 	public static void publishContainerStarted(ConfigurableApplicationContext context) {
 		XDContainer container = new XDContainer();
+		context.setId(container.getId());
 		container.setContext(context);
 		context.publishEvent(new ContainerStartedEvent(container));
 	}


### PR DESCRIPTION
- Use the XDContainer's randomly generated UUID as its id
- Use XDContainer's id as the launcher context id
