### PR TITLE
[Review Only] XD-812 Tapping named channel streams

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
@@ -151,8 +151,23 @@ public class ChannelNode extends AstNode {
 							getStreamName());
 				}
 				// Point to the first element of the stream
-				indexingElements = new ArrayList<String>();
-				indexingElements.add(sn.getModuleNodes().get(0).getName() + ".0");
+				if (sn.getSourceChannelNode() == null) {
+					indexingElements = new ArrayList<String>();
+					indexingElements.add(sn.getModuleNodes().get(0).getName() + ".0");
+				}
+				else {
+					SourceChannelNode source = sn.getSourceChannelNode();
+					// TODO: Another hack to get named channel taps working
+					if (source.getChannelType() == ChannelType.QUEUE) {
+						channelType = ChannelType.TAP_QUEUE;
+					}
+					else {
+						channelType = ChannelType.TAP_TOPIC;
+					}
+					nameComponents = source.getChannelNode().nameComponents;
+					startpos = source.getChannelNode().getStartPos();
+					endpos = source.getChannelNode().getEndPos();
+				}
 			}
 			else {
 				// Easter Egg: can use index of module in a stream when tapping.

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
@@ -107,13 +107,15 @@ public abstract class AbstractSingleNodeStreamDeploymentIntegrationTests extends
 
 	@Test
 	public void testBasicTap() {
-
 		StreamDefinition streamDefinition = new StreamDefinition(
 				"mystream",
 				"queue:source >  transform --expression=payload.toUpperCase() > queue:sink"
 				);
+		// Tap should get the data prior to the stream's transform
 		StreamDefinition tapDefinition = new StreamDefinition("mytap",
-				"tap:stream:mystream > transform --expression=payload.replaceAll('A','.') > queue:tap");
+				"tap:stream:mystream > transform --expression=payload.replaceAll('a','.') " +
+						" | transform --expression=payload.toUpperCase()" +
+						" > queue:tap");
 		tapTest(streamDefinition, tapDefinition);
 	}
 

--- a/src/test/scripts/basic_stream_tests
+++ b/src/test/scripts/basic_stream_tests
@@ -45,9 +45,10 @@ destroy_stream 'ticktock'
 destroy_stream 'httptofile'
 destroy_stream 'timejdbc'
 
-echo -e '*** Test 4. http | filter | file stream\n'
+
+echo -e '*** Test 4. http | filter | file stream with taps and labels\n'
 create_stream 'httpfilter1' "http | good: filter --expression=payload=='good' | good2: filter --expression=payload=='good' | good3: filter --expression=payload=='good' | file --dir=$TEST_DIR"
-create_stream 'httpfilter1tap'  "tap:stream:httpfilter1.good > counter --name=good"
+create_stream 'httpfilter1tap' "tap:stream:httpfilter1.good > counter --name=good"
 # Send one message
 curl -d 'good' $XD_HOST:9000
 
@@ -58,6 +59,27 @@ destroy_stream 'httpfilter1'
 
 # This fails when we have multiple filters
 #assert_equals 'value":1' $good
+
+
+echo -e '*** Test 4a. Tapping named channel queue:good > file\n'
+
+create_stream 'good2file' "queue:good > file --dir=$TEST_DIR"
+create_stream 'goodfeed'  'http > queue:good'
+create_stream 'goodqueuetap' "tap:queue:good > file --dir=$TEST_DIR"
+create_stream 'good2filetap' "tap:stream:good2file > file --dir=$TEST_DIR"
+
+curl -d 'good' $XD_HOST:9000
+destroy_stream 'goodfeed'
+result=`cat $TEST_DIR/good2file.out`
+result3=`cat $TEST_DIR/goodqueuetap.out`
+result2=`cat $TEST_DIR/good2filetap.out`
+assert_equals 'good' $result
+assert_equals 'good' $result2
+assert_equals 'good' $result3
+
+destroy_stream 'good2filetap'
+destroy_stream 'goodqueuetap'
+destroy_stream 'good2file'
 
 echo -e '*** Test 5. tcp | file stream\n'
 


### PR DESCRIPTION
Support for tapping named channels and streams whose source is a named
channel.

This isn't correct as it stands, particularly wrt the lifecycle of
the taps. There will be problems if the same named channel is used more
than once. For example, creating a stream

queue:blah > log

will create the tap when the log module is deployed. When it is destroyed,
the tap will be removed. If in the meantime we had created another stream

queue:blah > file

then this would be a problem.
