### PR TITLE
XD-874 Support for deleting job files after import

### DIFF
--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/ResourcesIntoJdbcJobModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/ResourcesIntoJdbcJobModuleOptionsMetadata.java
@@ -32,6 +32,7 @@ public class ResourcesIntoJdbcJobModuleOptionsMetadata extends
 
 	private String resources;
 
+	private Boolean deleteFiles;
 
 	public ResourcesIntoJdbcJobModuleOptionsMetadata() {
 		configProperties = "batch-jdbc";
@@ -52,6 +53,11 @@ public class ResourcesIntoJdbcJobModuleOptionsMetadata extends
 		this.resources = resources;
 	}
 
+	@ModuleOption("whether to delete files after import")
+	public void setDeleteFiles(Boolean deleteFiles) {
+		this.deleteFiles = deleteFiles;
+	}
+
 	public Boolean getRestartable() {
 		return restartable;
 	}
@@ -64,4 +70,7 @@ public class ResourcesIntoJdbcJobModuleOptionsMetadata extends
 		return resources;
 	}
 
+	public Boolean getDeleteFiles() {
+		return deleteFiles;
+	}
 }

--- a/modules/job/filejdbc/config/filejdbc.xml
+++ b/modules/job/filejdbc/config/filejdbc.xml
@@ -20,8 +20,14 @@
 		</batch:step>
 		<batch:listeners>
 			<batch:listener ref="xdJobExecutionListener"/>
+			<batch:listener ref="fileDeletionListener" />
 		</batch:listeners>
 	</batch:job>
+
+	<bean id="fileDeletionListener" class="org.springframework.xd.dirt.plugins.job.support.listener.FileDeletionJobExecutionListener">
+		<property name="resources" value="${resources}"/>
+		<property name="deleteFiles" value="${deleteFiles:false}"/>
+	</bean>
 
 	<bean id="multiResourceReader" class="org.springframework.batch.item.file.MultiResourceItemReader" scope="step">
 		<property name="resources" value="${resources}"/>

--- a/modules/job/filepollhdfs.xml
+++ b/modules/job/filepollhdfs.xml
@@ -18,8 +18,13 @@
 		</batch:step>
 		<batch:listeners>
 			<batch:listener ref="xdJobExecutionListener"/>
+			<batch:listener ref="fileDeletionListener" />
 		</batch:listeners>
 	</batch:job>
+
+	<bean id="fileDeletionListener" class="org.springframework.xd.dirt.plugins.job.support.listener.FileDeletionJobExecutionListener">
+		<property name="deleteFiles" value="${deleteFiles:false}"/>
+	</bean>
 
 	<bean id="itemReader" class="org.springframework.batch.item.file.FlatFileItemReader" scope="step">
 		<property name="resource" value="file:///#{jobParameters['absoluteFilePath']}" />

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/FileDeletionJobExecutionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/FileDeletionJobExecutionListener.java
@@ -1,0 +1,90 @@
+package org.springframework.xd.dirt.plugins.job.support.listener;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.core.io.Resource;
+import org.springframework.xd.dirt.plugins.job.ExpandedJobParametersConverter;
+
+/**
+ * Job listener which can be used to deleted files once they have been successfully processed by XD.
+ *
+ * Can be used in one of two different ways:
+ *
+ * 1. If the 'resources' property is set, it will try to delete each resource as a file.
+ * 2. Otherwise, it will try to locate the 'absoluteFilePath' parameter in the job parameters and
+ *    delete this file if it exists.
+ *
+ * @author Luke Taylor
+ */
+public class FileDeletionJobExecutionListener implements JobExecutionListener {
+	private boolean deleteFiles;
+	private Resource[] resources;
+	private Log logger = LogFactory.getLog(getClass());
+
+	public void beforeJob(JobExecution jobExecution) {
+	}
+
+	@Override
+	public void afterJob(JobExecution jobExecution) {
+		if (!deleteFiles) {
+			return;
+		}
+
+		if (jobExecution.getStatus().equals(BatchStatus.STOPPED) || jobExecution.getStatus().isUnsuccessful()) {
+			logger.warn("Job is stopped, or failed to complete successfully. File deletion will be skipped");
+			return;
+		}
+
+		if (resources != null) {
+			deleteResources();
+		}
+		else {
+			deleteFilePath(jobExecution.getJobParameters().getString(ExpandedJobParametersConverter.ABSOLUTE_FILE_PATH));
+		}
+	}
+
+	private void deleteResources() {
+		for(Resource r : resources) {
+			if (r.exists()) {
+				try {
+					r.getFile().delete();
+				}
+				catch (IOException e) {
+					logger.error("Failed to delete " + r, e);
+				}
+			}
+		}
+	}
+
+	private void deleteFilePath(String filePath) {
+		if (filePath == null) {
+			// Nothing to delete
+			return;
+		}
+
+		File f = new File(filePath);
+		if (f.exists()) {
+			logger.info("Deleting file " + filePath);
+			f.delete();
+		}
+		else {
+			logger.warn("File '" + filePath + "' does not exist.");
+		}
+
+	}
+
+	public void setDeleteFiles(boolean deleteFiles) {
+		this.deleteFiles = deleteFiles;
+	}
+
+	public void setResources(Resource[] resources) {
+		this.resources = resources;
+	}
+}
+

