### PR TITLE
XD-1145. Add --date option to trigger

### DIFF
--- a/modules/source/trigger/config/trigger.xml
+++ b/modules/source/trigger/config/trigger.xml
@@ -1,33 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans:beans xmlns="http://www.springframework.org/schema/integration"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:beans="http://www.springframework.org/schema/beans"
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<channel id="output" />
+	<int:channel id="output" />
 
-	<beans:beans profile="use-date">
-		<inbound-channel-adapter channel="output"
+	<beans profile="use-date">
+		<int:inbound-channel-adapter channel="output"
 			auto-startup="false" expression="'${payload}'">
-			<poller trigger="dateTrigger" />
-		</inbound-channel-adapter>
-		<beans:bean id="dateTrigger"
-			class="org.springframework.xd.module.support.DateTrigger">
-		</beans:bean>
-	</beans:beans>
+			<int:poller trigger="dateTrigger" />
+		</int:inbound-channel-adapter>
+        <bean id="df" class="java.text.SimpleDateFormat">
+            <constructor-arg value="${dateFormat}" />
+        </bean>
+        <bean id="dateTrigger" class="org.springframework.xd.module.support.DateTrigger">
+            <constructor-arg>
+                <bean factory-bean="df" factory-method="parse">
+                    <constructor-arg value="${date}" />
+                </bean>
+            </constructor-arg>
+		</bean>
+	</beans>
 
-	<beans:beans profile="use-cron">
-		<inbound-channel-adapter channel="output"
+	<beans profile="use-cron">
+		<int:inbound-channel-adapter channel="output"
 			auto-startup="false" expression="'${payload}'">
-			<poller cron="${cron}" />
-		</inbound-channel-adapter>
-	</beans:beans>
+			<int:poller cron="${cron}" />
+		</int:inbound-channel-adapter>
+	</beans>
 
-	<beans:beans profile="use-delay">
-		<inbound-channel-adapter channel="output"
+	<beans profile="use-delay">
+		<int:inbound-channel-adapter channel="output"
 			auto-startup="false" expression="'${payload}'">
-			<poller fixed-delay="${fixedDelay}" time-unit="SECONDS" />
-		</inbound-channel-adapter>
-	</beans:beans>
+			<int:poller fixed-delay="${fixedDelay}" time-unit="SECONDS" />
+		</int:inbound-channel-adapter>
+	</beans>
 
-</beans:beans>
+</beans>

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TriggerSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TriggerSourceOptionsMetadata.java
@@ -16,17 +16,22 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
-import javax.validation.constraints.AssertTrue;
-import javax.validation.constraints.Min;
-
+import org.hibernate.validator.constraints.NotBlank;
 import org.springframework.xd.module.options.spi.ModuleOption;
 import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 import org.springframework.xd.module.options.spi.SourceModuleOptionsMetadataSupport;
+
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * Describes options to the {@code trigger} source module.
  * 
  * @author Eric Bottard
+ * @author Florent Biville
  */
 public class TriggerSourceOptionsMetadata extends SourceModuleOptionsMetadataSupport implements ProfileNamesProvider {
 
@@ -35,6 +40,10 @@ public class TriggerSourceOptionsMetadata extends SourceModuleOptionsMetadataSup
 	private String cron;
 
 	private String payload = "";
+
+    private String date;
+
+    private String dateFormat = "MM/dd/yy HH:mm:ss";
 
 	@Override
 	public String[] profilesToActivate() {
@@ -84,5 +93,26 @@ public class TriggerSourceOptionsMetadata extends SourceModuleOptionsMetadataSup
 		this.payload = payload;
 	}
 
+    @NotNull
+    public String getDate() {
+        if (date == null) {
+            return new SimpleDateFormat(dateFormat).format(new Date());
+        }
+        return date;
+    }
 
+    @ModuleOption("the date when the trigger should fire")
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    @NotBlank
+    public String getDateFormat() {
+        return dateFormat;
+    }
+
+    @ModuleOption("the format specifying how the date should be parsed")
+    public void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
+    }
 }

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/support/DateTrigger.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/support/DateTrigger.java
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  * soon as possible.
  * 
  * @author Glenn Renfro
