### PR TITLE
Refactor unique name generation logic

### DIFF
--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
@@ -130,28 +130,28 @@ public abstract class AbstractShellIntegrationTest extends RandomConfigurationSu
 
 	private String generateUniqueName() {
 		StackTraceElement[] element = Thread.currentThread().getStackTrace();
-		// Assumption here is that the getStreamName()/getJobName() is called from the @Test method
-		return generateUniqueName(element[3].getMethodName());
+		// Assumption here is that the generateStreamName()/generateJobName() is called from the @Test method
+		return generateUniqueName(element[4].getMethodName());
 	}
 
-	protected String getStreamName(String name) {
-		return generateUniqueName(name);
+	protected String generateStreamName(String name) {
+		return (name == null) ? generateUniqueName() : generateUniqueName(name);
 	}
 
-	protected String getStreamName() {
-		return generateUniqueName();
+	protected String generateStreamName() {
+		return generateStreamName(null);
 	}
 
 	protected String getTapName(String streamName) {
 		return "tap:stream:" + streamName;
 	}
 
-	protected String getJobName(String name) {
-		return generateUniqueName(name);
+	protected String generateJobName(String name) {
+		return (name == null) ? generateUniqueName() : generateUniqueName(name);
 	}
 
-	protected String getJobName() {
-		return generateUniqueName();
+	protected String generateJobName() {
+		return generateJobName(null);
 	}
 
 	protected String getJobLaunchQueue(String jobName) {

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobIntegrationTest.java
@@ -117,7 +117,7 @@ public abstract class AbstractJobIntegrationTest extends AbstractShellIntegratio
 	}
 
 	protected String executeJobCreate(String jobDefinition) {
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, jobDefinition, true);
 		return jobName;
 	}
@@ -210,7 +210,7 @@ public abstract class AbstractJobIntegrationTest extends AbstractShellIntegratio
 	}
 
 	protected void triggerJob(String jobName) {
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		CommandResult cr = getShell().executeCommand(
 				"stream create --name " + streamName + " --definition \"trigger > "
 						+ getJobLaunchQueue(jobName) + "\"");
@@ -219,7 +219,7 @@ public abstract class AbstractJobIntegrationTest extends AbstractShellIntegratio
 	}
 
 	protected void triggerJobWithParams(String jobName, String parameters) {
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		CommandResult cr = getShell().executeCommand(
 				String.format("stream create --name " + streamName
 						+ " --definition \"trigger --payload='%s' > " + getJobLaunchQueue(jobName) + "\"", parameters));
@@ -228,7 +228,7 @@ public abstract class AbstractJobIntegrationTest extends AbstractShellIntegratio
 	}
 
 	protected void triggerJobWithDelay(String jobName, String fixedDelay) {
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		CommandResult cr = getShell().executeCommand(
 				"stream create --name " + streamName + " --definition \"trigger --fixedDelay=" + fixedDelay
 						+ " > " + getJobLaunchQueue(jobName) + "\"");

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/FileSourceAndFileSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/FileSourceAndFileSinkTests.java
@@ -80,7 +80,7 @@ public class FileSourceAndFileSinkTests extends AbstractStreamIntegrationTest {
 		FileSink sink = newFileSink().binary(true);
 
 		source.appendToFile("Hi there!");
-		stream().create(getStreamName(), "%s | %s", source, sink);
+		stream().create(generateStreamName(), "%s | %s", source, sink);
 		assertThat(sink, eventually(hasContentsThat(equalTo("Hi there!"))));
 
 
@@ -93,7 +93,7 @@ public class FileSourceAndFileSinkTests extends AbstractStreamIntegrationTest {
 		}
 
 		// Both use stream name
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 
 		File inDir = new File(DEFAULT_IN, streamName);
 		inDir.mkdirs();

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/HttpCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/HttpCommandTests.java
@@ -63,7 +63,7 @@ public class HttpCommandTests extends AbstractStreamIntegrationTest {
 		final String stringToPost = "hello";
 		final FileSink fileSink = newFileSink().binary(true);
 
-		final String streamName = getStreamName();
+		final String streamName = generateStreamName();
 		final String stream = String.format("%s | %s", httpSource, fileSink);
 
 		logger.info("Creating Stream: " + stream);
@@ -89,7 +89,7 @@ public class HttpCommandTests extends AbstractStreamIntegrationTest {
 		/** I want to go to Japan. */
 		final String stringToPostInJapanese = "\u65e5\u672c\u306b\u884c\u304d\u305f\u3044\u3002";
 
-		final String streamName = getStreamName();
+		final String streamName = generateStreamName();
 		final String stream = String.format("%s | %s", httpSource, fileSink);
 
 		logger.info("Creating Stream: " + stream);
@@ -118,7 +118,7 @@ public class HttpCommandTests extends AbstractStreamIntegrationTest {
 		StreamUtils.copy(stringToPostInJapanese, inCharset, os);
 		os.close();
 
-		final String streamName = getStreamName();
+		final String streamName = generateStreamName();
 		final String stream = String.format("%s | %s", source, fileSink);
 
 		stream().create(streamName, stream);

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/JobCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/JobCommandTests.java
@@ -87,7 +87,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	@Test
 	public void testStreamDestroyMissing() {
 		logger.info("Destroy a job that doesn't exist");
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		CommandResult cr = jobDestroy(jobName);
 		checkForFail(cr);
 		checkErrorMessages(cr, "There is no job definition named '" + jobName + "'");
@@ -96,7 +96,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	@Test
 	public void testJobCreateDuplicateWithDeployFalse() {
 		logger.info("Create 2 myJobs with --deploy = false");
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, false);
 
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, false);
@@ -113,7 +113,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 		logger.info("Create batch job");
 		JobParametersHolder.reset();
 		final JobParametersHolder jobParametersHolder = new JobParametersHolder();
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, false);
 
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, false);
@@ -140,7 +140,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	public void testInvalidJobDescriptor() throws InterruptedException {
 		JobParametersHolder.reset();
 		final JobParametersHolder jobParametersHolder = new JobParametersHolder();
-		CommandResult cr = getShell().executeCommand("job create --definition \"barsdaf\" --name " + getJobName());
+		CommandResult cr = getShell().executeCommand("job create --definition \"barsdaf\" --name " + generateJobName());
 		checkForFail(cr);
 		checkErrorMessages(cr, "Module definition is missing");
 		assertFalse("Job did not complete within time alotted", jobParametersHolder.isDone());
@@ -148,7 +148,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 
 	@Test
 	public void testMissingJobDescriptor() {
-		CommandResult cr = getShell().executeCommand("job create --name " + getJobName());
+		CommandResult cr = getShell().executeCommand("job create --name " + generateJobName());
 		checkForFail(cr);
 	}
 
@@ -157,7 +157,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 		logger.info("Create batch job with parameters");
 
 		JobParametersHolder.reset();
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, false);
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, false);
 
@@ -186,7 +186,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	public void testJobDeployWithTypedParameters() throws InterruptedException, ParseException {
 		logger.info("Create batch job with typed parameters");
 		JobParametersHolder.reset();
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, false);
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, false);
 
@@ -224,7 +224,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	@Test
 	public void testLaunchJob() {
 		logger.info("Launch batch job");
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR);
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, true);
 		executeJobLaunch(jobName);
@@ -241,7 +241,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	@Test
 	public void testLaunchNotDeployedJob() {
 		logger.info("Launch batch job that is not deployed");
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, false);
 		CommandResult result = executeCommandExpectingFailure("job launch --name " + jobName);
 		assertThat(result.getException().getMessage(),
@@ -254,7 +254,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 		String myJobParams = "{\"-param1(long)\":\"12345\",\"param2(date)\":\"1990/10/03\"}";
 		JobParametersHolder.reset();
 		final JobParametersHolder jobParametersHolder = new JobParametersHolder();
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR);
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, true);
 		executeJobLaunch(jobName, myJobParams);
@@ -287,7 +287,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	@Test
 	public void testLaunchJobTwiceWhereMakeUniqueIsImplicitlyTrue() throws Exception {
 		logger.info("Launch batch job twice (makeUnique is implicitly true)");
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		// Batch 3.0 requires at least one parameter to reject duplicate executions of an instance
 		String myJobParams = "{\"-param(long)\":\"12345\"}";
 		JobParametersHolder.reset();
@@ -303,7 +303,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	@Test
 	public void testLaunchJobTwiceWhereMakeUniqueIsTrue() throws Exception {
 		logger.info("Launch batch job (makeUnique=true) twice");
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		// Batch 3.0 requires at least one parameter to reject duplicate executions of an instance
 		String myJobParams = "{\"-param(long)\":\"12345\"}";
 		JobParametersHolder.reset();
@@ -319,7 +319,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	@Test
 	public void testLaunchJobTwiceWhereMakeUniqueIsFalse() throws Exception {
 		logger.info("Launch batch job (makeUnique=false) twice");
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		// Batch 3.0 requires at least one parameter to reject duplicate executions of an instance
 		String myJobParams = "{\"-param(long)\":\"12345\"}";
 		JobParametersHolder.reset();
@@ -368,7 +368,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 
 	@Test
 	public void testListJobExecutions() {
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR);
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, true);
 		executeJobLaunch(jobName);
@@ -377,7 +377,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 
 	@Test
 	public void testDisplaySpecificJobExecution() {
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR);
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, true);
 		executeJobLaunch(jobName);
@@ -388,7 +388,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 
 	@Test
 	public void testDisplaySpecificJobExecutionWithDateParam() {
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		String jobDefinition = JOB_WITH_PARAMETERS_DESCRIPTOR + " --dateFormat='yyyy/dd/MM' --numberFormat='###;(###)'";
 		executeJobCreate(jobName, jobDefinition);
 		checkForJobInList(jobName, jobDefinition, true);
@@ -403,7 +403,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 
 	@Test
 	public void testListStepExecutionsForSpecificJobExecution() {
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR);
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, true);
 		executeJobLaunch(jobName);
@@ -418,7 +418,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 
 	@Test
 	public void testStopJobExecution() throws Exception {
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_STEP_EXECUTIONS);
 		checkForJobInList(jobName, JOB_WITH_STEP_EXECUTIONS, true);
 		triggerJobWithDelay(jobName, "5");
@@ -445,7 +445,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 
 	@Test
 	public void testStopAllJobExecutions() throws Exception {
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_STEP_EXECUTIONS);
 		checkForJobInList(jobName, JOB_WITH_STEP_EXECUTIONS, true);
 		triggerJobWithDelay(jobName, "5");
@@ -471,7 +471,7 @@ public class JobCommandTests extends AbstractJobIntegrationTest {
 	}
 
 	public void testStepExecutionProgress() {
-		String jobName = getJobName();
+		String jobName = generateJobName();
 		executeJobCreate(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR);
 		checkForJobInList(jobName, JOB_WITH_PARAMETERS_DESCRIPTOR, true);
 		executeJobLaunch(jobName);

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MailCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MailCommandTests.java
@@ -47,7 +47,7 @@ public class MailCommandTests extends AbstractStreamIntegrationTest {
 
 		mailSource.ensureStarted();
 
-		stream().create(getStreamName(), "%s | %s", mailSource, fileSink);
+		stream().create(generateStreamName(), "%s | %s", mailSource, fileSink);
 
 		mailSource.sendEmail("from@foo.com", "The Subject", "My body is slim!");
 
@@ -61,7 +61,7 @@ public class MailCommandTests extends AbstractStreamIntegrationTest {
 
 		mailSource.ensureStarted();
 
-		stream().create(getStreamName(), "%s | %s", mailSource, fileSink);
+		stream().create(generateStreamName(), "%s | %s", mailSource, fileSink);
 
 		mailSource.sendEmail("from@foo.com", "The Subject", "My body is slim!");
 
@@ -78,7 +78,7 @@ public class MailCommandTests extends AbstractStreamIntegrationTest {
 				.subject("payload");
 
 
-		stream().create(getStreamName(), "%s | %s", httpSource, mailSink);
+		stream().create(generateStreamName(), "%s | %s", httpSource, mailSink);
 
 		httpSource.ensureReady().postData("Woohoo!");
 		MimeMessage result = mailSink.waitForEmail();

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MessageStoreBenchmarkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MessageStoreBenchmarkTests.java
@@ -74,7 +74,7 @@ public class MessageStoreBenchmarkTests extends AbstractStreamIntegrationTest {
 		HttpSource source = newHttpSource();
 		CounterSink sink = metrics().newCounterSink();
 		stream().create(
-				getStreamName(),
+				generateStreamName(),
 				"%s | aggregator --store=%s --count=3 --aggregation=T(org.springframework.util.StringUtils).collectionToDelimitedString(#this.![payload],' ') --timeout=500000%s | %s ",
 				source, storeName,
 				streamDynamicPart, sink);

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MetricsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MetricsTests.java
@@ -50,7 +50,7 @@ public class MetricsTests extends AbstractStreamIntegrationTest {
 	public void testSimpleCounter() throws Exception {
 		httpSource = newHttpSource();
 		CounterSink counter = metrics().newCounterSink();
-		stream().create(getStreamName(), "%s | %s", httpSource, counter);
+		stream().create(generateStreamName(), "%s | %s", httpSource, counter);
 
 		httpSource.postData("one");
 		httpSource.postData("one");
@@ -62,7 +62,7 @@ public class MetricsTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testSimpleCounterImplicitName() throws Exception {
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		httpSource = newHttpSource();
 
 		// Create counter object, but don't use its toString
@@ -78,7 +78,7 @@ public class MetricsTests extends AbstractStreamIntegrationTest {
 	public void testAggregateCounterList() throws Exception {
 		httpSource = newHttpSource();
 		AggregateCounterSink counter = metrics().newAggregateCounterSink();
-		stream().create(getStreamName(), "%s | %s", httpSource, counter);
+		stream().create(generateStreamName(), "%s | %s", httpSource, counter);
 
 		httpSource.postData("one");
 		httpSource.postData("one");
@@ -89,7 +89,7 @@ public class MetricsTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testAggregateCounterImplicitName() throws Exception {
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		httpSource = newHttpSource();
 
 		// Create sink object, but don't use its toString
@@ -106,7 +106,7 @@ public class MetricsTests extends AbstractStreamIntegrationTest {
 	public void testRichGaugeDisplay() throws Exception {
 		httpSource = newHttpSource();
 		RichGaugeSink sink = metrics().newRichGauge();
-		stream().create(getStreamName(), "%s | %s", httpSource, sink);
+		stream().create(generateStreamName(), "%s | %s", httpSource, sink);
 
 		httpSource.ensureReady();
 		httpSource.postData("5");
@@ -125,7 +125,7 @@ public class MetricsTests extends AbstractStreamIntegrationTest {
 
 		FieldValueCounterSink sink = metrics().newFieldValueCounterSink("fromUser");
 
-		stream().create(getStreamName(), "%s | %s", tailSource, sink);
+		stream().create(generateStreamName(), "%s | %s", tailSource, sink);
 		assertThat(sink, eventually(exists()));
 	}
 
@@ -138,7 +138,7 @@ public class MetricsTests extends AbstractStreamIntegrationTest {
 		tailTweets(tailSource);
 
 		FieldValueCounterSink sink = metrics().newFieldValueCounterSink("fromUser");
-		stream().create(getStreamName(), "%s | %s", tailSource, sink);
+		stream().create(generateStreamName(), "%s | %s", tailSource, sink);
 
 		Table t = sink.constructFVCDisplay(fvcMap);
 		assertThat(sink, eventually(hasValue(t)));

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ModuleClasspathTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ModuleClasspathTests.java
@@ -43,7 +43,7 @@ public class ModuleClasspathTests extends AbstractStreamIntegrationTest {
 	public void testModuleWithClasspathAfterServerStarted() throws Exception {
 		installTestModule("source", "time2");
 		FileSink fileSink = newFileSink();
-		stream().create(getStreamName(), "time2 --fixedDelay=1000 | %s", fileSink);
+		stream().create(generateStreamName(), "time2 --fixedDelay=1000 | %s", fileSink);
 
 		assertThat(fileSink, eventually(hasContentsThat(not(isEmptyOrNullString()))));
 	}

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/NamedChannelTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/NamedChannelTests.java
@@ -43,15 +43,15 @@ public class NamedChannelTests extends AbstractStreamIntegrationTest {
 		logger.info("Creating stream with named channel 'queue:foo' as sink");
 		HttpSource source = newHttpSource();
 
-		stream().create(getStreamName(),
+		stream().create(generateStreamName(),
 				"%s | transform --expression=payload.toUpperCase() > queue:foo", source);
 	}
 
 	@Test
 	public void testCreateNamedChannelAsSource() throws InterruptedException {
 		logger.info("Creating stream with named channel 'foo' as source");
-		String streamName1 = getStreamName();
-		String streamName2 = getStreamName();
+		String streamName1 = generateStreamName();
+		String streamName2 = generateStreamName();
 
 		HttpSource httpSource = newHttpSource();
 		CounterSink counterSink = metrics().newCounterSink();

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ProcessorsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ProcessorsTests.java
@@ -43,7 +43,7 @@ public class ProcessorsTests extends AbstractStreamIntegrationTest {
 		HttpSource httpSource = newHttpSource();
 		CounterSink counterSink = metrics().newCounterSink();
 
-		stream().create(getStreamName(), "%s | splitter | %s", httpSource, counterSink);
+		stream().create(generateStreamName(), "%s | splitter | %s", httpSource, counterSink);
 
 		httpSource.ensureReady().postData("Hello World !");
 		assertThat(counterSink, eventually(hasValue("1")));
@@ -55,7 +55,7 @@ public class ProcessorsTests extends AbstractStreamIntegrationTest {
 		HttpSource httpSource = newHttpSource();
 		CounterSink counterSink = metrics().newCounterSink();
 
-		stream().create(getStreamName(), "%s | splitter --expression=payload.split(' ') | %s",
+		stream().create(generateStreamName(), "%s | splitter --expression=payload.split(' ') | %s",
 				httpSource, counterSink);
 
 		httpSource.ensureReady().postData("Hello World !");
@@ -69,7 +69,7 @@ public class ProcessorsTests extends AbstractStreamIntegrationTest {
 		FileSink fileSink = newFileSink().binary(true);
 
 		stream().create(
-				getStreamName(),
+				generateStreamName(),
 				"%s | aggregator --count=3 --aggregation=T(org.springframework.util.StringUtils).collectionToDelimitedString(#this.![payload],' ') | %s",
 				httpSource, fileSink);
 
@@ -87,7 +87,7 @@ public class ProcessorsTests extends AbstractStreamIntegrationTest {
 		int timeout = 1000;
 
 		stream().create(
-				getStreamName(),
+				generateStreamName(),
 				"%s | aggregator --count=100 --timeout=%d --aggregation=T(org.springframework.util.StringUtils).collectionToDelimitedString(#this.![payload],' ') | %s",
 				httpSource, timeout, fileSink);
 

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/RuntimeCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/RuntimeCommandTests.java
@@ -57,7 +57,7 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testListRuntimeModules() {
 		logger.info("List runtime modules");
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
 		CommandResult cmdResult = executeCommand("runtime modules");
 		Table table = (Table) cmdResult.getResult();
@@ -74,7 +74,7 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testListRuntimeModulesAfterUndeploy() {
 		logger.info("List runtime modules after undeploy");
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
 		stream().undeploy(streamName);
 		CommandResult cmdResult = executeCommand("runtime modules");
@@ -92,7 +92,7 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testListRuntimeModulesByContainerId() {
 		logger.info("Test listing of runtime modules by containerId");
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
 
 		Table table = (Table) executeCommand("runtime modules").getResult();
@@ -123,7 +123,7 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testListRuntimeModulesByInvalidContainerId() {
 		logger.info("Test listing of runtime modules by invalid containerId");
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
 		CommandResult cmdResult = executeCommand("runtime modules --containerId 10000");
 		Table table = (Table) cmdResult.getResult();

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpelPropertyAccessorIntegrationTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpelPropertyAccessorIntegrationTests.java
@@ -48,7 +48,7 @@ public class SpelPropertyAccessorIntegrationTests extends AbstractStreamIntegrat
 		HttpSource source = newHttpSource();
 
 		stream().create(
-				getStreamName(),
+				generateStreamName(),
 				"%s | json-to-tuple | transform --expression=payload.foo | %s",
 				source, sink);
 
@@ -66,7 +66,7 @@ public class SpelPropertyAccessorIntegrationTests extends AbstractStreamIntegrat
 		HttpSource source = newHttpSource();
 
 		stream().create(
-				getStreamName(),
+				generateStreamName(),
 				"%s | transform --expression=payload.foo.toString() | %s",
 				source, sink);
 
@@ -82,7 +82,7 @@ public class SpelPropertyAccessorIntegrationTests extends AbstractStreamIntegrat
 		HttpSource source = newHttpSource();
 
 		stream().create(
-				getStreamName(),
+				generateStreamName(),
 				"%s | json-to-tuple | transform --expression=payload.entities.hashtags.![text].toString() | %s",
 				source, sink);
 		String tweet = "{\"created_at\":\"Tue Aug 27 18:17:06 +0000 2013\",\"id\":100000,\"text\":\"whocares\",\"retweet_count\":0,"

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandTests.java
@@ -48,7 +48,7 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testStreamLifecycleForTickTock() throws InterruptedException {
 		logger.info("Starting Stream Test for TickTock");
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
 		stream().undeploy(streamName);
 	}
@@ -56,7 +56,7 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testStreamCreateDuplicate() throws InterruptedException {
 		logger.info("Create tictock stream");
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		String streamDefinition = "time | log";
 		stream().create(streamName, streamDefinition);
 
@@ -69,7 +69,7 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testCreatingTapWithSameNameAsExistingStream_xd299() {
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		CommandResult cr = getShell().executeCommand(
 				"stream create --name " + streamName + " --definition \"" + getTapName(streamName) + " > counter\"");
 		assertTrue("Failure. CommandResult = " + cr.toString(), !cr.isSuccess());
@@ -80,7 +80,7 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testStreamDestroyMissing() {
 		logger.info("Destroy a stream that doesn't exist");
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		CommandResult cr = getShell().executeCommand("stream destroy --name " + streamName);
 		assertTrue("Failure.  CommandResult = " + cr.toString(), !cr.isSuccess());
 		assertTrue("Failure.  CommandResult = " + cr.toString(),
@@ -90,7 +90,7 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testStreamCreateDuplicateWithDeployFalse() {
 		logger.info("Create 2 tictok streams with --deploy = false");
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		String streamDefinition = "time | log";
 		stream().createDontDeploy(streamName, streamDefinition);
 
@@ -106,7 +106,7 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testStreamDeployUndeployFlow() {
 		logger.info("Create tictok stream");
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		String streamDefinition = "time | log";
 		stream().createDontDeploy(streamName, streamDefinition);
 
@@ -124,7 +124,7 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testNamedChannelWithNoConsumerShouldBuffer() {
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		logger.info("Create " + streamName + " stream");
 		HttpSource source = newHttpSource();
 		stream().create(streamName, "%s > queue:foox", source);
@@ -134,8 +134,8 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	@Test
 	public void testNamedChannelsLinkingSourceAndSink() {
 		HttpSource source = newHttpSource();
-		stream().create(getStreamName(), "%s > queue:foo", source);
-		stream().create(getStreamName(), "queue:foo > transform --expression=payload.toUpperCase() | log");
+		stream().create(generateStreamName(), "%s > queue:foo", source);
+		stream().create(generateStreamName(), "queue:foo > transform --expression=payload.toUpperCase() | log");
 		source.postData("blahblah");
 	}
 
@@ -146,9 +146,9 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	public void testProcessorLinkingChannels() throws Exception {
 		FileSink sink = newFileSink().binary(true);
 		HttpSource source = newHttpSource(9314);
-		stream().create(getStreamName(), "%s > queue:foo", source);
-		stream().create(getStreamName(), "queue:foo > transform --expression=payload.toUpperCase() > queue:bar");
-		stream().create(getStreamName(), "queue:bar > %s", sink);
+		stream().create(generateStreamName(), "%s > queue:foo", source);
+		stream().create(generateStreamName(), "queue:foo > transform --expression=payload.toUpperCase() > queue:bar");
+		stream().create(generateStreamName(), "queue:bar > %s", sink);
 		source.postData("blahblah");
 		assertThat(sink, eventually(hasContentsThat(equalTo("BLAHBLAH"))));
 
@@ -156,15 +156,15 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testDefiningSubstream() {
-		stream().createDontDeploy(getStreamName(), "transform --expression=payload.replace('Andy','zzz')");
+		stream().createDontDeploy(generateStreamName(), "transform --expression=payload.replace('Andy','zzz')");
 	}
 
 	@Test
 	public void testUsingSubstream() {
 		HttpSource httpSource = newHttpSource();
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().createDontDeploy(streamName, "transform --expression=payload.replace('Andy','zzz')");
-		stream().create(getStreamName(), "%s | %s | log", httpSource, streamName);
+		stream().create(generateStreamName(), "%s | %s | log", httpSource, streamName);
 		httpSource.ensureReady().postData("fooAndyfoo");
 	}
 
@@ -172,9 +172,9 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	public void testUsingCompositionWithParameterizationAndDefaultValue() throws IOException {
 		FileSink sink = newFileSink().binary(true);
 		HttpSource httpSource = newHttpSource();
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().createDontDeploy(streamName, "transform --expression=payload.replace('${text:rys}','.')");
-		stream().create(getStreamName(), "%s | %s | %s", httpSource, streamName, sink);
+		stream().create(generateStreamName(), "%s | %s | %s", httpSource, streamName, sink);
 
 		httpSource.ensureReady().postData("Dracarys!");
 		assertThat(sink, eventually(hasContentsThat(equalTo("Draca.!"))));
@@ -185,9 +185,9 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	public void testParameterizedStreamComposition() throws IOException {
 		HttpSource httpSource = newHttpSource();
 		FileSink sink = newFileSink().binary(true);
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().createDontDeploy(streamName, "transform --expression=payload.replace('${text}','.')");
-		stream().create(getStreamName(), "%s | %s --text=aca | %s", httpSource, streamName, sink);
+		stream().create(generateStreamName(), "%s | %s --text=aca | %s", httpSource, streamName, sink);
 		httpSource.ensureReady().postData("Dracarys!");
 		assertThat(sink, eventually(hasContentsThat(equalTo("Dr.rys!"))));
 
@@ -196,10 +196,10 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	public void testComposedModules() throws IOException {
 		FileSink sink = newFileSink().binary(true);
 		HttpSource httpSource = newHttpSource();
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().createDontDeploy(streamName,
 				"filter --expression=true | transform --expression=payload.replace('abc','...')");
-		stream().create(getStreamName(), "%s | %s | %s", httpSource, streamName, sink);
+		stream().create(generateStreamName(), "%s | %s | %s", httpSource, streamName, sink);
 		httpSource.postData("abcdefghi!");
 		assertThat(sink, eventually(hasContentsThat(equalTo("...defghi!"))));
 
@@ -209,10 +209,10 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	public void testFilteringSource() throws IOException {
 		FileSink sink = newFileSink().binary(true);
 		HttpSource httpSource = newHttpSource();
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().createDontDeploy(streamName,
 				"%s | filter --expression=payload.contains('e')", httpSource);
-		stream().create(getStreamName(), "%s | transform --expression=payload.replace('e','.') | %s", streamName,
+		stream().create(generateStreamName(), "%s | transform --expression=payload.replace('e','.') | %s", streamName,
 				sink);
 		httpSource.postData("foobar");
 		httpSource.postData("hello");
@@ -227,10 +227,10 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	public void testParameterizedComposedSource() throws IOException {
 		FileSink sink = newFileSink().binary(true);
 		HttpSource httpSource = newHttpSource();
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().createDontDeploy(streamName,
 				"%s | filter --expression=payload.contains('${word}')", httpSource);
-		stream().create(getStreamName(), "%s --word=foo | %s", streamName, sink);
+		stream().create(generateStreamName(), "%s --word=foo | %s", streamName, sink);
 		httpSource.postData("foobar");
 		httpSource.postData("hello");
 		httpSource.postData("custardfoo");
@@ -243,10 +243,10 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	public void testComposedStreamThatIsItselfDeployable() throws IOException {
 		FileSink sink = newFileSink();
 		HttpSource httpSource = newHttpSource();
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().createDontDeploy(streamName,
 				"%s | filter --expression=payload.contains('${word:foo}') | %s", httpSource, sink);
-		stream().create(getStreamName(), streamName);
+		stream().create(generateStreamName(), streamName);
 		httpSource.postData("foobar");
 		httpSource.postData("hello");
 		httpSource.postData("custardfoo");
@@ -260,13 +260,13 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	public void testNestedStreamComposition() throws IOException {
 		HttpSource source = newHttpSource();
 		FileSink sink = newFileSink().binary(true);
-		String streamName1 = getStreamName();
-		String streamName2 = getStreamName();
-		String streamName3 = getStreamName();
+		String streamName1 = generateStreamName();
+		String streamName2 = generateStreamName();
+		String streamName3 = generateStreamName();
 		stream().createDontDeploy(streamName1, "transform --expression=payload.replaceAll('${from}','${to}')");
 		stream().createDontDeploy(streamName2, "%s --from=a --to=z | %s --from=b --to=y", streamName1, streamName1);
 		stream().create(streamName3, "%s | %s | filter --expression=true | %s", source, streamName2, sink);
-		stream().create(getStreamName(), "%s.filter > log", getTapName(streamName3)); // will log zzyyccxxyyzz
+		stream().create(generateStreamName(), "%s.filter > log", getTapName(streamName3)); // will log zzyyccxxyyzz
 		source.postData("aabbccxxyyzz");
 		assertThat(sink, eventually(hasContentsThat(equalTo("zzyyccxxyyzz"))));
 
@@ -283,14 +283,14 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 		FileSink tapsink5 = newFileSink().binary(true);
 		FileSink tapsink6 = newFileSink().binary(true);
 
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().create(streamName, "%s | transform --expression=payload.toUpperCase() | %s", httpSource, sink);
-		stream().create(getStreamName(), "%s > transform --expression=payload.replaceAll('A','.') | %s",
+		stream().create(generateStreamName(), "%s > transform --expression=payload.replaceAll('A','.') | %s",
 				getTapName(streamName), tapsink3);
-		stream().create(getStreamName(),
+		stream().create(generateStreamName(),
 				"%s.transform > transform --expression=payload.replaceAll('A','.') | %s", getTapName(streamName),
 				tapsink5);
-		stream().create(getStreamName(),
+		stream().create(generateStreamName(),
 				"%s.0 > transform --expression=payload.replaceAll('A','.') | %s", getTapName(streamName), tapsink6);
 		// use the tap channel as a sink. Not very useful currently but will be once we allow users to create pub/sub
 		// channels
@@ -325,12 +325,12 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 		HttpSource source = newHttpSource();
 		FileSink sink = newFileSink().binary(true);
 		FileSink tapsink1 = newFileSink().binary(true);
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().create(
 				streamName,
 				"%s | flibble: transform --expression=payload.toUpperCase() | flibble2: transform --expression=payload.toUpperCase() | %s"
 				, source, sink);
-		stream().create(getStreamName(),
+		stream().create(generateStreamName(),
 				"%s.flibble > transform --expression=payload.replaceAll('A','.') | %s", getTapName(streamName),
 				tapsink1);
 		source.ensureReady().postData("Dracarys!");
@@ -346,15 +346,15 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 		FileSink tapsink3 = newFileSink().binary(true);
 		FileSink tapsink5 = newFileSink().binary(true);
 
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().create(streamName,
 				"%s | transform --expression=payload.toUpperCase() | filter --expression=true > queue:foobar", source);
-		stream().create(getStreamName(), "queue:foobar > %s", sink);
+		stream().create(generateStreamName(), "queue:foobar > %s", sink);
 
-		stream().create(getStreamName(),
+		stream().create(generateStreamName(),
 				"%s > transform --expression=payload.replaceAll('r','.') | %s", getTapName(streamName), tapsink3);
 
-		stream().create(getStreamName(),
+		stream().create(generateStreamName(),
 				"%s.filter > transform --expression=payload.replaceAll('A','.') | %s", getTapName(streamName), tapsink5);
 
 		source.ensureReady().postData("Dracarys!");
@@ -375,11 +375,11 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 
 		HttpSource source = newHttpSource();
 
-		String streamName = getStreamName();
+		String streamName = generateStreamName();
 		stream().create(streamName, "%s | flibble: transform --expression=payload.toUpperCase() | %s", source, sink1);
-		stream().create(getStreamName(),
+		stream().create(generateStreamName(),
 				"%s.transform > transform --expression=payload.replaceAll('a','.') | %s", getTapName(streamName), sink2);
-		stream().create(getStreamName(),
+		stream().create(generateStreamName(),
 				"%s.flibble > transform --expression=payload.replaceAll('a','.') | %s", getTapName(streamName), sink3);
 
 		source.ensureReady().postData("Dracarys!");
@@ -397,10 +397,10 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 		HttpSource source2 = newHttpSource();
 		HttpSource source3 = newHttpSource();
 		FileSink sink = newFileSink().binary(true);
-		String streamName = getStreamName();
-		stream().create(getStreamName(), "%s > queue:foo", source1);
+		String streamName = generateStreamName();
+		stream().create(generateStreamName(), "%s > queue:foo", source1);
 		stream().create(streamName, "%s > queue:foo", source2);
-		stream().create(getStreamName(), "queue:foo > %s", sink);
+		stream().create(generateStreamName(), "queue:foo > %s", sink);
 
 		source1.ensureReady().postData("Dracarys!");
 		source2.ensureReady().postData("testing");
@@ -413,7 +413,7 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 		source1.ensureReady().postData("stillup");
 		assertThat(sink, eventually(hasContentsThat(equalTo("Dracarys!testingstillup"))));
 
-		stream().create(getStreamName(), "%s > queue:foo", source3);
+		stream().create(generateStreamName(), "%s > queue:foo", source3);
 		source3.ensureReady().postData("newstream");
 		assertThat(sink, eventually(hasContentsThat(equalTo("Dracarys!testingstillupnewstream"))));
 	}
@@ -422,7 +422,7 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 	public void testJsonPath() throws IOException {
 		HttpSource source = newHttpSource();
 		FileSink sink = newFileSink().binary(true);
-		stream().create(getStreamName(),
+		stream().create(generateStreamName(),
 				"%s | transform --expression='#jsonPath(payload, \"$.foo.bar\")' | %s",
 				source, sink);
 		source.ensureReady().postData("{\"foo\":{\"bar\":\"123\"}}");
@@ -431,8 +431,8 @@ public class StreamCommandTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testDestroyTap() {
-		String streamName = getStreamName();
-		String tapName = getStreamName();
+		String streamName = generateStreamName();
+		String tapName = generateStreamName();
 		stream().create(streamName, "file | log");
 		stream().create(tapName, "%s > queue:foo", getTapName(streamName));
 		stream().destroyStream(streamName);

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/TcpModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/TcpModulesTests.java
@@ -41,7 +41,7 @@ public class TcpModulesTests extends AbstractStreamIntegrationTest {
 	public void testTcpSource() throws Exception {
 		TcpSource tcpSource = newTcpSource();
 		FileSink fileSink = newFileSink().binary(true);
-		stream().create(getStreamName(), "%s | %s", tcpSource, fileSink);
+		stream().create(generateStreamName(), "%s | %s", tcpSource, fileSink);
 
 		// Following \r\n is because of CRLF deserializer
 		tcpSource.ensureReady().sendBytes("Hello\r\n".getBytes("UTF-8"));
@@ -56,7 +56,7 @@ public class TcpModulesTests extends AbstractStreamIntegrationTest {
 		HttpSource httpSource = newHttpSource();
 
 
-		stream().create(getStreamName(), "%s | %s", httpSource, tcpSink);
+		stream().create(generateStreamName(), "%s | %s", httpSource, tcpSink);
 		httpSource.ensureReady().postData("Hi there!");
 		// The following CRLF is b/c of the default tcp serializer
 		// NOT because of FileSink

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/TriggerModulesTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/TriggerModulesTest.java
@@ -37,7 +37,7 @@ public class TriggerModulesTest extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void receivesContentsInstantlyByDefault() {
-		stream().create(getStreamName(), "trigger --payload='Hello' | %s", binaryFileSink);
+		stream().create(generateStreamName(), "trigger --payload='Hello' | %s", binaryFileSink);
 
 		assertThat(binaryFileSink, eventually(hasContentsThat(equalTo("Hello"))));
 	}
@@ -45,7 +45,7 @@ public class TriggerModulesTest extends AbstractStreamIntegrationTest {
 	@Test
 	public void doesNotReceiveAnyContentsForAFarFuture() {
 		stream().create(
-				getStreamName(), "trigger --payload='Hello' --date='25/12/2032' --dateFormat='dd/MM/yyyy' | %s",
+				generateStreamName(), "trigger --payload='Hello' --date='25/12/2032' --dateFormat='dd/MM/yyyy' | %s",
 				binaryFileSink
 				);
 


### PR DESCRIPTION
- Changed the method name getStreamName()/getJobName() to read generateStreamName()/generateJobName()
- Refactored the methods
