### PR TITLE
Exclude jline 0.9.94 dependency from curator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -378,7 +378,9 @@ project('spring-xd-dirt') {
 		compile "org.jolokia:jolokia-client-java:$jolokiaVersion"
 		compile "com.esotericsoftware.kryo:kryo:$kryoVersion"
 		compile "com.lambdaworks:lettuce:$lettuceVersion"
-		compile "org.apache.curator:curator-recipes:$curatorVersion"
+		compile ("org.apache.curator:curator-recipes:$curatorVersion") {
+			exclude group: 'jline'
+		}
 		compile "commons-lang:commons-lang:2.4"
 		compile "args4j:args4j:$args4jVersion"
 


### PR DESCRIPTION
- The subproject spring-xd-dirt's compile dependency Curator 2.4.0 has jline 0.9.94
  as a transitive dependency.
  Currently, spring-xd-shell's spring-shell has jline-2.11 as the dependency.
  Since, spring-xd-shell has spring-xd-dirt as "testCompile" dependency, there is
  a conflict using spring-xd-shell only from within IDE.
