### PR TITLE
XD-1274 Fix Schema Imports

### DIFF
--- a/extensions/spring-xd-extension-reactor/src/main/resources/org/springframework/xd/integration/reactor/config/spring-integration-reactor.xsd
+++ b/extensions/spring-xd-extension-reactor/src/main/resources/org/springframework/xd/integration/reactor/config/spring-integration-reactor.xsd
@@ -11,7 +11,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
 	<xsd:import namespace="http://www.springframework.org/schema/integration"
-				schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+				schemaLocation="http://www.springframework.org/schema/integration/spring-integration-4.0.xsd"/>
 
 	<xsd:annotation>
 	<xsd:documentation>

--- a/spring-xd-hadoop/src/main/resources/org/springframework/xd/integration/hadoop/config/spring-integration-hadoop.xsd
+++ b/spring-xd-hadoop/src/main/resources/org/springframework/xd/integration/hadoop/config/spring-integration-hadoop.xsd
@@ -9,7 +9,7 @@
 
 	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
 	<xsd:import namespace="http://www.springframework.org/schema/integration"
-		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-3.0.xsd"/>
+		schemaLocation="http://www.springframework.org/schema/integration/spring-integration-4.0.xsd"/>
 
 	<xsd:annotation>
 		<xsd:documentation><![CDATA[


### PR DESCRIPTION
Reactor and Hadoop were importing the core SI 3.0 schema
instead of 4.0.
