### PR TITLE
XD-1276 Add job and step listeners to OOTB jobs

### DIFF
--- a/modules/job/filejdbc/config/filejdbc.xml
+++ b/modules/job/filejdbc/config/filejdbc.xml
@@ -14,7 +14,13 @@
 			<batch:tasklet>
 				<batch:chunk reader="multiResourceReader" writer="itemWriter" commit-interval="100"/>
 			</batch:tasklet>
+			<batch:listeners>
+				<batch:listener ref="xdStepExecutionListener"/>
+			</batch:listeners>
 		</batch:step>
+		<batch:listeners>
+			<batch:listener ref="xdJobExecutionListener"/>
+		</batch:listeners>
 	</batch:job>
 
 	<bean id="multiResourceReader" class="org.springframework.batch.item.file.MultiResourceItemReader" scope="step">

--- a/modules/job/filepollhdfs.xml
+++ b/modules/job/filepollhdfs.xml
@@ -12,7 +12,13 @@
 			<batch:tasklet>
 				<batch:chunk reader="itemReader" writer="itemWriter" commit-interval="100"/>
 			</batch:tasklet>
+			<batch:listeners>
+				<batch:listener ref="xdStepExecutionListener"/>
+			</batch:listeners>
 		</batch:step>
+		<batch:listeners>
+			<batch:listener ref="xdJobExecutionListener"/>
+		</batch:listeners>
 	</batch:job>
 
 	<bean id="itemReader" class="org.springframework.batch.item.file.FlatFileItemReader" scope="step">

--- a/modules/job/hdfsjdbc/config/hdfsjdbc.xml
+++ b/modules/job/hdfsjdbc/config/hdfsjdbc.xml
@@ -16,7 +16,13 @@
 			<batch:tasklet>
 				<batch:chunk reader="multiResourceReader" writer="itemWriter" commit-interval="100"/>
 			</batch:tasklet>
+			<batch:listeners>
+				<batch:listener ref="xdStepExecutionListener"/>
+			</batch:listeners>
 		</batch:step>
+		<batch:listeners>
+			<batch:listener ref="xdJobExecutionListener"/>
+		</batch:listeners>
 	</batch:job>
 
 	<bean id="multiResourceReader" class="org.springframework.batch.item.file.MultiResourceItemReader" scope="step">

--- a/modules/job/hdfsmongodb/config/hdfsmongodb.xml
+++ b/modules/job/hdfsmongodb/config/hdfsmongodb.xml
@@ -18,7 +18,13 @@
 			<batch:tasklet>
 				<batch:chunk reader="multifileReader" writer="itemWriter" commit-interval="100"/>
 			</batch:tasklet>
+			<batch:listeners>
+				<batch:listener ref="xdStepExecutionListener"/>
+			</batch:listeners>
 		</batch:step>
+		<batch:listeners>
+			<batch:listener ref="xdJobExecutionListener"/>
+		</batch:listeners>
 	</batch:job>
 
 	<bean id="multifileReader" class="org.springframework.batch.item.file.MultiResourceItemReader" scope="step">

--- a/modules/job/jdbchdfs/config/jdbchdfs.xml
+++ b/modules/job/jdbchdfs/config/jdbchdfs.xml
@@ -16,7 +16,13 @@
 			<batch:tasklet>
 				<batch:chunk reader="itemReader" writer="itemWriter" commit-interval="100"/>
 			</batch:tasklet>
+			<batch:listeners>
+				<batch:listener ref="xdStepExecutionListener"/>
+			</batch:listeners>
 		</batch:step>
+		<batch:listeners>
+			<batch:listener ref="xdJobExecutionListener"/>
+		</batch:listeners>
 	</batch:job>
 
 	<bean id="dataSource" class="org.apache.tomcat.jdbc.pool.DataSource" destroy-method="close">

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/BatchListenerEventType.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/BatchListenerEventType.java
@@ -25,6 +25,7 @@ package org.springframework.xd.dirt.plugins.job.support.listener;
  */
 public enum BatchListenerEventType {
 
+	JOB_EXECUTION_LISTENER_BEFORE_JOB,
 	JOB_EXECUTION_LISTENER_AFTER_JOB,
 
 	STEP_EXECUTION_LISTENER_BEFORE_STEP,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdJobExecutionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdJobExecutionListener.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.batch.core.listener.JobExecutionListenerSupport;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.MessageChannel;
@@ -29,7 +30,7 @@ import org.springframework.xd.dirt.plugins.job.BatchJobHeaders;
  * @author Gunnar Hillert
  * @since 1.0
  */
-public class SimpleXdJobExecutionListener extends JobExecutionListenerSupport {
+public class SimpleXdJobExecutionListener implements JobExecutionListener {
 
 	private static final Log logger = LogFactory.getLog(SimpleXdJobExecutionListener.class);
 
@@ -37,6 +38,17 @@ public class SimpleXdJobExecutionListener extends JobExecutionListenerSupport {
 
 	public void setNotificationsChannel(MessageChannel notificationsChannel) {
 		this.notificationsChannel = notificationsChannel;
+	}
+
+	@Override
+	public void beforeJob(JobExecution jobExecution) {
+		if (logger.isDebugEnabled()) {
+			logger.debug("Executing beforeJob: " + jobExecution);
+		}
+		notificationsChannel.send(MessageBuilder.withPayload(jobExecution)
+				.setHeader(BatchJobHeaders.BATCH_LISTENER_EVENT_TYPE,
+						BatchListenerEventType.JOB_EXECUTION_LISTENER_BEFORE_JOB.name())
+				.build());
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/job-module-beans.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/job/job-module-beans.xml
@@ -34,7 +34,7 @@
 	<int:channel id="jobLaunchingChannel"/>
 
 	<int:service-activator id="jobLaunchingMessageHandler" method="launch"
-		input-channel="jobLaunchingChannel" output-channel="notifications">
+		input-channel="jobLaunchingChannel" output-channel="nullChannel">
 		<bean class="org.springframework.batch.integration.launch.JobLaunchingMessageHandler">
 			<constructor-arg ref="jobLauncher"/>
 		</bean>

--- a/src/test/scripts/jdbc_tests
+++ b/src/test/scripts/jdbc_tests
@@ -64,9 +64,15 @@ assert_equals 292 $rows
 echo -e "\n\n Test 4. Load multiple CSV files using filejdbc jobs with table name specified\n"
 
 create_job csvjdbcjob1 "filejdbc --driverClass=org.sqlite.JDBC --url=jdbc:sqlite:$DB_FILE --names=col1,col2,col3 --resources=file://$PWD/csv/data.csv --tableName=JOB_TABLE --initializeDatabase=true"
+create_stream job1Notifications "queue:job:csvjdbcjob1-notifications > file --dir=$TEST_DIR"
 launch_job csvjdbcjob1
 sleep 5
 destroy_job csvjdbcjob1
+destroy_stream job1Notifications
+
+nJobMessages=`wc -l $TEST_DIR/job1Notifications.out`
+assert_equals 4 $nJobMessages
+
 create_job csvjdbcjob2 "filejdbc --driverClass=org.sqlite.JDBC --url=jdbc:sqlite:$DB_FILE --names=col1,col2,col3 --resources=file://$PWD/csv/data.csv --tableName=JOB_TABLE --initializeDatabase=false"
 launch_job csvjdbcjob2
 sleep 5


### PR DESCRIPTION
- Adds builtin listeners to job config files.
- Removes notifications from launcher to avoid dup job execution
  msgs.
- Adds beforeJob notifications in default job listener
- Adds a basic script test to check notifications
