### PR TITLE
XD-1250 RabbitMessageBus Shutdown

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -67,12 +67,13 @@ import org.springframework.xd.tuple.Tuple;
  * @author Gunnar Hillert
  * @author Mark Fisher
  * @author Ilayaperumal Gopinathan
+ * @author Gary Russell
  */
 public abstract class AbstractSingleNodeStreamDeploymentIntegrationTests extends RandomConfigurationSupport {
 
 	protected static AbstractApplicationContext context;
 
-	private static SingleNodeApplication application;
+	protected static SingleNodeApplication application;
 
 	protected static StreamDefinitionRepository streamDefinitionRepository;
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,17 +13,22 @@
 
 package org.springframework.xd.dirt.stream;
 
+import java.util.ArrayList;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.ExternalResource;
 
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionListener;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.integration.x.bus.RabbitTestMessageBus;
 import org.springframework.xd.test.rabbit.RabbitTestSupport;
 
 /**
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class RabbitSingleNodeStreamDeploymentIntegrationTests extends
 		AbstractSingleNodeStreamDeploymentIntegrationTests {
@@ -53,6 +58,10 @@ public class RabbitSingleNodeStreamDeploymentIntegrationTests extends
 			RabbitAdmin admin = context.getBean(RabbitAdmin.class);
 			String deployerQueue = context.getEnvironment().resolvePlaceholders(XD_DEPLOYER_PLACEHOLDER);
 			String undeployerExchange = context.getEnvironment().resolvePlaceholders(XD_UNDEPLOYER_PLACEHOLDER);
+			CachingConnectionFactory ccf = context.getBean(CachingConnectionFactory.class);
+			ccf.setConnectionListeners(new ArrayList<ConnectionListener>());
+			admin.setApplicationContext(null);
+			application.close();
 			admin.deleteQueue(deployerQueue);
 			admin.deleteExchange(undeployerExchange);
 		}


### PR DESCRIPTION
Several issues resolved:
1. The message bus was using unnamed auto-delete queues for pub/sub.
     A connection glitch would cause such queues to be deleted and
     the container could not recover.
   - changed to use AnonymousQueue and configure the admin to redeclare
     the queue and binding when necessary.
2. The module-common context was never closed so the RabbitMessageBus
     containers would go into recovery mode; currently this is a hard-
     wired 15 second delay (3x5 seconds).
   - the ModuleDeployer is now a `DisposableBean` and destroys all
     deployed modules and the common module context.
3. Changed `RabbitSingleNodeStreamDeploymentIntegrationTests` to delete
     the deployment queues after all contexts are closed.
