### PR TITLE
Fix ModuleDefinitionRegistry when using Redis

### DIFF
--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ModuleCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ModuleCommandTests.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.xd.module.core.CompositeModule.OPTION_SEPARATOR;
 import static org.springframework.xd.shell.command.fixtures.XDMatchers.eventually;
 import static org.springframework.xd.shell.command.fixtures.XDMatchers.hasContentsThat;
 
@@ -32,7 +33,6 @@ import java.io.IOException;
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.shell.core.CommandResult;
@@ -62,9 +62,11 @@ public class ModuleCommandTests extends AbstractStreamIntegrationTest {
 		assertThat(t.getRows(), hasItem(rowWithValue(1, "(c) compositesource")));
 	}
 
+	/**
+	 * This tests that options passed in the definition of a composed module are kept as first level defaults.
+	 */
 	@Test
-	@Ignore
-	public void testComposedModules() throws IOException {
+	public void testComposedModulesValuesInDefinition() throws IOException {
 		FileSink sink = newFileSink().binary(true);
 		HttpSource httpSource = newHttpSource();
 		compose().newModule("filterAndTransform",
@@ -75,6 +77,23 @@ public class ModuleCommandTests extends AbstractStreamIntegrationTest {
 
 	}
 
+	/**
+	 * This tests that options passed at usage time of a composed module are override definition values.
+	 */
+	@Test
+	public void testComposedModulesValuesAtUsageTime() throws IOException {
+		FileSink sink = newFileSink().binary(true);
+		HttpSource httpSource = newHttpSource();
+		compose().newModule("filterAndTransform",
+				"filter --expression=false | transform --expression=payload.replace('abc','...')");
+		String options = String.format(
+				"--filter%sexpression=true --transform%sexpression=payload.replace('def','...')", OPTION_SEPARATOR,
+				OPTION_SEPARATOR);
+		stream().create(generateStreamName(), "%s | filterAndTransform %s | %s", httpSource, options, sink);
+		httpSource.postData("abcdefghi!");
+		assertThat(sink, eventually(hasContentsThat(equalTo("abc...ghi!"))));
+
+	}
 
 	private Matcher<TableRow> rowWithValue(final int col, final String value) {
 		return new DiagnosingMatcher<TableRow>() {


### PR DESCRIPTION
The ModuleDefinitionRegistry relied on json serialization, which loses some information (most notably xml resource location) when serializing/deserializing
