### PR TITLE
XD-1194 Handle boolean cmdLineOption default

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
@@ -38,7 +38,7 @@ public class CommonOptions {
 
 
 	public Boolean getXD_JMX_ENABLED() {
-		return (jmxEnabled != null && jmxEnabled) ? jmxEnabled : null;
+		return jmxEnabled;
 	}
 
 


### PR DESCRIPTION
Fixed 'jmxEnabled' CommonOption to use Boolean type instead of boolean
so that getter method could return null when the flag is not set and,
the setter would always set the appropriate precedence value when
resolving PropertySources.
Also note we have the application.yml setting XD_JMX_ENABLED to false hence
setter is always set with non-null value.
