### PR TITLE
XD-822 JSON to/from Tuple handling of id, timestamp

### DIFF
--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/JsonStringToTupleConverter.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/JsonStringToTupleConverter.java
@@ -54,15 +54,7 @@ public class JsonStringToTupleConverter implements Converter<String, Tuple> {
 					builder.addEntry(name, nodeToList(node));
 				}
 				else {
-					if (name.equals("id")) {
-						// TODO how should this be handled?
-					}
-					else if (name.equals("timestamp")) {
-						// TODO how should this be handled?
-					}
-					else {
-						builder.addEntry(name, node.asText());
-					}
+					builder.addEntry(name, node.asText());
 				}
 			}
 		}

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleToJsonStringConverter.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleToJsonStringConverter.java
@@ -41,8 +41,6 @@ public class TupleToJsonStringConverter implements Converter<Tuple, String> {
 
 	private ObjectNode toObjectNode(Tuple source) {
 		ObjectNode root = mapper.createObjectNode();
-		root.put("id", source.getId().toString());
-		root.put("timestamp", source.getTimestamp());
 		for (int i = 0; i < source.size(); i++) {
 			Object value = source.getValues().get(i);
 			String name = source.getFieldNames().get(i);


### PR DESCRIPTION
id and timestamp fields in JSON were being ignored when converted to Tuple.
These are now written to the list of named fields, independent of the Tuple's
own id and timestamp properties. When converting a Tuple to JSON, the Tuple id
and timestamp are no longer written to the JSON.
