### PR TITLE
XD-1191 Modifying JDBC sink configuration

### DIFF
--- a/config/jdbc.properties
+++ b/config/jdbc.properties
@@ -1,6 +1,7 @@
-#spring.datasource.driverClass=org.hsqldb.jdbcDriver
-#spring.datasource.url=jdbc:hsqldb:mem:xd
-#spring.datasource.username=sa
-#spring.datasource.password=
-#spring.datasource.initialize=true
+#driverClass=org.hsqldb.jdbc.JDBCDriver
+#url=jdbc:hsqldb:mem:xd
+#username=sa
+#password=
 
+#initializeDatabase=true
+#initializerScript=init_db.sql

--- a/modules/sink/jdbc/config/jdbc.properties
+++ b/modules/sink/jdbc/config/jdbc.properties
@@ -6,11 +6,9 @@ options.columns.default = payload
 options.columns.type = String
 
 options.initializeDatabase.description = whether the database initialization script should be run
-options.initializeDatabase.default = true
 options.initializeDatabase.type = boolean
 
 options.initializerScript.description = the name of the SQL script (in /config) to run if 'initializeDatabase' is set
-options.initializerScript.default = init_db.sql
 options.initializerScript.type = String
 
 options.driverClass.description = the JDBC driver to use

--- a/modules/sink/jdbc/config/jdbc.xml
+++ b/modules/sink/jdbc/config/jdbc.xml
@@ -30,13 +30,13 @@
 		class="org.springframework.jdbc.datasource.init.DataSourceInitializer">
 		<beans:property name="databasePopulator" ref="databasePopulator" />
 		<beans:property name="dataSource" ref="dataSource" />
-		<beans:property name="enabled" value="${initializeDatabase}" />
+		<beans:property name="enabled" value="${initializeDatabase:false}" />
 	</beans:bean>
 
 	<beans:bean id="databasePopulator"
 		class="org.springframework.xd.jdbc.SingleTableDatabaseInitializer">
 		<beans:property name="scripts"
-			value="${xd.config.home}/${initializerScript}" />
+			value="${xd.config.home}/${initializerScript:init_db.sql}" />
 		<beans:property name="ignoreFailedDrops" value="true" />
 		<beans:property name="tableName" value="${tableName:${xd.stream.name}}" />
 	</beans:bean>

--- a/src/test/scripts/jdbc_tests
+++ b/src/test/scripts/jdbc_tests
@@ -38,7 +38,7 @@ assert_equals 'x' $col1
 
 echo -e "\n\n Test 2. tail | jdbc stream with db initialization"
 
-create_stream jdbc2 "tail --lines=10 --name=$TEST_DIR/jdbc2.data --fileDelay=1000 | jdbc --driverClass=org.sqlite.JDBC --username='' --password='' --url=jdbc:sqlite:$DB_FILE"
+create_stream jdbc2 "tail --lines=10 --name=$TEST_DIR/jdbc2.data --fileDelay=1000 | jdbc --driverClass=org.sqlite.JDBC --username='' --password='' --url=jdbc:sqlite:$DB_FILE --initializeDatabase=true"
 
 echo "blahblah" >> $TEST_DIR/jdbc2.data
 sleep 3


### PR DESCRIPTION
- changing default for 'initializeDatabase' to false
  (this was the original value - used to be overridden in jdbc.properties)
- moving some default values back to xml file from options properties file
  so we can override them in the jdbc.properties file
- leaving initializeDatabase commented out in jdbc.properties since we are
  now using the existing batch database by default instead of a temporary
  in-memory db
- modifying test script to reflect change of default value
