### PR TITLE
[DO NOT MERGE YET] XD-1190 Setup PropertySource precedence for module props

### DIFF
--- a/modules/sink/rabbit.xml
+++ b/modules/sink/rabbit.xml
@@ -18,9 +18,6 @@
 
 	<rabbit:template id="rabbitTemplate" connection-factory="rabbitConnectionFactory"/>
 
-	<context:property-placeholder location="${xd.config.home}/${configProperties:rabbit}.properties"
-		ignore-resource-not-found="true" />
-
 	<rabbit:connection-factory id="rabbitConnectionFactory" host="${host:${spring.rabbitmq.host:localhost}}"
 		port="${port:${spring.rabbitmq.port:5672}}" virtual-host="${vhost:${spring.rabbitmq.virtualHost:/}}"
 		username="${username:${spring.rabbitmq.username:guest}}" password="${password:${spring.rabbitmq.password:guest}}"/>

--- a/modules/source/rabbit.xml
+++ b/modules/source/rabbit.xml
@@ -18,9 +18,6 @@
 
 	<int:channel id="output" />
 
-	<context:property-placeholder
-		location="${xd.config.home}/${configProperties:rabbit}.properties"
-		ignore-resource-not-found="true" />
 	<rabbit:connection-factory id="rabbitConnectionFactory" host="${host:${spring.rabbitmq.host:localhost}}"
 		port="${port:${spring.rabbitmq.port:5672}}" virtual-host="${vhost:${spring.rabbitmq.virtualHost:/}}"
 		username="${username:${spring.rabbitmq.username:guest}}" password="${password:${spring.rabbitmq.password:guest}}"/>

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/Module.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/Module.java
@@ -31,6 +31,10 @@ import org.springframework.xd.module.ModuleType;
  */
 public interface Module extends Lifecycle {
 
+	public static final String XD_CONFIG_HOME = "${xd.config.home}";
+
+	public static final String MODULES_CONFIG_HOME = "${xd.config.home}/modules";
+
 	void initialize();
 
 	/**

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadata.java
@@ -43,7 +43,7 @@ public class DefaultModuleOptionsMetadata implements ModuleOptionsMetadata {
 			@Override
 			@SuppressWarnings("unchecked")
 			public EnumerablePropertySource<?> asPropertySource() {
-				return new MapPropertySource("options", (Map) raw);
+				return new MapPropertySource(MODULE_OPTIONS_PROPERTY_SOURCE_NAME, (Map) raw);
 			}
 		};
 	}

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOptionsMetadata.java
@@ -28,6 +28,8 @@ import org.springframework.validation.BindException;
  */
 public interface ModuleOptionsMetadata extends Iterable<ModuleOption> {
 
+	public static final String MODULE_OPTIONS_PROPERTY_SOURCE_NAME = "moduleOptions";
+
 	public abstract ModuleOptions interpolate(Map<String, String> raw) throws BindException;
 
 }

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/PojoModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/PojoModuleOptionsMetadata.java
@@ -230,7 +230,7 @@ public class PojoModuleOptionsMetadata implements ModuleOptionsMetadata {
 
 			@Override
 			public EnumerablePropertySource<?> asPropertySource() {
-				return new EnumerablePropertySource<BeanWrapper>(this.toString(), beanWrapper) {
+				return new EnumerablePropertySource<BeanWrapper>(MODULE_OPTIONS_PROPERTY_SOURCE_NAME, beanWrapper) {
 
 					@Override
 					public String[] getPropertyNames() {
@@ -273,12 +273,13 @@ public class PojoModuleOptionsMetadata implements ModuleOptionsMetadata {
 		DataBinder dataBinder = new DataBinder(beanWrapper.getWrappedInstance());
 		dataBinder.setIgnoreUnknownFields(false);
 		MutablePropertySources mps = new MutablePropertySources();
-		mps.addFirst(new MapPropertySource("options", (Map) raw));
+		mps.addFirst(new MapPropertySource(MODULE_OPTIONS_PROPERTY_SOURCE_NAME, (Map) raw));
 		try {
 			dataBinder.bind(new PropertySourcesPropertyValues(mps));
 		}
 		catch (InvalidPropertyException e) {
-			dataBinder.getBindingResult().addError(new FieldError("options", e.getPropertyName(), e.getMessage()));
+			dataBinder.getBindingResult().addError(
+					new FieldError(MODULE_OPTIONS_PROPERTY_SOURCE_NAME, e.getPropertyName(), e.getMessage()));
 		}
 
 		CustomValidatorBean validator = new CustomValidatorBean();

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/SimpleModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/SimpleModuleOptionsMetadata.java
@@ -49,10 +49,11 @@ public class SimpleModuleOptionsMetadata implements ModuleOptionsMetadata {
 	@Override
 	public ModuleOptions interpolate(final Map<String, String> raw) throws BindException {
 
-		MapBindingResult bindingResult = new MapBindingResult(new HashMap<String, String>(), "options");
+		MapBindingResult bindingResult = new MapBindingResult(new HashMap<String, String>(),
+				MODULE_OPTIONS_PROPERTY_SOURCE_NAME);
 		for (String provided : raw.keySet()) {
 			if (!options.containsKey(provided)) {
-				bindingResult.addError(new FieldError("options", provided, String.format(
+				bindingResult.addError(new FieldError(MODULE_OPTIONS_PROPERTY_SOURCE_NAME, provided, String.format(
 						"Module option '%s' does not exist", provided)));
 			}
 		}


### PR DESCRIPTION
- Allow PropertySources to have the following precedence when
  resolving the module properties

High 6 - CommandLine options ('moduleOptions' PropertySource)
     5 - System Properties ('systemProperties' PropertySource)
     4 - System Environment ('systemEnvironment' PropertySource)
     3 - ${xd.config.home}/modules/<moduleType>/<moduleName>.properties
         ('moduleConfigOptions' PropertySource)
         Note: this location is different from ${xd.home}/'modules'
     2 - ${xd.config.home}/<moduleName>.properties
         ('xdConfigOptions' PropertySource)
     1 - application.(yml/properties) fragment file:./ file:./config/ classpath:config/ & classpath:
     0 - application.(yml/properties)
- Fixed RabbitMQ source/sink
  - Removed propertysource placehoder configurer
  - Fixed 'virtualHost' property name
  - Updated the property to use 'vhost' as in RabbitSourceOptionMetaData
