### PR TITLE
XD-1199 Updating filejdbc batch job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1110,7 +1110,7 @@ project('modules.sink.splunk') {
 
 // ================ M O D U L E S : J O B S ============================
 
-project('modules.job.filejdbc') {
+project('modules.job.files2jdbc') {
 	dependencies {
 		runtime(project(":spring-xd-extension-jdbc"))
 	}

--- a/modules/job/files2jdbc/config/files2jdbc.xml
+++ b/modules/job/files2jdbc/config/files2jdbc.xml
@@ -18,7 +18,8 @@
 	</batch:job>
 
 	<bean id="multiResourceReader" class="org.springframework.batch.item.file.MultiResourceItemReader" scope="step">
-		<property name="resources" value="${resources}"/>
+		<!--<property name="resources" value="${resources}"/>-->
+        <property name="resources" value="file://#{jobParameters['dir']}/#{jobParameters['pattern']}" />
 		<property name="delegate" ref="itemReader"/>
 	</bean>
 


### PR DESCRIPTION
- renaming job to files2jdbc to refelect the purpose of the job
- changing config to accept job parameters for 'dir' and 'pattern' when job is triggered instead of 'resources' parameter
- can be triggered with:
  stream create --name files --definition "trigger --payload='{"dir":"/data","pattern":"*.csv"}' > queue:job:myjob"
