### PR TITLE
Fix Job module options

### DIFF
--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/AbstractImportToJdbcOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/AbstractImportToJdbcOptionsMetadata.java
@@ -47,7 +47,7 @@ public abstract class AbstractImportToJdbcOptionsMetadata extends AbstractJdbcOp
 		this.initializerScript = initializerScript;
 	}
 
-	public Boolean getInitializeDatabase() {
+	public boolean getInitializeDatabase() {
 		return initializeDatabase;
 	}
 

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcHdfsOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcHdfsOptionsMetadata.java
@@ -2,20 +2,22 @@ package org.springframework.xd.jdbc;
 
 import javax.validation.constraints.AssertTrue;
 
+import org.springframework.util.StringUtils;
 import org.springframework.xd.module.options.spi.ModuleOption;
 
 /**
  * @author Luke Taylor
+ * @author Ilayaperumal Gopinathan
  */
 public class JdbcHdfsOptionsMetadata extends AbstractJdbcOptionsMetadata {
 
 	private boolean restartable;
 
-	private String tableName;
+	private String tableName = "";
 
-	private String columns;
+	private String columns = "";
 
-	private String sql;
+	private String sql = "";
 
 	private String fileName;
 
@@ -48,10 +50,10 @@ public class JdbcHdfsOptionsMetadata extends AbstractJdbcOptionsMetadata {
 
 	@AssertTrue(message = "Use ('tableName' AND 'columns') OR 'sql' to define the data import")
 	boolean isEitherSqlOrTableAndColumns() {
-		if (sql == null) {
-			return tableName != null && columns != null;
+		if (!StringUtils.hasText(sql)) {
+			return StringUtils.hasText(tableName) && StringUtils.hasText(columns);
 		} else {
-			return tableName == null && columns == null;
+			return !StringUtils.hasText(tableName) && !StringUtils.hasText(columns);
 		}
 	}
 
@@ -75,7 +77,7 @@ public class JdbcHdfsOptionsMetadata extends AbstractJdbcOptionsMetadata {
 		this.fileExtension = fileExtension;
 	}
 
-	public Boolean isRestartable() {
+	public boolean getRestartable() {
 		return restartable;
 	}
 

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/ResourcesIntoJdbcJobModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/ResourcesIntoJdbcJobModuleOptionsMetadata.java
@@ -58,7 +58,7 @@ public class ResourcesIntoJdbcJobModuleOptionsMetadata extends
 		this.deleteFiles = deleteFiles;
 	}
 
-	public Boolean getRestartable() {
+	public boolean getRestartable() {
 		return restartable;
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FilePollHdfsJobOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FilePollHdfsJobOptionsMetadata.java
@@ -59,11 +59,11 @@ public class FilePollHdfsJobOptionsMetadata {
 		this.fileExtension = fileExtension;
 	}
 
-	public Boolean getRestartable() {
+	public boolean getRestartable() {
 		return restartable;
 	}
 
-	public Boolean getDeleteFiles() {
+	public boolean getDeleteFiles() {
 		return deleteFiles;
 	}
 


### PR DESCRIPTION
- Changed the getter method name for the property
  "restartable" in JdbcHdfsOptionsMetadata to "getRestartable"
  so that Metadata BeanWrapper's PropertyDescriptor sets
  the read method name correctly.
- Initialize `tableName`, `columns` and `sql` properties with empty text
  so that their placeholders in jdbchdfs.xml get set. This doesn't do any
  harm as NamedColumnJdbcItemReader checks it again.
- Changed the return type of the boolean getter methods to primitive type
  boolean in some of the job module options metadata pojos.
