### PR TITLE
Update xd ui test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1173,9 +1173,9 @@ project('spring-xd-ui') {
 	//}
 
 	tasks['grunt_build'].dependsOn(['npmInstall', 'installGrunt']);
-	tasks['grunt_teste2e'].dependsOn(['npmInstall', 'installGrunt']);
+	tasks['grunt_teste2e'].dependsOn(['grunt_build']);
 
-	task test(dependsOn: ['grunt_teste2e', ':spring-xd-dirt:backgroundAdminServer']) {
+	task ui_test(dependsOn: ['grunt_teste2e', ':spring-xd-dirt:backgroundAdminServer']) {
 
 		description = "E2E-test the Admin UI using Grunt"
 
@@ -1188,7 +1188,7 @@ project('spring-xd-ui') {
 		}
 	}
 
-	task setupUI(dependsOn: ['grunt_build', 'test']) {
+	task setupUI(dependsOn: ['grunt_build']) {
 		description = "Build the Admin UI using Grunt"
 	}
 


### PR DESCRIPTION
 Rename ui test task to 'ui_test' so that gradle test won't
  call spring-xd-ui tests. To run the E2E tests, the ui_test
  task needs to be invoked explicitly.
 The 'ui_test' task will also build the UI and runs the unit tests
  as it depends on 'grunt_build'

 Once we have valid UI tests, we will rename the task ui_test to 'test'
  so that will run as a 'test' task.
