### PR TITLE
XD-1206 ReST Ignore Missing StepExecutions

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchStepExecutionsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchStepExecutionsController.java
@@ -104,7 +104,10 @@ public class BatchStepExecutionsController {
 		final Collection<StepExecutionInfoResource> result = new ArrayList<StepExecutionInfoResource>();
 
 		for (StepExecution stepExecution : stepExecutions) {
-			result.add(stepExecutionInfoResourceAssembler.toResource(new StepExecutionInfo(stepExecution, timeZone)));
+			// Band-Aid to prevent Hateos crash - see XD-1206
+			if (stepExecution.getId() != null) {
+				result.add(stepExecutionInfoResourceAssembler.toResource(new StepExecutionInfo(stepExecution, timeZone)));
+			}
 		}
 
 		return result;


### PR DESCRIPTION
JIRA: https://jira.springsource.org/browse/XD-1206

This is a Band-Aid for XD-1206. There is some crosstalk between
JobCommandTests.testStopJobExecution and
JobCommandTests.testListStepExecutionsForSpecificJobExecution.

They use the same job names, but use different step names.

The JobService sometimes returns stepexecutions from the stopped job
with null entity Id, causing the Hateoas layer to fail.

This patch simply ignores those StepExutions.

See the JIRA for more information.
