### PR TITLE
XD-1266: Assume use of HttpClient for twitterstream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ ext {
 	hamcrestDateVersion = '0.9.3'
 	hsqldbVersion = '2.3.0'
 	h2Version = '1.3.172'
+	httpClientVersion = '4.1.2'
 	jodaTimeVersion = '2.1'
 	jolokiaVersion = '1.1.5'
 	snakeYamlVersion = '1.12'
@@ -531,6 +532,7 @@ project('spring-xd-extension-twitter') {
 	description = 'Spring XD Twitter'
 	dependencies {
 		compile "org.springframework.integration:spring-integration-twitter:$springIntegrationVersion"
+		compile "org.apache.httpcomponents:httpclient:$httpClientVersion"
 	}
 }
 


### PR DESCRIPTION
The existing DirectFieldAccessor workaround for setting connection
properties assumed the use of a SimpleClientHttpRequestFactory. If
Apache HttpClient is on the classpath, a different instance is
dynamically chosen. This commit adds httpclient explicitly and fixes
TwitterStreamChannelAdapter to work with the different request factory.