+ * @author Florent Biville
  */
 public class DateTrigger implements Trigger {
 
@@ -40,20 +41,14 @@ public class DateTrigger implements Trigger {
 
 	private final Log logger = LogFactory.getLog(getClass());
 
-
-	public DateTrigger() {
-		nextFireDates.add(new Date());
-	}
-
 	public DateTrigger(Date... dates) {
-		for (Date date : dates) {
-			Assert.notNull(date, "Date must not be null");
-			this.nextFireDates.add(date);
-		}
-		Collections.sort(this.nextFireDates);
+        for (Date date : dates) {
+            addDate(date);
+        }
+        Collections.sort(nextFireDates);
 	}
 
-	@Override
+    @Override
 	public Date nextExecutionTime(TriggerContext triggerContext) {
 		Date result = null;
 		if (nextFireDates.size() > 0) {
@@ -66,5 +61,10 @@ public class DateTrigger implements Trigger {
 		}
 		return result;
 	}
+
+    private void addDate(Date date) {
+        Assert.notNull(date, "Date must not be null");
+        nextFireDates.add(date);
+    }
 
 }

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/support/DateTriggerTest.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/support/DateTriggerTest.java
@@ -40,16 +40,6 @@ public class DateTriggerTest {
 	}
 
 	@Test
-	public void testDefaultConstructor() {
-		DateTrigger dateTrigger = new DateTrigger();
-		Date nextExecutionTime = dateTrigger.nextExecutionTime(null);
-		assertNotNull("The next Execution Time must have a value from a default constructor.", nextExecutionTime);
-		nextExecutionTime = dateTrigger.nextExecutionTime(null);
-		assertNull("The default constructor has only one entry and thus, this value should have already been pulled.",
-				nextExecutionTime);
-	}
-
-	@Test
 	public void testConstructor() {
 		Date epoch = new Date(0);
 		Calendar currentCalendar = Calendar.getInstance();

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/TriggerModulesTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/TriggerModulesTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.shell.command;
+
+import org.junit.Test;
+import org.springframework.xd.shell.command.fixtures.FileSink;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.springframework.xd.shell.command.fixtures.XDMatchers.eventually;
+import static org.springframework.xd.shell.command.fixtures.XDMatchers.hasContentsThat;
+
+/**
+ * Tests for Trigger modules.
+ *
+ * @author Florent Biville
+ */
+public class TriggerModulesTest extends AbstractStreamIntegrationTest {
+
+    private FileSink binaryFileSink = newFileSink().binary(true);
+
+    @Test
+    public void receivesContentsInstantlyByDefault() {
+        stream().create("trigger-stream", "trigger --payload='Hello' | %s", binaryFileSink);
+
+        assertThat(binaryFileSink, eventually(hasContentsThat(equalTo("Hello"))));
+    }
+
+    @Test
+    public void doesNotReceiveAnyContentsForALatterDate() {
+        stream().create(
+            "trigger-stream", "trigger --payload='Hello' --date='25/12/2032' --dateFormat='dd/MM/yyyy' | %s",
+            binaryFileSink
+        );
+
+        assertThat(binaryFileSink, not(eventually(3, 300, hasContentsThat(equalTo("Hello")))));
+
+    }
+}


### PR DESCRIPTION
Please note I couldn't run the integration tests (part of this commit):

```
 $ cd /path/to/spring-xd
 $ ./gradlew clean :spring-xd-shell:test -Dtest.single=TriggerModulesTest
[...]
14/01/13 20:55:18 ERROR web.BasicErrorController: java.lang.NoClassDefFoundError: org/springframework/integration/core/MessageHandler
```

This error has been reproduced on @ericbottard's laptop.
Finally, it seems I already signed the CLA (for Spring Data, as far as I remember).