--- a/src/test/scripts/hdfs_import_export_tests
+++ b/src/test/scripts/hdfs_import_export_tests
@@ -34,32 +34,55 @@ assert_equals 6358 $blah_size || exit $?
 
 echo -e "\n\n*** Test 2. Import duplicate copies of a CSV data file\n"
 
-if [[ ! -f $TEST_DIR/csv/data1.csv ]]
-then
-  mkdir -p $TEST_DIR/csv
-  for i in {1..4}
-  do
-    echo "Copying csv file $i to $TEST_DIR/csv"
-    cp $PWD/csv/data.csv "$TEST_DIR/csv/data$i.csv"
-  done
-fi
+copy_files() {
+  if [[ ! -f $TEST_DIR/csv/data1.csv ]]
+  then
+    mkdir -p $TEST_DIR/csv
+    for i in {1..4}
+    do
+      echo "Copying csv file $i to $TEST_DIR/csv"
+      cp $PWD/csv/data.csv "$TEST_DIR/csv/data$i.csv"
+    done
+  fi
+}
 
-create_job csvjob2 "filepollhdfs --names=col1,col2,col3 --rollover=5000 --directory=$BASE_PATH --fileExtension=csv"
+copy_files
+create_job csvjob2 "filepollhdfs --deleteFiles=true --names=col1,col2,col3 --rollover=5000 --directory=$BASE_PATH --fileExtension=csv"
 create_stream csvstream2 "file --ref=true --dir=$TEST_DIR/csv --pattern=*.csv > queue:job:csvjob2"
 
-echo -e "\nWaiting for jobs to finish..."
-sleep 25;
+count_files() {
+  local nCsvFiles=`ls $TEST_DIR/csv | xargs -n 1 | wc -l`
+  echo "$nCsvFiles"
+}
+
+i=5
+while [ $i != 0 ]
+do
+  nFiles=`count_files`
+  if [ $nFiles != 0 ]
+  then
+    echo "Waiting for jobs to finish..."; sleep 5
+    ((i--))
+  else
+    i=0
+  fi
+done
+
 
 job2_size=`hdfs_size "$BASE_PATH/csvjob2*"`
 
 destroy_stream csvstream2
 destroy_job    csvjob2
 
+nCsvFiles=`count_files`
+assert_equals 0 $nCsvFiles
+
 echo "Checking size of HDFS results matches imports from $TEST_DIR/csv"
 assert_equals 25432 $job2_size
 
 echo -e "\n\n*** Test 3. Import files using hdfs sink\n"
 
+copy_files
 create_stream csvstream3 "file --dir=$TEST_DIR/csv --pattern=data1.csv --outputType=text/plain | hdfs --directory=$BASE_PATH"
 sleep 10
 undeploy_stream csvstream3

