### PR TITLE
Removed compile warnings

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/memory/InMemoryModuleDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/memory/InMemoryModuleDefinitionRepository.java
@@ -120,12 +120,11 @@ public class InMemoryModuleDefinitionRepository extends AbstractInMemoryReposito
 		return dependentModules;
 	}
 
-	// TODO- BEGIN SHARED IMPL WITH RedisModuleDefintionRepository
+	// TODO- BEGIN SHARED IMPL WITH RedisModuleDefinitionRepository
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public ModuleDefinition save(ModuleDefinition entity) {
-		ModuleDefinition md = super.save(entity);
+	public <M extends ModuleDefinition> M save(M entity) {
+		M md = super.save(entity);
 		for (ModuleDefinition child : md.getComposedModuleDefinitions()) {
 			ModuleDefinitionRepositoryUtils.saveDependencies(moduleDependencyRepository, child, dependencyKey(entity));
 		}
@@ -150,13 +149,12 @@ public class InMemoryModuleDefinitionRepository extends AbstractInMemoryReposito
 		}
 	}
 
-
 	// TODO refactor to use keyFor
 	private String dependencyKey(ModuleDefinition moduleDefinition) {
 		return String.format("module:%s:%s", moduleDefinition.getType(), moduleDefinition.getName());
 	}
 
-	// TODO END SHARED IMPL WITH RedisModuleDefintionRepository
+	// TODO END SHARED IMPL WITH RedisModuleDefinitionRepository
 
 	/**
 	 * Post-process the list to only return elements matching the page request.

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/redis/RedisModuleDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/redis/RedisModuleDefinitionRepository.java
@@ -98,10 +98,9 @@ public class RedisModuleDefinitionRepository extends AbstractRedisRepository<Mod
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public ModuleDefinition save(ModuleDefinition entity) {
-		ModuleDefinition md = super.save(entity);
+	public <M extends ModuleDefinition> M save(M entity) {
+		M md = super.save(entity);
 		for (ModuleDefinition child : md.getComposedModuleDefinitions()) {
 			ModuleDefinitionRepositoryUtils.saveDependencies(moduleDependencyRepository, child, dependencyKey(entity));
 		}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/ChunkContextInfo.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/ChunkContextInfo.java
@@ -26,6 +26,7 @@ import org.springframework.batch.core.StepExecution;
  * @author Gunnar Hillert
  * @since 1.0
  */
