### PR TITLE
XD-1271 Enable Endpoint RequestHandlers

### DIFF
--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -39,18 +39,6 @@ server:
 ---
 
 spring:
-  profiles: memory
-transport: local
-analytics: memory
-store: memory
-server:
-  port: -1
-management:
-  port: -1
-
----
-
-spring:
   profiles: rabbit
 transport: rabbit
 
@@ -73,8 +61,6 @@ spring:
   batch:
     initializer:
       enabled: false
-management:
-  port: ${PORT:0}
 server:
   port: ${PORT:0}
 


### PR DESCRIPTION
- By default, Boot's EndpointWebMvcAutoConfiguration disables
  Endpoints request handlers if the management port set to '0'
  If we remove the explicit setting of management port to '0' then
  the management port will use the server properties port and
  the Endpoint request handlers are enabled.
- Also, removed unused "memory" profile
