### PR TITLE
Remove mongodb dependency from spring-xd-hadoop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -598,7 +598,6 @@ project('spring-xd-hadoop') {
 		compile "org.springframework:spring-tx:$springVersion"
 		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
 		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-		compile "org.springframework.data:spring-data-mongodb:$springDataMongoVersion"
 		compile ("org.springframework.data:spring-data-hadoop:$springDataHadoopVersion") {
 			exclude group: 'javax.servlet'
 			exclude group: 'javax.servlet.jsp'


### PR DESCRIPTION
- Remove org.springframework.data:spring-data-mongodb:$springDataMongoVersion
  compile dependency from spring-xd-hadoop as this is only needed by
  any module and the module can use spring-xd-extension-mongodb
- Since this removes mongodb on XD admin, launcher classpath, the Mongodb
  autoconfiguration is avoided.