--- a/src/test/scripts/jdbc_tests
+++ b/src/test/scripts/jdbc_tests
@@ -51,9 +51,10 @@ assert_equals 1 $rows
 payload=`sqlite3 $DB_FILE 'select payload from jdbc2'`
 assert_equals 'blahblah' $payload
 
-echo -e "\n\n Test 3. Load single CSV file using filejdbc job with defaults\n"
+echo -e "\n\n Test 3. Load single CSV file using filejdbc job with defaults, deleting file after import\n"
+cp $PWD/csv/data.csv $TEST_DIR/delete_after_use.csv
 
-create_job csvjdbcjob0 "filejdbc --driverClass=org.sqlite.JDBC --url=jdbc:sqlite:$DB_FILE --names=col1,col2,col3 --resources=file://$PWD/csv/data.csv --initializeDatabase=true"
+create_job csvjdbcjob0 "filejdbc --deleteFiles=true --driverClass=org.sqlite.JDBC --url=jdbc:sqlite:$DB_FILE --names=col1,col2,col3 --resources=file://$TEST_DIR/delete_after_use.csv --initializeDatabase=true"
 launch_job csvjdbcjob0
 sleep 5
 rows=`sqlite3 $DB_FILE 'select count(*) from csvjdbcjob0'`
@@ -61,9 +62,15 @@ destroy_job csvjdbcjob0
 echo "Checking row count in database table matches import from file..."
 assert_equals 292 $rows
 
+if [[ -f $TEST_DIR/delete_after_use.csv ]]
+then
+  echo "Data file was not deleted"
+  exit 1
+fi
+
 echo -e "\n\n Test 4. Load multiple CSV files using filejdbc jobs with table name specified\n"
 
-create_job csvjdbcjob1 "filejdbc --driverClass=org.sqlite.JDBC --url=jdbc:sqlite:$DB_FILE --names=col1,col2,col3 --resources=file://$PWD/csv/data.csv --tableName=JOB_TABLE --initializeDatabase=true"
+create_job csvjdbcjob1 "filejdbc --driverClass=org.sqlite.JDBC --url=jdbc:sqlite:$DB_FILE --url=jdbc:sqlite:$DB_FILE --names=col1,col2,col3 --resources=file://$PWD/csv/data.csv --tableName=JOB_DATA_TABLE --initializeDatabase=true"
 create_stream job1Notifications "queue:job:csvjdbcjob1-notifications > file --dir=$TEST_DIR"
 launch_job csvjdbcjob1
 sleep 5
@@ -73,11 +80,11 @@ destroy_stream job1Notifications
 nJobMessages=`wc -l $TEST_DIR/job1Notifications.out`
 assert_equals 4 $nJobMessages
 
-create_job csvjdbcjob2 "filejdbc --driverClass=org.sqlite.JDBC --url=jdbc:sqlite:$DB_FILE --names=col1,col2,col3 --resources=file://$PWD/csv/data.csv --tableName=JOB_TABLE --initializeDatabase=false"
+create_job csvjdbcjob2 "filejdbc --driverClass=org.sqlite.JDBC --url=jdbc:sqlite:$DB_FILE --names=col1,col2,col3 --resources=file://$PWD/csv/data.csv --tableName=JOB_DATA_TABLE --initializeDatabase=false"
 launch_job csvjdbcjob2
 sleep 5
 destroy_job csvjdbcjob2
-rows=`sqlite3 $DB_FILE 'select count(*) from JOB_TABLE'`
+rows=`sqlite3 $DB_FILE 'select count(*) from JOB_DATA_TABLE'`
 echo "Checking row count in database table matches import from file..."
 assert_equals 584 $rows
 


### PR DESCRIPTION
- filejdbc and filepollhdfs now support the 'deleteFiles' option. If set
  the job will delete the file(s) on successful completion.
- The class 'FileDeletionJobExecutionListener' is responsible for doing
  the work.
- script tests for both modules have been added which check files are
  actually deleted in practice.
