### PR TITLE
XD-1318 Start Container before Admin

### DIFF
--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/batch.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/batch.xml
@@ -85,9 +85,6 @@
 			</constructor-arg>
 		</bean>
 
-	</beans>
-
-	<beans>
 		<bean id="jobInstanceDao"
 			class="org.springframework.batch.admin.service.JdbcSearchableJobInstanceDao">
 			<property name="jdbcTemplate" ref="jdbcTemplate" />

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
@@ -70,4 +70,26 @@
 		<tasklet ref="tasklet"/>
 	</step>
 
+	<bean id="jobInstanceDao"
+		class="org.springframework.batch.admin.service.JdbcSearchableJobInstanceDao">
+		<property name="jdbcTemplate" ref="jdbcTemplate" />
+	</bean>
+
+	<bean id="jobExecutionDao"
+		class="org.springframework.batch.admin.service.JdbcSearchableJobExecutionDao">
+		<property name="dataSource" ref="dataSource" />
+	</bean>
+
+	<bean id="stepExecutionDao"
+		class="org.springframework.batch.admin.service.JdbcSearchableStepExecutionDao">
+		<property name="dataSource" ref="dataSource" />
+	</bean>
+
+	<bean id="executionContextDao" class="org.springframework.batch.core.repository.dao.JdbcExecutionContextDao">
+		<property name="jdbcTemplate" ref="jdbcTemplate" />
+		<property name="serializer">
+			<bean class="org.springframework.batch.core.repository.dao.XStreamExecutionContextStringSerializer" />
+		</property>
+	</bean>
+
 </beans>

--- a/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests-context.xml
+++ b/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests-context.xml
@@ -26,7 +26,7 @@
 	</bean>
 
 	<bean id="jobExplorer" class="org.springframework.batch.core.explore.support.MapJobExplorerFactoryBean">
-	        <property name="repositoryFactory" ref="&amp;jobRepository" />
+		<property name="repositoryFactory" ref="&amp;jobRepository" />
 	</bean>
 
 	<bean id="transactionManager" class="org.springframework.batch.support.transaction.ResourcelessTransactionManager" />
@@ -36,7 +36,13 @@
 	</bean>
 
 	<bean id="executionContextDao" class="java.lang.Object" />
-	
+
+	<bean id="jobExecutionDao" class="java.lang.Object" />
+
+	<bean id="jobInstanceDao" class="java.lang.Object" />
+
+	<bean id="stepExecutionDao" class="java.lang.Object" />
+
 	<bean id="sessionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.integration.file.remote.session.SessionFactory" />
 	</bean>

--- a/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests-context.xml
+++ b/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests-context.xml
@@ -24,7 +24,7 @@
 	</bean>
 
 	<bean id="jobExplorer" class="org.springframework.batch.core.explore.support.MapJobExplorerFactoryBean">
-	        <property name="repositoryFactory" ref="&amp;jobRepository" />
+		<property name="repositoryFactory" ref="&amp;jobRepository" />
 	</bean>
 
 	<bean id="transactionManager" class="org.springframework.batch.support.transaction.ResourcelessTransactionManager" />
@@ -34,13 +34,19 @@
 	</bean>
 
 	<bean id="executionContextDao" class="java.lang.Object" />
-	
+
+	<bean id="jobExecutionDao" class="java.lang.Object" />
+
+	<bean id="jobInstanceDao" class="java.lang.Object" />
+
+	<bean id="stepExecutionDao" class="java.lang.Object" />
+
 	<bean id="sessionFactory" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="org.springframework.integration.file.remote.session.SessionFactory" />
 	</bean>
 
 	<!-- Override the RemoteFileToHadoopTasklet to write to java.io.tmpdir, and the hadoop beans -->
-	
+
 	<bean id="tasklet" class="org.springframework.batch.integration.x.RemoteFileToTmpTests$RemoteFileToTmpDirTasklet">
 		<constructor-arg ref="remoteFileTemplate" />
 	</bean>


### PR DESCRIPTION
- Moved the DAO beans back to 'adminServer' profile in batch.xml
  This will make sure these DAOs are only available in AdminServer's
  parent configuration
- Added the necessary DAO beans into singlestep-partition-support
  This will make sure these beans will only be loaded when the job
  module that requires singlestep partition support is deployed into
  the container. And, by this time the admin should be up as that's
  where the ModuleDeploymentRequest is coming from.
- Fixed the tests context files
