### PR TITLE
XD-1122 Add mgmt port option

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
@@ -22,6 +22,7 @@ import org.kohsuke.args4j.Option;
  * Base class for command line options that are common to absolutely every setup (single and distributed).
  * 
  * @author Eric Bottard
+ * @author Ilayaperumal Gopinathan
  */
 public class CommonOptions {
 
@@ -30,6 +31,9 @@ public class CommonOptions {
 
 	@Option(name = "--jmxEnabled", usage = "Whether to enable JMX exposition of beans")
 	private Boolean jmxEnabled;
+
+	@Option(name = "--mgmtPort", usage = "The port for the management server", metaVar = "<mgmtPort>")
+	private Integer mgmtPort;
 
 	// Using wrapped here so that "showHelp" is not returned as a property by BeanPropertiesPropertySource
 	public Boolean isShowHelp() {
@@ -46,5 +50,12 @@ public class CommonOptions {
 		this.jmxEnabled = jmxEnabled;
 	}
 
+	public Integer getXD_MGMT_PORT() {
+		return mgmtPort;
+	}
+
+	public void setXD_MGMT_PORT(int mgmtPort) {
+		this.mgmtPort = mgmtPort;
+	}
 
 }

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -35,7 +35,8 @@ xd:
 
 server:
   port: ${PORT:9393}
-
+management:
+  port: ${XD_MGMT_PORT:${PORT:9393}}
 ---
 
 spring:
@@ -63,7 +64,8 @@ spring:
       enabled: false
 server:
   port: ${PORT:0}
-
+management:
+  port: ${XD_MGMT_PORT:${PORT:}}
 ---
 
 spring:


### PR DESCRIPTION
- Added `mgmtPort` as a CommonOption (for both admin/container)
- The management port can also be set via `XD_MGMT_PORT` as an environment variable property
- By default, the mangement port uses admin/container server port in admin/container servers
  respectively.
