### PR TITLE
XD-1209 external config support for Windows

### DIFF
--- a/scripts/xd/xd-admin.bat
+++ b/scripts/xd/xd-admin.bat
@@ -92,10 +92,19 @@ if exist "%APP_HOME_LIB%" (
 )
 
 @rem Set XD_HOME to APP_HOME if XD_HOME is not defined yet
-if not exist "%XD_HOME%" (
-    set XD_HOME=%APP_HOME%
+if not defined XD_HOME (
+    set XD_HOME="%APP_HOME%"
 )
-set SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:%XD_HOME%/config/xd-admin-logger.properties -Dxd.home=%XD_HOME%"
+
+@rem Check for an explicitly set XD_CONFIG
+if not defined XD_CONFIG (
+    set XD_CONFIG=%XD_HOME%/config/xd-config.yml
+)
+
+set SPRING_XD_OPTS=-Dspring.config.location=file:%XD_CONFIG% -Dspring.application.name=admin -Dlogging.config=file:%XD_HOME%/config/xd-admin-logger.properties -Dxd.home=%XD_HOME%
+
+@rem make sure to remove double quotes if any
+set XD_HOME=%XD_HOME:"=%
 
 @rem Execute xd-admin
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_OPTS% -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.AdminServerApplication %CMD_LINE_ARGS%
@@ -114,4 +123,3 @@ exit /b 1
 if "%OS%"=="Windows_NT" endlocal
 
 :omega
-

--- a/scripts/xd/xd-container.bat
+++ b/scripts/xd/xd-container.bat
@@ -92,10 +92,19 @@ if exist "%APP_HOME_LIB%" (
 )
 
 @rem Set XD_HOME to APP_HOME if XD_HOME is not defined yet
-if not exist "%XD_HOME%" (
-    set XD_HOME=%APP_HOME%
+if not defined XD_HOME (
+    set XD_HOME="%APP_HOME%"
 )
-set SPRING_XD_OPTS="-Dspring.application.name=container -Dlogging.config=file:%XD_HOME%/config/xd-container-logger.properties -Dxd.home=%XD_HOME%"
+
+@rem Check for an explicitly set XD_CONFIG
+if not defined XD_CONFIG (
+    set XD_CONFIG=%XD_HOME%/config/xd-config.yml
+)
+
+set SPRING_XD_OPTS=-Dspring.config.location=file:%XD_CONFIG% -Dspring.application.name=container -Dlogging.config=file:%XD_HOME%/config/xd-container-logger.properties -Dxd.home=%XD_HOME%
+
+@rem make sure to remove double quotes if any
+set XD_HOME=%XD_HOME:"=%
 
 @rem Execute xd-container
 "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_OPTS% -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.LauncherApplication %CMD_LINE_ARGS%

--- a/scripts/xd/xd-singlenode
+++ b/scripts/xd/xd-singlenode
@@ -180,7 +180,7 @@ if [ x"$XD_HOME" = x ] ; then
     export XD_HOME=$APP_HOME
 fi
 
-# Check for an explicity set XD_CONFIG
+# Check for an explicitly set XD_CONFIG
 if [ x"$XD_CONFIG" = x ] ; then
     export XD_CONFIG=file:$XD_HOME/config/xd-config.yml
 fi

--- a/scripts/xd/xd-singlenode.bat
+++ b/scripts/xd/xd-singlenode.bat
@@ -92,13 +92,22 @@ if exist "%APP_HOME_LIB%" (
 )
 
 @rem Set XD_HOME to APP_HOME if XD_HOME is not defined yet
-if not exist "%XD_HOME%" (
-    set XD_HOME=%APP_HOME%
+if not defined XD_HOME (
+    set XD_HOME="%APP_HOME%"
 )
-set SPRING_XD_OPTS="-Dspring.application.name=singlenode -Dlogging.config=file:%XD_HOME%/config/xd-singlenode-logger.properties  -Dxd.home=%XD_HOME%"
+
+@rem Check for an explicitly set XD_CONFIG 
+if not defined XD_CONFIG ( 
+    set XD_CONFIG=%XD_HOME%/config/xd-config.yml
+)
+
+set SPRING_XD_OPTS=-Dspring.config.location=file:%XD_CONFIG% -Dspring.application.name=singlenode -Dlogging.config=file:%XD_HOME%/config/xd-singlenode-logger.properties -Dxd.home=%XD_HOME%
+
+@rem make sure to remove double quotes if any
+set XD_HOME=%XD_HOME:"=%
 
 @rem Execute xd-singlenode
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_OPTS%  -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.SingleNodeApplication %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %SPRING_XD_OPTS% -classpath "%CLASSPATH%" org.springframework.xd.dirt.server.SingleNodeApplication %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
- Fix xd batch scripts to pass XD_CONFIG as the jvm arg
  by setting `spring.config.location`
  - made sure the `file:` URL prefix is added to XD_CONFIG
  - Handle double quotes appropriately. If an environment variable
    has space in it, it is expected to receive the variable in
    double quotes.
