### PR TITLE
XD-1352 JobLaunch request handling

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDeployer.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
@@ -54,7 +55,6 @@ import org.springframework.xd.module.core.SimpleModule;
 import org.springframework.xd.module.options.ModuleOptions;
 import org.springframework.xd.module.options.ModuleOptionsMetadata;
 import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
-import org.springframework.xd.module.options.PassthruModuleOptionsMetadata;
 import org.springframework.xd.module.support.ParentLastURLClassLoader;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -314,9 +314,7 @@ public class ModuleDeployer extends AbstractMessageHandler implements Applicatio
 			processLaunchRequest(modules, request);
 		}
 		else {
-			// Deploy the job module and then launch
-			handleDeploy(request);
-			processLaunchRequest(this.deployedModules.get(group), request);
+			throw new ModuleNotDeployedException("Job launch");
 		}
 	}
 

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
@@ -343,7 +343,7 @@ public class JobCommands implements CommandMarker {
 			@CliOption(key = { "", "name" }, help = "the name of the job to deploy", optionContext = "existing-job disable-string-converter") String name,
 			@CliOption(key = { "params" }, help = "the parameters for the job", unspecifiedDefaultValue = "") String jobParameters) {
 		jobOperations().launchJob(name, jobParameters);
-		return String.format("Successfully launched the job '%s'", name);
+		return String.format("Successfully submitted launch request for job '%s'", name);
 	}
 
 	@CliCommand(value = UNDEPLOY_JOB, help = "Un-deploy an existing job")

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobIntegrationTest.java
@@ -164,7 +164,7 @@ public abstract class AbstractJobIntegrationTest extends AbstractShellIntegratio
 	 */
 	protected void executeJobLaunch(String jobName, String jobParameters) {
 		CommandResult cr = executeCommand("job launch --name " + jobName + " --params " + jobParameters);
-		String prefix = "Successfully launched the job '";
+		String prefix = "Successfully submitted launch request for job '";
 		assertEquals(prefix + jobName + "'", cr.getResult());
 	}
 
@@ -173,7 +173,7 @@ public abstract class AbstractJobIntegrationTest extends AbstractShellIntegratio
 	 */
 	protected void executeJobLaunch(String jobName) {
 		CommandResult cr = executeCommand("job launch --name " + jobName);
-		String prefix = "Successfully launched the job '";
+		String prefix = "Successfully submitted launch request for job '";
 		assertEquals(prefix + jobName + "'", cr.getResult());
 	}
 


### PR DESCRIPTION
- Throw ModuleNotDeployedException if the job module is not already
  deployed in the container that processes "job launch" request
- If the underlying control bus is Rabbit, then this would enable
  the MessageListenerContainer not acknowledging the DeploymentRequest message
  thereby the message gets processed by a different container. This process
  would go on until the container that has the deployed job receives the
  DeploymentRequest.
