### PR TITLE
Updates for boot RC3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ ext {
 	springBatchVersion = '3.0.0.BUILD-SNAPSHOT'
 	springIntegrationVersion = '4.0.0.M3'
 	springAmqpVersion = '1.3.0.M2'
-	springBootVersion = '1.0.0.RC1'
+	springBootVersion = '1.0.0.BUILD-SNAPSHOT'
 	springCloudVersion = '0.9.2'
 	springBatchAdminMgrVersion = '1.3.0.M1'
 	springIntegrationSplunkVersion = '1.1.0.M1'

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommandLinePropertySourceOverridingListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommandLinePropertySourceOverridingListener.java
@@ -24,18 +24,12 @@ import java.util.Map;
 
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
-import org.springframework.boot.SpringApplicationEnvironmentAvailableEvent;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.boot.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.EnvironmentAware;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
-import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.PropertySource;
-import org.springframework.util.Assert;
 
 /**
  * An {@code ApplicationListener} that will parse command line options and also replace the default boot commandline
@@ -46,7 +40,7 @@ import org.springframework.util.Assert;
  * @author Luke Taylor
  */
 public class CommandLinePropertySourceOverridingListener<T extends CommonOptions> implements
-		ApplicationListener<SpringApplicationEnvironmentAvailableEvent> {
+		ApplicationListener<ApplicationEnvironmentPreparedEvent> {
 
 	private T options;
 
@@ -56,7 +50,7 @@ public class CommandLinePropertySourceOverridingListener<T extends CommonOptions
 	}
 
 	@Override
-	public void onApplicationEvent(SpringApplicationEnvironmentAvailableEvent event) {
+	public void onApplicationEvent(ApplicationEnvironmentPreparedEvent event) {
 		if (event.getArgs().length == 0) {
 			return;
 		}


### PR DESCRIPTION
A boot class we use has been renamed in the latest Boot snapshots.
This change fixes the compilation error.
