### PR TITLE
XD-1090: Add job restart command

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
@@ -26,13 +26,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.xd.dirt.job.JobExecutionAlreadyRunningException;
 import org.springframework.xd.dirt.job.JobExecutionInfo;
 import org.springframework.xd.dirt.job.JobExecutionNotRunningException;
@@ -51,7 +50,7 @@ import org.springframework.xd.rest.client.domain.JobExecutionInfoResource;
  * @author Gunnar Hillert
  * 
  */
-@Controller
+@RestController
 @RequestMapping("/batch/executions")
 @ExposesResourceFor(JobExecutionInfoResource.class)
 public class BatchJobExecutionsController {
@@ -62,9 +61,6 @@ public class BatchJobExecutionsController {
 
 	private final JobExecutionInfoResourceAssembler jobExecutionInfoResourceAssembler;
 
-	/**
-	 * @param timeZone the timeZone to set
-	 */
 	@Autowired(required = false)
 	@Qualifier("userTimeZone")
 	public void setTimeZone(TimeZone timeZone) {
@@ -87,7 +83,6 @@ public class BatchJobExecutionsController {
 	 */
 	@RequestMapping(value = { "" }, method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
 	public Collection<JobExecutionInfoResource> list(@RequestParam(defaultValue = "0") int startJobExecution,
 			@RequestParam(defaultValue = "20") int pageSize) {
 
@@ -99,22 +94,21 @@ public class BatchJobExecutionsController {
 	}
 
 	/**
-	 * @param jobExecutionId Id of the {@link JobExecution}
+	 * @param executionId Id of the {@link JobExecution}
 	 * @return JobExecutionInfo for the given job name
 	 * @throws NoSuchJobExecutionException Thrown if the {@link JobExecution} does not exist
 	 */
-	@RequestMapping(value = "/{jobExecutionId}", method = RequestMethod.GET)
+	@RequestMapping(value = "/{executionId}", method = RequestMethod.GET)
 	@ResponseStatus(HttpStatus.OK)
-	@ResponseBody
-	public JobExecutionInfoResource getJobExecutionInfo(@PathVariable Long jobExecutionId) {
+	public JobExecutionInfoResource getJobExecutionInfo(@PathVariable long executionId) {
 
 		final JobExecution jobExecution;
 
 		try {
-			jobExecution = jobService.getJobExecution(jobExecutionId);
+			jobExecution = jobService.getJobExecution(executionId);
 		}
 		catch (org.springframework.batch.core.launch.NoSuchJobExecutionException e) {
-			throw new NoSuchJobExecutionException(jobExecutionId);
+			throw new NoSuchJobExecutionException(executionId);
 		}
 
 		return jobExecutionInfoResourceAssembler.toResource(new JobExecutionInfo(jobExecution, timeZone));
@@ -127,7 +121,7 @@ public class BatchJobExecutionsController {
 	 */
 	@RequestMapping(value = { "/{executionId}" }, method = RequestMethod.PUT, params = "stop=true")
 	@ResponseStatus(HttpStatus.OK)
-	public void stopJobExecution(@PathVariable("executionId") Long jobExecutionId) {
+	public void stopJobExecution(@PathVariable("executionId") long jobExecutionId) {
 		try {
 			jobService.stop(jobExecutionId);
 		}
@@ -146,7 +140,7 @@ public class BatchJobExecutionsController {
 	 */
 	@RequestMapping(value = { "/{executionId}" }, method = RequestMethod.PUT, params = "restart=true")
 	@ResponseStatus(HttpStatus.OK)
-	public void restartJobExecution(@PathVariable("executionId") Long jobExecutionId) {
+	public void restartJobExecution(@PathVariable("executionId") long jobExecutionId) {
 
 		try {
 			jobService.restart(jobExecutionId);
@@ -176,7 +170,6 @@ public class BatchJobExecutionsController {
 
 	/**
 	 * Stop all job executions.
-	 * 
 	 */
 	@RequestMapping(value = { "" }, method = RequestMethod.PUT, params = "stop=true")
 	@ResponseStatus(HttpStatus.OK)

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/JobOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/JobOperations.java
@@ -75,6 +75,11 @@ public interface JobOperations extends ResourceOperations {
 	public void stopJobExecution(long jobExecutionId);
 
 	/**
+	 * Restart a given job execution.
+	 */
+	public void restartJobExecution(long jobExecutionId);
+
+	/**
 	 * Stop all job executions.
 	 */
 	public void stopAllJobExecutions();

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/JobTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/JobTemplate.java
@@ -96,6 +96,15 @@ public class JobTemplate extends AbstractTemplate implements JobOperations {
 	}
 
 	@Override
+	public void restartJobExecution(long executionId) {
+		String uriTemplate = resources.get("batch/executions").toString() + "/{executionId}";
+		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
+		values.add("executionId", executionId);
+		uriTemplate = uriTemplate + "?restart=true";
+		restTemplate.put(uriTemplate, values, executionId);
+	}
+
+	@Override
 	public void undeploy(String name) {
 		String uriTemplate = resources.get("jobs").toString() + "/{name}";
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
@@ -69,6 +69,8 @@ public class JobCommands implements CommandMarker {
 
 	private final static String STOP_JOB_EXECUTION = "job execution stop";
 
+	private final static String RESTART_JOB_EXECUTION = "job execution restart";
+
 	private final static String DEPLOY_JOB = "job deploy";
 
 	private final static String DEPLOY_ALL_JOBS = "job all deploy";
@@ -298,11 +300,18 @@ public class JobCommands implements CommandMarker {
 		}
 	}
 
-	@CliCommand(value = STOP_JOB_EXECUTION, help = "Stop the job execution that is running")
+	@CliCommand(value = STOP_JOB_EXECUTION, help = "Stop a job execution that is running")
 	public String stopJobExecution(
 			@CliOption(key = { "", "id" }, help = "the id of the job execution", mandatory = true) long executionId) {
 		jobOperations().stopJobExecution(executionId);
 		return String.format("Stopped Job execution that has executionId '%s'", executionId);
+	}
+
+	@CliCommand(value = RESTART_JOB_EXECUTION, help = "Restart a job that failed previously")
+	public String restartJobExecution(
+			@CliOption(key = { "", "id" }, help = "the id of the job execution that failed", mandatory = true) long executionId) {
+		jobOperations().restartJobExecution(executionId);
+		return String.format("Restarted Job execution that had executionId '%s'", executionId);
 	}
 
 	@CliCommand(value = DEPLOY_JOB, help = "Deploy a previously created job")


### PR DESCRIPTION
I reckon the added command works fine, but I could not test it properly because the underlying job code fails with a NPE.

Also, commands that start or restart a job should return a resource for the JobExecution IMHO. That way, this command could inform the user about the new execution id.
