### PR TITLE
XD-1294 Update spring-xd-extension-reactor dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -391,7 +391,6 @@ project('spring-xd-dirt') {
 
 		// ************* Container: Imposed by some Module (can't move)
 		compile "com.sun.mail:javax.mail:$javaxMailVersion"
-		runtime project(":spring-xd-extension-reactor")
 
 		// The following is needed eg by twitter module b/c jackson classes
 		// are loaded by RestTemplate and RestTemplate is in Dirt
@@ -1025,12 +1024,11 @@ project('modules.source.twittersearch') {
 	}
 }
 
-// Does not work b/c of shared Reactor stuff in module-common.xml
-//project('modules.source.reactor-syslog') {
-//	dependencies {
-//		runtime project(":spring-xd-extension-reactor")
-//	}
-//}
+project('modules.source.reactor-syslog') {
+	dependencies {
+		runtime project(":spring-xd-extension-reactor")
+	}
+}
 
 // ================ M O D U L E S : P R O C E S S O R S ================
 

--- a/modules/source/reactor-syslog/config/reactor-syslog.xml
+++ b/modules/source/reactor-syslog/config/reactor-syslog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans:beans xmlns="http://www.springframework.org/schema/integration"
+<beans:beans xmlns="http://www.springframework.org/schema/beans"
 			 xmlns:int="http://www.springframework.org/schema/integration"
 			 xmlns:int-reactor="http://www.springframework.org/schema/integration/reactor"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -11,5 +11,7 @@
 	<int-reactor:syslog-inbound-channel-adapter id="syslog" port="${port}" channel="output" auto-startup="false"/>
 
 	<int:channel id="output"/>
+
+	<bean id="reactorEnv" class="reactor.core.Environment"/>
 
 </beans:beans>

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/module-common.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/module-common.xml
@@ -8,8 +8,6 @@
 	<!-- Parent context for all modules. Before adding beans here, consider contributing them
 	by means of Plugin.preProcessSharedContext -->
 
-	<bean id="reactorEnv" class="reactor.core.Environment"/>
-
 	<int:spel-property-accessors>
 	    <bean id="tuplePropertyAccessor" class="org.springframework.xd.tuple.spel.TuplePropertyAccessor" />
 	    <bean id="jsonPropertyAccessor" class="org.springframework.integration.json.JsonPropertyAccessor" />


### PR DESCRIPTION
- Move the reactor Environment bean definition out of module common context
- Remove the 'spring-xd-extension-reactor' runtime dependency from spring-xd-dirt
- Add back 'spring-xd-extension-reactor' runtime dependency to reactor-syslog module
