### PR TITLE
XD-1161 Fix hdfs writing not to overwrite when stream restarted (wait SHDP PR#39)

### DIFF
--- a/modules/sink/hdfs.properties
+++ b/modules/sink/hdfs.properties
@@ -1,13 +1,16 @@
 options.directory.description = where to output the files in the Hadoop FileSystem
 options.directory.type = String
-options.directory.default = /xd
+
+options.overwrite.description = if writer is allowed to overwrite files in Hadoop FileSystem
+options.overwrite.type = boolean
+options.overwrite.default = false
 
 options.fileName.description = the base filename to use for the created files
 options.fileName.type = String
 
-options.fileSuffix.description = the base filename suffix to use for the created files
-options.fileSuffix.type = String
-options.fileSuffix.default = .txt
+options.fileExtension.description = the base filename extension to use for the created files
+options.fileExtension.type = String
+options.fileExtension.default = txt
 
 options.rolloverSize.description = threshold in bytes when file will be automatically rolled over
 options.rolloverSize.type = String

--- a/modules/sink/hdfs.xml
+++ b/modules/sink/hdfs.xml
@@ -24,22 +24,22 @@
 	</int-hadoop:rollover-strategy>
 
 	<!--
-	Starting / for first static needed to start with a directory till we support
-	this use case in shdp store. Path passed into first naming strategy is
-	a directory(base-path) from a writer.
 	Order options needed because xml parser don't yet support
-	ordering in a way it exist in this xml
+	ordering in a way it exist in this xml.
+	default option for fileName set here due to variable.
 	-->
 	<int-hadoop:naming-strategy>
-		<int-hadoop:static order="1" file-name="/${xd.stream.name}/${fileName:${xd.stream.name}}" />
+		<int-hadoop:static order="1" name="${fileName:${xd.stream.name}}" />
 		<int-hadoop:rolling order="2" />
-		<int-hadoop:static order="3" file-name="${fileSuffix}" />
+		<int-hadoop:static order="3" prefix="." name="${fileExtension}" />
 		<int-hadoop:codec />
 	</int-hadoop:naming-strategy>
 
+	<!-- default option for directory set here due to variable -->
 	<int-hadoop:store-writer
-		base-path="${directory}"
+		base-path="${directory:/xd/${xd.stream.name}}"
 		codec="${codec}"
+		overwrite="${overwrite}"
 		idle-timeout="${idleTimeout}"
 		in-use-suffix="${inUseSuffix}"
 		in-use-prefix="${inUsePrefix}"

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/NamingStrategyParser.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/NamingStrategyParser.java
@@ -52,11 +52,9 @@ public class NamingStrategyParser extends AbstractBeanDefinitionParser {
 		ManagedList<RuntimeBeanReference> strategies = new ManagedList<RuntimeBeanReference>();
 		List<Element> staticElements = DomUtils.getChildElementsByTagName(element, "static");
 		List<Element> rollingElements = DomUtils.getChildElementsByTagName(element, "rolling");
-		List<Element> renamingElements = DomUtils.getChildElementsByTagName(element, "renaming");
 		List<Element> codecElements = DomUtils.getChildElementsByTagName(element, "codec");
 
-		if (staticElements.size() == 0 && rollingElements.size() == 0 && renamingElements.size() == 0
-				&& codecElements.size() == 0) {
+		if (staticElements.size() == 0 && rollingElements.size() == 0 && codecElements.size() == 0) {
 			builder = BeanDefinitionBuilder.genericBeanDefinition(StaticFileNamingStrategy.class);
 			return builder.getBeanDefinition();
 		}
@@ -66,7 +64,8 @@ public class NamingStrategyParser extends AbstractBeanDefinitionParser {
 		for (Element e : staticElements) {
 			BeanDefinitionBuilder nestedBuilder = BeanDefinitionBuilder.genericBeanDefinition(StaticFileNamingStrategy.class);
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(nestedBuilder, e, "order");
-			IntegrationNamespaceUtils.setValueIfAttributeDefined(nestedBuilder, e, "file-name", "fileName");
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(nestedBuilder, e, "name");
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(nestedBuilder, e, "prefix");
 			String nestedBeanName = BeanDefinitionReaderUtils.registerWithGeneratedName(
 					nestedBuilder.getBeanDefinition(),
 					parserContext.getRegistry());
@@ -76,6 +75,7 @@ public class NamingStrategyParser extends AbstractBeanDefinitionParser {
 		for (Element e : rollingElements) {
 			BeanDefinitionBuilder nestedBuilder = BeanDefinitionBuilder.genericBeanDefinition(RollingFileNamingStrategy.class);
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(nestedBuilder, e, "order");
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(nestedBuilder, e, "prefix");
 			String nestedBeanName = BeanDefinitionReaderUtils.registerWithGeneratedName(
 					nestedBuilder.getBeanDefinition(),
 					parserContext.getRegistry());

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterParser.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterParser.java
@@ -48,6 +48,7 @@ public class StoreWriterParser extends AbstractBeanDefinitionParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "in-use-suffix", "inWritingSuffix");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "in-use-prefix", "inWritingPrefix");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "idle-timeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "overwrite");
 
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "naming-strategy",
 				"fileNamingStrategy");

--- a/spring-xd-hadoop/src/main/resources/org/springframework/xd/integration/hadoop/config/spring-integration-hadoop.xsd
+++ b/spring-xd-hadoop/src/main/resources/org/springframework/xd/integration/hadoop/config/spring-integration-hadoop.xsd
@@ -68,6 +68,7 @@
 			<xsd:attribute name="base-path" use="optional"/>
 			<xsd:attribute name="configuration" use="optional" default="hadoopConfiguration"/>
 			<xsd:attribute name="codec" use="optional"/>
+			<xsd:attribute name="overwrite" use="optional"/>
 			<xsd:attribute name="idle-timeout" use="optional"/>
 			<xsd:attribute name="in-use-suffix" use="optional"/>
 			<xsd:attribute name="in-use-prefix" use="optional"/>
@@ -133,7 +134,8 @@
 
 	<xsd:complexType name="staticNamingStrategyType" mixed="true">
 		<xsd:attribute name="order" type="xsd:integer" use="optional"/>
-		<xsd:attribute name="file-name" type="xsd:string" use="optional"/>
+		<xsd:attribute name="prefix" type="xsd:string" use="optional"/>
+		<xsd:attribute name="name" type="xsd:string" use="optional"/>
 	</xsd:complexType>
 
 	<xsd:complexType name="codecNamingStrategyType" mixed="true">
@@ -142,6 +144,7 @@
 
 	<xsd:complexType name="rollingNamingStrategyType" mixed="true">
 		<xsd:attribute name="order" type="xsd:integer" use="optional"/>
+		<xsd:attribute name="prefix" type="xsd:string" use="optional"/>
 	</xsd:complexType>
 
 </xsd:schema>


### PR DESCRIPTION
- Depends on SHDP-243 and its PR 39
- Naming strategies are now ordered so that we can have base file name
  and suffix before and after rolling part. i.e. data-1.txt,
  data-2.txt, etc.
- Added missing default options to hdfs.properties and changed
  hdfs.xml accordingly
- Forcing new directory for every stream is done in naming by using
  "/${xd.stream.name}/${fileName:${xd.stream.name}}". afaik, default
  value for option with variable can't be yet defined in hdfs.properties.
