### PR TITLE
reset mqtt.xml to use mqtt.default.topic

### DIFF
--- a/modules/source/mqtt/config/mqtt.xml
+++ b/modules/source/mqtt/config/mqtt.xml
@@ -20,7 +20,7 @@
 		auto-startup="false"
 		client-id="${clientId:${mqtt.default.client.id}.src}"
 		url="${url:${mqtt.url}}"
-		topics="${topics:${mqtt.default.topics}}"
+		topics="${topic:${mqtt.default.topic}}"
 		client-factory="clientFactory"
 		channel="output"/>
 


### PR DESCRIPTION
Last change used topics and thus the sink failed.
If we don't want this change then we will have to add mqtt.default.topic to the mqtt.properties in the config directory.
