### PR TITLE
Remove commons-logging jars from XD distro.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1419,6 +1419,7 @@ task copyXDInstall(type: Copy, dependsOn: [
 	from "$rootDir/spring-xd-dirt/build/install/spring-xd-dirt"
 	into "$buildDir/dist/spring-xd/xd"
 	exclude "**/lib/hadoop-*.jar"
+	exclude "**/commons-logging*.jar"
 	exclude "**/lib/spring-data-hadoop-*.jar"
 }
 


### PR DESCRIPTION
The main lib directory has slf4j jars including jcl-over-slf4j so we don't
need commons-logging. This change excludes them from the copy of
spring-xd-dirt to the final distro. Otherwise we end up with 27 copies of the
jar in the various module and extension subdirectories.