+@SuppressWarnings("serial")
 public class ChunkContextInfo implements Serializable {
 
 	private boolean complete;
@@ -45,7 +46,6 @@ public class ChunkContextInfo implements Serializable {
 	public StepExecution getStepExecution() {
 		return stepExecution;
 	}
-
 
 	public void setStepExecution(StepExecution stepExecution) {
 		this.stepExecution = stepExecution;
@@ -96,4 +96,5 @@ public class ChunkContextInfo implements Serializable {
 			return false;
 		return true;
 	}
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommandLinePropertySourceOverridingInitializer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommandLinePropertySourceOverridingInitializer.java
@@ -46,7 +46,7 @@ import org.springframework.util.Assert;
  */
 public class CommandLinePropertySourceOverridingInitializer<T extends CommonOptions> implements EnvironmentAware,
 		SpringApplicationInitializer,
-		ApplicationContextInitializer {
+		ApplicationContextInitializer<ConfigurableApplicationContext> {
 
 	private ConfigurableEnvironment environment;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/memory/InMemoryStreamDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/memory/InMemoryStreamDefinitionRepository.java
@@ -39,10 +39,9 @@ public class InMemoryStreamDefinitionRepository extends AbstractInMemoryReposito
 		this.dependencyRepository = dependencyRepository;
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public StreamDefinition save(StreamDefinition entity) {
-		StreamDefinition sd = super.save(entity);
+	public <S extends StreamDefinition> S save(S entity) {
+		S sd = super.save(entity);
 		StreamDefinitionRepositoryUtils.saveDependencies(dependencyRepository, sd);
 		return sd;
 	}
@@ -51,7 +50,7 @@ public class InMemoryStreamDefinitionRepository extends AbstractInMemoryReposito
 	public void delete(StreamDefinition entity) {
 		StreamDefinitionRepositoryUtils.deleteDependencies(dependencyRepository, entity);
 		super.delete(entity);
-	};
+	}
 
 	@Override
 	public void delete(String id) {
@@ -59,7 +58,7 @@ public class InMemoryStreamDefinitionRepository extends AbstractInMemoryReposito
 		if (def != null) {
 			this.delete(def);
 		}
-	};
+	}
 
 	@Override
 	protected String keyFor(StreamDefinition entity) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/redis/RedisStreamDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/redis/RedisStreamDefinitionRepository.java
@@ -45,10 +45,9 @@ public class RedisStreamDefinitionRepository extends AbstractRedisDefinitionRepo
 		objectMapper.addMixInAnnotations(ModuleDefinition.class, ModuleDefinitionMixin.class);
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public StreamDefinition save(StreamDefinition entity) {
-		StreamDefinition sd = super.save(entity);
+	public <S extends StreamDefinition> S save(S entity) {
+		S sd = super.save(entity);
 		StreamDefinitionRepositoryUtils.saveDependencies(dependencyRepository, sd);
 		return sd;
 	}

--- a/spring-xd-hadoop/src/main/java/org/springframework/data/hadoop/x/store/dataset/DatasetTemplateAllowingNulls.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/data/hadoop/x/store/dataset/DatasetTemplateAllowingNulls.java
@@ -55,11 +55,12 @@ public class DatasetTemplateAllowingNulls extends DatasetTemplate {
 	}
 
 	@Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
 	public void write(Collection<?> records, PartitionStrategy partitionStrategy) {
 		if (records == null || records.size() < 1) {
 			return;
 		}
-		@SuppressWarnings("unchecked")
+
 		Class recordClass = (Class) records.iterator().next().getClass();
 		Dataset dataset = getOrCreateDataset(recordClass, partitionStrategy);
 		DatasetWriter writer = dataset.newWriter();

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadata.java
@@ -41,8 +41,9 @@ public class DefaultModuleOptionsMetadata implements ModuleOptionsMetadata {
 		return new ModuleOptions() {
 
 			@Override
+            @SuppressWarnings("unchecked")
 			public EnumerablePropertySource<?> asPropertySource() {
-				return new MapPropertySource("options", (Map)raw);
+				return new MapPropertySource("options", (Map) raw);
 			}
 		};
 	}

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/PojoModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/PojoModuleOptionsMetadata.java
@@ -267,6 +267,7 @@ public class PojoModuleOptionsMetadata implements ModuleOptionsMetadata {
 		};
 	}
 
+    @SuppressWarnings("unchecked")
 	private void bindAndValidate(Map<String, String> raw) throws BindException {
 		DataBinder dataBinder = new DataBinder(beanWrapper.getWrappedInstance());
 		dataBinder.setIgnoreUnknownFields(false);

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/util/RestTemplateMessageConverterUtil.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/util/RestTemplateMessageConverterUtil.java
@@ -26,7 +26,6 @@ import javax.xml.bind.JAXBException;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
 import org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter;
 import org.springframework.http.converter.xml.AbstractJaxb2HttpMessageConverter;
 import org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter;
@@ -90,13 +89,15 @@ public class RestTemplateMessageConverterUtil {
 	/**
 	 * Install message converters we're interested in, with json coming before xml.
 	 */
+    @SuppressWarnings("deprecation")
 	public static List<HttpMessageConverter<?>> installMessageConverters(List<HttpMessageConverter<?>> messageConverters) {
 		messageConverters.add(new AllEncompassingFormHttpMessageConverter());
 		if (jackson2Present) {
 			messageConverters.add(new MappingJackson2HttpMessageConverter());
 		}
 		else if (jacksonPresent) {
-			messageConverters.add(new MappingJacksonHttpMessageConverter());
+			// avoiding import of MappingJacksonHttpMessageConverter to prevent deprecation warning
+			messageConverters.add(new org.springframework.http.converter.json.MappingJacksonHttpMessageConverter());
 		}
 		if (jaxb2Present) {
 			Jaxb2RootElementHttpMessageConverter jaxbConverter = new Jaxb2RootElementHttpMessageConverter();


### PR DESCRIPTION
Compile warnings related to casting, generics, and deprecated
classes/methods were removed. There are still 3 categories
of warnings remaining:

(1) Cannot find annotation method 'value()' in type 'Repeatable'

This results from the usage of @Repeatable in the core
Spring framework. This annotation is present starting in
JDK 8; therefore compiling with JDK 7 or older will
show this warning.

See the following:
http://docs.oracle.com/javase/tutorial/java/annotations/repeating.html

(2) bootstrap class path not set in conjunction with -source 1.6

This results from setting a target of 1.6 when compiling with
the 1.7 javac. To guarantee backwards compatibility with 1.6,
the rt.jar for JDK 1.6 should be included in the boot classpath
for javac.

The current line of thinking is that we will enable this on the
CI server to catch any usage of 1.7 methods in the project since
it must execute on 1.6. We cannot simply compile with 1.6 on
the CI server because the tests require 1.7.

See the following:
http://docs.oracle.com/javase/7/docs/technotes/tools/solaris/javac.html

(3)  Class JavaLaunchHelper is implemented in both...

This message appears on OS X with JDK 1.7.0_45:

objc[53170]: Class JavaLaunchHelper is implemented in both
/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home/bin/java
and /Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home/jre/
lib/libinstrument.dylib. One of the two will be used. Which one is
undefined.

This is a bug in the JDK that has been resolved and will be released
in u60.

See the following:
http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=8021205
