### PR TITLE
XD-1221 Remove build task from modules project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -893,6 +893,9 @@ project('spring-xd-rest-domain') {
 
 project('modules') {
 	description = 'Spring XD Modules'
+	dependencies {
+                compile project(':spring-xd-dirt')
+        }
 	task build(overwrite: true) {}
 }
 


### PR DESCRIPTION
This avoids 'build' directory created under 'modules'

Currently, the 'modules' project is considered as JavaProject
and the build task creates a 'build' directory which gets copied into
the dist as well. Rather than removing the 'build' directory from
modules subproject during 'dist', it is better to disable build task
for 'modules' project as it simply acts as a wrapper around the individual
modules.

The only reason modules project is considered as JavaProject is to
enable the eclipse/idea plugins to generate metadata.
