### PR TITLE
XD-1321 Creating shell scripts and support classes to start XD on YARN

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -790,6 +790,8 @@ project('spring-xd-hadoop:phd1') {
 
 project('spring-xd-yarn') {
 	description = 'Spring XD YARN'
+	apply plugin: 'spring-boot'
+
 	dependencies {
 		compile "org.springframework:spring-aop:$springVersion"
 		compile "org.springframework:spring-context:$springVersion"
@@ -797,7 +799,7 @@ project('spring-xd-yarn') {
 		compile "org.springframework:spring-jdbc:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
 		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-		compile ("org.springframework.data:spring-yarn:$springDataHadoopBase") {
+		compile ("org.springframework.data:spring-yarn-boot:$springDataHadoopBase") {
 			exclude group: 'javax.servlet'
 			exclude group: 'javax.servlet.jsp'
 			exclude group: 'tomcat'
@@ -809,7 +811,39 @@ project('spring-xd-yarn') {
 			exclude group: 'junit'
 			exclude group: 'hsqldb'
 		}
+		compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
 	}
+
+	task clientJar(type: Jar) {
+	    appendix = 'client'
+	    from sourceSets.main.output
+	    exclude('**/AppMaster*')
+	}
+
+	task clientBoot(type: BootRepackage, dependsOn: clientJar) {
+	    withJarTask = clientJar
+	    customConfiguration = "bootRuntime"
+	}
+
+	task appmasterJar(type: Jar) {
+	    appendix = 'appmaster'
+	    from sourceSets.main.output
+	    exclude('**/Client*')
+	}
+
+	task appmasterBootJar(type: BootRepackage, dependsOn: appmasterJar) {
+	    withJarTask = appmasterJar
+	    customConfiguration = "bootRuntime"
+	}
+
+	clean.doLast {ant.delete(dir: "target")}
+
+	jar.enabled = false
+
+	bootRepackage.enabled = false
+
+	build.dependsOn(clientBoot, appmasterBootJar)
+
 }
 
 // 'Binary' distributions projects
@@ -1603,19 +1637,54 @@ task distTar(type: Tar, dependsOn: [asciidoctorHtml, copyInstall], overwrite: tr
 
 task yarnZip(type: Zip, dependsOn: [copyInstall], overwrite: true) {
 	group = 'Application'
-	classifier = 'yarn'
-	description = "Bundles the XD project and associated installs with libs prepared for YARN deployment as a zip file."
+	appendix = 'yarn'
+	description = "Bundles the XD project and with libs prepared for YARN deployment as a zip file."
 
-	ext.baseDir = "${project.name}-yarn-${project.version}";
+	destinationDir = new File("$buildDir/tmp")
 
-	from("$buildDir/dist/spring-xd-yarn") {
-		into "${baseDir}"
+    from("$buildDir/dist/spring-xd-yarn/xd-yarn/lib") {
+		into "/lib"
 	}
+    from("$buildDir/dist/spring-xd-yarn/xd-yarn/config") {
+        into "/config"
+    }
+    from("$buildDir/dist/spring-xd-yarn/xd-yarn/modules") {
+        into "/modules"
+    }
+}
+
+task distYarnZip(type: Zip, dependsOn: [copyInstall, yarnZip], overwrite: true) {
+	group = 'Application'
+	classifier = 'yarn'
+	description = "Bundles the XD files needed for YARN deployments."
+
+	ext.baseDir = "${project.name}-${project.version}";
+
+	from("$rootDir/spring-xd-yarn/site/scripts") {
+		include '*.sh'
+		into "${baseDir}/bin"
+	}
+
+	from("$rootDir/spring-xd-yarn/site/config") {
+		include '*.yml'
+		into "${baseDir}/config"
+	}
+
+	from("$rootDir/spring-xd-yarn/build/libs") {
+		include "spring-xd-yarn-client-${project.version}.jar"
+		include "spring-xd-yarn-appmaster-${project.version}.jar"
+		into "${baseDir}/lib"
+	}
+
+    from("$buildDir/tmp") {
+    	include '*-yarn-*.zip'
+    	into "${baseDir}"
+    }
 }
 
 artifacts {
 	archives distZip
-	archives yarnZip
+	archives distYarnZip
 	archives docsZip
 }
 

--- a/spring-xd-yarn/site/config/xd-site.yml
+++ b/spring-xd-yarn/site/config/xd-site.yml
@@ -1,0 +1,12 @@
+server:
+    port: 9393
+
+spring:
+    xd:
+        adminServers: 1
+        containers: 3
+#    yarn:
+#        applicationDir: /xd/app/
+#        fsUri: hdfs://localhost:8020
+#        rmAddress: localhost:8032
+#        schedulerAddress: localhost:8030

--- a/spring-xd-yarn/site/scripts/xd-admin.sh
+++ b/spring-xd-yarn/site/scripts/xd-admin.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+##############################################################################
+##
+##  xd-container start up script for UN*X
+##
+##############################################################################
+
+# Add default JVM options here. You can also use JAVA_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+APP_NAME="xd-container"
+APP_BASE_NAME=`basename "$0"`
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "$*"
+}
+
+die ( ) {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+esac
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched.
+if $cygwin ; then
+    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+fi
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/.." >&-
+APP_HOME="`pwd -P`"
+XD_ZIP=`ls spring-xd-yarn*.zip`
+cd lib
+XD_AM_JAR=`ls spring-xd-yarn-appmaster*.jar`
+XD_CLIENT_JAR=`ls spring-xd-yarn-client*.jar`
+cd ..
+cd "$SAVED" >&-
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+exec "$JAVACMD" "${JVM_OPTS[@]}" -Dspring.profiles.active=admin "-Dspring.config.location=${APP_HOME}/config/xd-site.yml" "-Dspring.xd.yarn.app.path=${APP_HOME}" "-Dspring.xd.yarn.app.zip=${XD_ZIP}" "-Dspring.xd.yarn.am.path=${APP_HOME}/lib" "-Dspring.xd.yarn.am.jar=${XD_AM_JAR}" -jar "${APP_HOME}/lib/${XD_CLIENT_JAR}"

--- a/spring-xd-yarn/site/scripts/xd-container.sh
+++ b/spring-xd-yarn/site/scripts/xd-container.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+##############################################################################
+##
+##  xd-container start up script for UN*X
+##
+##############################################################################
+
+# Add default JVM options here. You can also use JAVA_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+APP_NAME="xd-container"
+APP_BASE_NAME=`basename "$0"`
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "$*"
+}
+
+die ( ) {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+esac
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched.
+if $cygwin ; then
+    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+fi
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/.." >&-
+APP_HOME="`pwd -P`"
+XD_ZIP=`ls spring-xd-yarn*.zip`
+cd lib
+XD_AM_JAR=`ls spring-xd-yarn-appmaster*.jar`
+XD_CLIENT_JAR=`ls spring-xd-yarn-client*.jar`
+cd ..
+cd "$SAVED" >&-
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+exec "$JAVACMD" "${JVM_OPTS[@]}" -Dspring.profiles.active=container "-Dspring.config.location=${APP_HOME}/config/xd-site.yml" "-Dspring.xd.yarn.app.path=${APP_HOME}" "-Dspring.xd.yarn.app.zip=${XD_ZIP}" "-Dspring.xd.yarn.am.path=${APP_HOME}/lib" "-Dspring.xd.yarn.am.jar=${XD_AM_JAR}" -jar "${APP_HOME}/lib/${XD_CLIENT_JAR}"

--- a/spring-xd-yarn/src/main/java/org/springframework/xd/yarn/AppMaster.java
+++ b/spring-xd-yarn/src/main/java/org/springframework/xd/yarn/AppMaster.java
@@ -1,0 +1,15 @@
+package org.springframework.xd.yarn;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+import java.util.Map;
+
+@EnableAutoConfiguration
+public class AppMaster {
+
+	public static void main(String[] args) {
+		SpringApplication.run(AppMaster.class, args);
+	}
+
+}

--- a/spring-xd-yarn/src/main/java/org/springframework/xd/yarn/ClientApp.java
+++ b/spring-xd-yarn/src/main/java/org/springframework/xd/yarn/ClientApp.java
@@ -1,0 +1,15 @@
+package org.springframework.xd.yarn;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.yarn.client.YarnClient;
+
+@EnableAutoConfiguration
+public class ClientApp {
+	public static void main(String[] args) {
+		SpringApplication.run(ClientApp.class, args)
+				.getBean(YarnClient.class)
+				.submitApplication();
+	}
+
+}

--- a/spring-xd-yarn/src/main/resources/application.yml
+++ b/spring-xd-yarn/src/main/resources/application.yml
@@ -1,0 +1,73 @@
+spring:
+    yarn:
+        applicationDir: /xd/app/
+        fsUri: hdfs://localhost:8020
+        rmAddress: localhost:8032
+        schedulerAddress: localhost:8030
+        client:
+            memory: 512M
+            files:
+                - "file:${spring.xd.yarn.app.path}/${spring.xd.yarn.app.zip}"
+                - "file:${spring.xd.yarn.am.path}/${spring.xd.yarn.am.jar}"
+            appmasterFile: "${spring.xd.yarn.am.jar}"
+---
+spring:
+    profiles: admin
+    yarn:
+        appName: xd-admin
+        client:
+            arguments:
+                -Dspring.profiles.active: "admin"
+                -Dspring.xd.yarn.app.path: "${spring.xd.yarn.app.path}"
+                -Dspring.xd.yarn.app.zip: "${spring.xd.yarn.app.zip}"
+                -Dspring.xd.yarn.am.path: "${spring.xd.yarn.am.path}"
+                -Dspring.xd.yarn.am.jar: "${spring.xd.yarn.am.jar}"
+                -Dspring.yarn.applicationDir: "${spring.yarn.applicationDir}"
+                -Dspring.yarn.fsUri: "${spring.yarn.fsUri}"
+                -Dspring.yarn.rmAddress: "${spring.yarn.rmAddress}"
+                -Dspring.yarn.schedulerAddress: "${spring.yarn.schedulerAddress}"
+                -Dserver.port: "${PORT:${server.port:9393}}"
+        appmaster:
+            appmasterClass: org.springframework.yarn.am.StaticEventingAppmaster
+            containerRunner: org.springframework.xd.dirt.server.AdminServerApplication
+            containerCount: 1
+            arguments:
+                -DxdHomeDir: "./${spring.xd.yarn.app.zip}"
+                -Dspring.application.name: "admin"
+                -DPORT: "${server.port}"
+            waitLatch: false
+            classpath:
+                - "./${spring.xd.yarn.app.zip}"
+                - "./${spring.xd.yarn.app.zip}/config"
+                - "./${spring.xd.yarn.app.zip}/lib/*"
+---
+spring:
+    profiles: container
+    yarn:
+        appName: xd-container
+        client:
+            arguments:
+                -Dspring.profiles.active: "container"
+                -Dspring.xd.yarn.app.path: "${spring.xd.yarn.app.path}"
+                -Dspring.xd.yarn.app.zip: "${spring.xd.yarn.app.zip}"
+                -Dspring.xd.yarn.am.path: "${spring.xd.yarn.am.path}"
+                -Dspring.xd.yarn.am.jar: "${spring.xd.yarn.am.jar}"
+                -Dspring.yarn.appName: "${spring.yarn.appName}"
+                -Dspring.yarn.applicationDir: "${spring.yarn.applicationDir}"
+                -Dspring.yarn.fsUri: "${spring.yarn.fsUri}"
+                -Dspring.yarn.rmAddress: "${spring.yarn.rmAddress}"
+                -Dspring.yarn.schedulerAddress: "${spring.yarn.schedulerAddress}"
+                --spring.yarn.appmaster.containerCount: "${spring.xd.containers:1}"
+        appmaster:
+            appmasterClass: org.springframework.yarn.am.StaticEventingAppmaster
+            containerCount: 1
+            containerRunner: org.springframework.xd.dirt.server.LauncherApplication
+            arguments:
+                -DxdHomeDir: "./${spring.xd.yarn.app.zip}"
+                -Dspring.application.name: "container"
+            waitLatch: false
+            classpath:
+                - "./${spring.xd.yarn.app.zip}"
+                - "./${spring.xd.yarn.app.zip}/config"
+                - "./${spring.xd.yarn.app.zip}/lib/*"
+                - "./${spring.xd.yarn.app.zip}/modules/processor/scripts"

--- a/spring-xd-yarn/src/main/resources/log4j.properties
+++ b/spring-xd-yarn/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%C{1}] - %m%n
+
+log4j.category.org.springframework.yarn=INFO
+log4j.category.org.springframework.boot=INFO
+


### PR DESCRIPTION
- Adding xd-admin and xd-container scripts for YARN
- Adding YARN Client and Appmaster implementations
- Removing directory paths from xd-yarn zip distribution

To try this out:

1) install Hadoop 2.2.0 and start up dfs, yarn and historyserver
2) build xd distribution - build/distributions/ should now have a spring-xd-1.0.0.BUILD-SNAPSHOT-yarn.zip
3) unzip spring-xd-1.0.0.BUILD-SNAPSHOT-yarn.zip somewhere
4) the unzipped dir (spring-xd-1.0.0.BUILD-SNAPSHOT-yarn) contains a config/xd-site.yml file with localized settings
   change anything that needs to be modified (should work with defaults if hadoop runs on localhost)
5) from the unzipped dir (spring-xd-1.0.0.BUILD-SNAPSHOT-yarn) run:
   ./bin/xd-admin.sh
   ./bin/xd-container.sh
6) check that there are two apps running in YARN:
   yarn application -list

To get two apps running in YARN I had to modify my etc/hadoop/yarn-site.xml - added this:

```
<property>
    <name>yarn.nodemanager.resource.cpu-vcores</name>
    <value>8</value>
</property>
<property>
    <name>yarn.nodemanager.resource.memory-mb</name>
    <value>8192</value>
</property>
<property>
    <name>yarn.scheduler.minimum-allocation-mb</name>
    <value>512</value>
</property>
<property>
    <name>yarn.nodemanager.vmem-pmem-ratio</name>
    <value>8.1</value>
</property>
<property>
    <name>yarn.nodemanager.pmem-check-enabled</name>
    <value>false</value>
</property>
<property>
    <name>yarn.nodemanager.vmem-check-enabled</name>
    <value>false</value>
</property>
```

What you need would probably be a bit different, but this is a start.
