### PR TITLE
XD-1186: Support for overriding application.yml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1279,14 +1279,6 @@ task copyXDShellInstall(type: Copy, dependsOn: [":spring-xd-shell:installApp"]) 
 	exclude "**/lib/spring-data-hadoop-*.jar"
 }
 
-task copyYMLInstall(type: Copy, dependsOn: ["copyXDShellInstall"]) {
-	from "$rootDir/spring-xd-dirt/src/main/resources/application.yml"
-	into "$buildDir/dist/spring-xd/xd/config"
-	    rename { String fileName ->
-        fileName.replace('yml', 'template')
-    }
-}
-
 task copyHadoopLibs(dependsOn: [":spring-xd-hadoop:hadoop12:copyToLib", ":spring-xd-hadoop:hadoop22:copyToLib", ":spring-xd-hadoop:cdh4:copyToLib", ":spring-xd-hadoop:hdp13:copyToLib", ":spring-xd-hadoop:phd1:copyToLib"]) << {
 	['hadoop12', 'hadoop22', 'cdh4', 'hdp13', 'phd1'].each { distro ->
 		copy {
@@ -1300,7 +1292,7 @@ task copyHadoopLibs(dependsOn: [":spring-xd-hadoop:hadoop12:copyToLib", ":spring
 	}
 }
 
-task copyInstall (type: Copy, dependsOn: ["copyRedisInstall", "copyGemfireInstall", "copyXDInstall", "copyHadoopLibs", "copyXDShellInstall", "copyYMLInstall"]) {
+task copyInstall (type: Copy, dependsOn: ["copyRedisInstall", "copyGemfireInstall", "copyXDInstall", "copyHadoopLibs", "copyXDShellInstall"]) {
 	group = 'Application'
 	description = "Copy all the required installs to build/dist directory"
 	from "$rootDir/scripts/README"

--- a/config/xd-config.yml
+++ b/config/xd-config.yml
@@ -1,0 +1,21 @@
+# XD Configuration file
+# You can set properties here to override the default which
+# are set in the application.yml file loaded by Spring Boot.
+#
+# Propertes set in here will take precedence.
+#
+# Alternatively, you can set the environment variable XD_CONFIG
+# to point to a file (use a file:// URL). That file will then be
+# used instead.
+
+
+#spring:
+#  datasource:
+#    url: jdbc:hsqldb:hsql://localhost:9101/xdjob
+#    username: sa
+#    password:
+#    driverClassName: org.hsqldb.jdbc.JDBCDriver
+
+#server:
+#  port: 9393
+

--- a/scripts/xd/xd-admin
+++ b/scripts/xd/xd-admin
@@ -180,8 +180,13 @@ if [ x"$XD_HOME" = x ] ; then
     export XD_HOME=$APP_HOME
 fi
 
+# Check for an explicity set XD_CONFIG
+if [ x"$XD_CONFIG" = x ] ; then
+    export XD_CONFIG=file:$XD_HOME/config/xd-config.yml
+fi
+
 # set app name etc. via SPRING_XD_OPTS
-SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-admin-logger.properties -Dxd.home=$XD_HOME"
+SPRING_XD_OPTS="-Dspring.config.location=$XD_CONFIG -Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-admin-logger.properties -Dxd.home=$XD_HOME"
 
 # Split up the JVM_OPTS And SPRING_XD_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/xd/xd-container
+++ b/scripts/xd/xd-container
@@ -180,8 +180,13 @@ if [ x"$XD_HOME" = x ] ; then
     export XD_HOME=$APP_HOME
 fi
 
+# Check for an explicity set XD_CONFIG
+if [ x"$XD_CONFIG" = x ] ; then
+    export XD_CONFIG=file:$XD_HOME/config/xd-config.yml
+fi
+
 # set app name etc. via SPRING_XD_OPTS
-SPRING_XD_OPTS="-Dspring.application.name=container -Dlogging.config=file:$XD_HOME/config/xd-container-logger.properties -Dxd.home=$XD_HOME"
+SPRING_XD_OPTS="-Dspring.config.location=$XD_CONFIG -Dspring.application.name=container -Dlogging.config=file:$XD_HOME/config/xd-container-logger.properties -Dxd.home=$XD_HOME"
 
 # Split up the JVM_OPTS And SPRING_XD_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {

--- a/scripts/xd/xd-singlenode
+++ b/scripts/xd/xd-singlenode
@@ -180,8 +180,13 @@ if [ x"$XD_HOME" = x ] ; then
     export XD_HOME=$APP_HOME
 fi
 
+# Check for an explicity set XD_CONFIG
+if [ x"$XD_CONFIG" = x ] ; then
+    export XD_CONFIG=file:$XD_HOME/config/xd-config.yml
+fi
+
 # set app name etc. via SPRING_XD_OPTS
-SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-singlenode-logger.properties  -Dxd.home=$XD_HOME"
+SPRING_XD_OPTS="-Dspring.config.location=$XD_CONFIG -Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-singlenode-logger.properties  -Dxd.home=$XD_HOME"
 
 # Split up the JVM_OPTS And SPRING_XD_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {


### PR DESCRIPTION
Use Spring Boot's spring.config.location option to point to an additional 
configuration file which can be used to override the defaults.

Introduces XD_CONFIG environment variable which defaults to 
config/xd-config.yml in the startup scripts but which a user can set to point
to a filesystem location outside XD if they wish.

The file config/xd-config.yml is commented out by default so has no effect 
unless edited.
