### PR TITLE
XD-1303 JobInstance REST endpoint

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceInfo.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceInfo.java
@@ -18,7 +18,6 @@ package org.springframework.xd.dirt.job;
 
 import java.util.List;
 
-import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.util.Assert;
 
@@ -32,9 +31,9 @@ public class JobInstanceInfo {
 
 	private final JobInstance jobInstance;
 
-	private final List<JobExecution> jobExecutions;
+	private final List<JobExecutionInfo> jobExecutions;
 
-	public JobInstanceInfo(JobInstance jobInstance, List<JobExecution> jobExecutions) {
+	public JobInstanceInfo(JobInstance jobInstance, List<JobExecutionInfo> jobExecutions) {
 		Assert.notNull(jobInstance, "jobInstance must not null");
 		Assert.notNull(jobExecutions, "jobExecutions must not null");
 		this.jobInstance = jobInstance;
@@ -45,7 +44,7 @@ public class JobInstanceInfo {
 		return jobInstance;
 	}
 
-	public List<JobExecution> getJobExecutions() {
+	public List<JobExecutionInfo> getJobExecutions() {
 		return jobExecutions;
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobInstancesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobInstancesController.java
@@ -16,6 +16,7 @@
 
 package org.springframework.xd.dirt.rest;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.batch.core.JobExecution;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.xd.dirt.job.JobExecutionInfo;
 import org.springframework.xd.dirt.job.JobInstanceInfo;
 import org.springframework.xd.dirt.job.NoSuchBatchJobException;
 import org.springframework.xd.dirt.job.NoSuchBatchJobInstanceException;
@@ -60,7 +62,11 @@ public class BatchJobInstancesController extends AbstractBatchJobsController {
 			try {
 				List<JobExecution> jobExecutions = (List<JobExecution>) jobService.getJobExecutionsForJobInstance(
 						jobInstance.getJobName(), jobInstance.getId());
-				return jobInstanceInfoResourceAssembler.toResource(new JobInstanceInfo(jobInstance, jobExecutions));
+				List<JobExecutionInfo> jobExecutionInfos = new ArrayList<JobExecutionInfo>();
+				for (JobExecution jobExecution : jobExecutions) {
+					jobExecutionInfos.add(new JobExecutionInfo(jobExecution, timeZone));
+				}
+				return jobInstanceInfoResourceAssembler.toResource(new JobInstanceInfo(jobInstance, jobExecutionInfos));
 			}
 			catch (NoSuchJobException e) {
 				throw new NoSuchBatchJobException(jobName);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
@@ -90,7 +90,11 @@ public class BatchJobsController extends AbstractBatchJobsController {
 			for (JobInstance jobInstance : jobInstances) {
 				List<JobExecution> jobExecutions = (List<JobExecution>) jobService.getJobExecutionsForJobInstance(
 						jobName, jobInstance.getId());
-				result.add(jobInstanceInfoResourceAssembler.toResource(new JobInstanceInfo(jobInstance, jobExecutions)));
+				List<JobExecutionInfo> jobExecutionInfos = new ArrayList<JobExecutionInfo>();
+				for (JobExecution jobExecution : jobExecutions) {
+					jobExecutionInfos.add(new JobExecutionInfo(jobExecution, timeZone));
+				}
+				result.add(jobInstanceInfoResourceAssembler.toResource(new JobInstanceInfo(jobInstance, jobExecutionInfos)));
 			}
 			return result;
 		}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobInstanceInfoResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobInstanceInfoResourceAssembler.java
@@ -30,6 +30,8 @@ import org.springframework.xd.rest.client.domain.JobInstanceInfoResource;
 public class JobInstanceInfoResourceAssembler extends
 		ResourceAssemblerSupport<JobInstanceInfo, JobInstanceInfoResource> {
 
+	JobExecutionInfoResourceAssembler jobExecutionInfoResourceAssembler = new JobExecutionInfoResourceAssembler();
+
 	public JobInstanceInfoResourceAssembler() {
 		super(BatchJobInstancesController.class, JobInstanceInfoResource.class);
 	}
@@ -41,6 +43,7 @@ public class JobInstanceInfoResourceAssembler extends
 
 	@Override
 	protected JobInstanceInfoResource instantiateResource(JobInstanceInfo entity) {
-		return new JobInstanceInfoResource(entity.getJobInstance(), entity.getJobExecutions());
+		return new JobInstanceInfoResource(entity.getJobInstance(),
+				jobExecutionInfoResourceAssembler.toResources(entity.getJobExecutions()));
 	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobInstancesControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobInstancesControllerIntegrationTests.java
@@ -143,9 +143,9 @@ public class BatchJobInstancesControllerIntegrationTests extends AbstractControl
 				.andExpect(jsonPath("$.instanceId").value(0))
 				.andExpect(jsonPath("$.jobName").value("job1"))
 				.andExpect(jsonPath("$.jobExecutions", Matchers.hasSize(1)))
-				.andExpect(jsonPath("$.jobExecutions[0].id").value(3))
-				.andExpect(jsonPath("$.jobExecutions[0].stepExecutions", Matchers.hasSize(1)))
-				.andExpect(jsonPath("$.jobExecutions[0].stepExecutions[0].stepName").value("s1"));
+				.andExpect(jsonPath("$.jobExecutions[0].jobExecution.id").value(3))
+				.andExpect(jsonPath("$.jobExecutions[0].jobExecution.stepExecutions", Matchers.hasSize(1)))
+				.andExpect(jsonPath("$.jobExecutions[0].jobExecution.stepExecutions[0].stepName").value("s1"));
 	}
 
 	@Test

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/JobInstanceInfoResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/JobInstanceInfoResource.java
@@ -18,7 +18,6 @@ package org.springframework.xd.rest.client.domain;
 
 import java.util.List;
 
-import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobInstance;
 import org.springframework.hateoas.ResourceSupport;
 
@@ -34,19 +33,19 @@ public class JobInstanceInfoResource extends ResourceSupport {
 
 	private final long instanceId;
 
-	private final List<JobExecution> jobExecutions;
+	private final List<JobExecutionInfoResource> jobExecutions;
 
-	public JobInstanceInfoResource(JobInstance jobInstance, List<JobExecution> jobExecutions) {
+	public JobInstanceInfoResource(JobInstance jobInstance, List<JobExecutionInfoResource> jobExecutionInfoResources) {
 		this.jobName = jobInstance.getJobName();
 		this.instanceId = jobInstance.getInstanceId();
-		this.jobExecutions = jobExecutions;
+		this.jobExecutions = jobExecutionInfoResources;
 	}
 
 	public String getJobName() {
 		return jobName;
 	}
 
-	public List<JobExecution> getJobExecutions() {
+	public List<JobExecutionInfoResource> getJobExecutions() {
 		return this.jobExecutions;
 	}
 


### PR DESCRIPTION
- Add ResourceAssembler that builds JobInstanceInfoResource out
  of JobInstanceInfo domain object
- Added REST endpoint /batch/instances/{instanceId} that returns
  the job instance for a given instanceId
- Updated the existing REST endpoint /batch/jobs/{jobName}/instances
  to return jobExecutions along with the given jobInstance
- Refactored Batch controllers
  - Created AbstractBatchJobsController that can be extended by XD batch
    job admin controllers
  - Removed NoSuchJobException and used NoSuchBatchJobException by moving
    the logic to update message when there is no job name
