### PR TITLE
XD-1104: Add tests for jdbc sink module and fix bugs

### DIFF
--- a/config/init_db.sql
+++ b/config/init_db.sql
@@ -1,3 +1,3 @@
 -- default script uses stream name as table name
 drop table #table;
-create table #table (payload varchar(2000));
+create table #table (#columns);

--- a/modules/sink/jdbc/config/jdbc.xml
+++ b/modules/sink/jdbc/config/jdbc.xml
@@ -39,6 +39,7 @@
 			value="${xd.config.home}/${initializerScript:init_db.sql}" />
 		<beans:property name="ignoreFailedDrops" value="true" />
 		<beans:property name="tableName" value="${tableName:${xd.stream.name}}" />
+		<beans:property name="columnNames" value="${columns:payload}" />
 	</beans:bean>
 
 	<context:annotation-config/>

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/HSQLServerBean.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/HSQLServerBean.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.hsqldb.persist.HsqlProperties;
 import org.hsqldb.server.ServerConfiguration;
 import org.hsqldb.server.ServerConstants;
+
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractStreamIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractStreamIntegrationTest.java
@@ -28,6 +28,7 @@ import org.springframework.xd.shell.command.fixtures.FileSink;
 import org.springframework.xd.shell.command.fixtures.FileSource;
 import org.springframework.xd.shell.command.fixtures.HttpSource;
 import org.springframework.xd.shell.command.fixtures.ImapSource;
+import org.springframework.xd.shell.command.fixtures.JdbcSink;
 import org.springframework.xd.shell.command.fixtures.MailSink;
 import org.springframework.xd.shell.command.fixtures.MailSource;
 import org.springframework.xd.shell.command.fixtures.TailSource;
@@ -94,6 +95,10 @@ public abstract class AbstractStreamIntegrationTest extends AbstractShellIntegra
 		TcpSink tcpSink = new TcpSink();
 		disposables.add(tcpSink);
 		return tcpSink;
+	}
+
+	protected JdbcSink newJdbcSink() {
+		return new JdbcSink();
 	}
 
 	protected FileSink newFileSink() {

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/JdbcModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/JdbcModulesTests.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.shell.command;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.xd.shell.command.fixtures.HttpSource;
+import org.springframework.xd.shell.command.fixtures.JdbcSink;
+
+
+/**
+ * Tests for the jdbc related modules.
+ * 
+ * @author Eric Bottard
+ * @author Florent Biville
+ */
+public class JdbcModulesTests extends AbstractStreamIntegrationTest {
+
+	@Test
+	public void testJdbcSinkWith1InsertionAndDefaultConfiguration() throws Exception {
+		JdbcSink jdbcSink = newJdbcSink().start();
+
+		HttpSource httpSource = newHttpSource();
+
+
+		String streamName = generateStreamName().replaceAll("-", "_");
+		stream().create(streamName, "%s | %s", httpSource, jdbcSink);
+		httpSource.ensureReady().postData("Hi there!");
+
+		String query = String.format("SELECT payload FROM %s", streamName);
+		assertEquals(
+				"Hi there!",
+				jdbcSink.getJdbcTemplate().queryForObject(query, String.class));
+	}
+
+	@Test
+	public void testJdbcSinkWith2InsertionsAndDefaultConfiguration() throws Exception {
+		JdbcSink jdbcSink = newJdbcSink().start();
+
+		HttpSource httpSource = newHttpSource();
+
+
+		String streamName = generateStreamName().replaceAll("-", "_");
+		stream().create(streamName, "%s | %s", httpSource, jdbcSink);
+		httpSource.ensureReady().postData("Hi there!");
+		httpSource.postData("How are you?");
+
+		String query = String.format("SELECT payload FROM %s", streamName);
+		List<String> result = jdbcSink.getJdbcTemplate().queryForList(query, String.class);
+		assertThat(result, contains("Hi there!", "How are you?"));
+	}
+
+	@Test
+	public void testJdbcSinkWithCustomTableName() throws Exception {
+		String tableName = "foobar";
+		JdbcSink jdbcSink = newJdbcSink().tableName(tableName).start();
+
+
+		HttpSource httpSource = newHttpSource();
+
+		stream().create(generateStreamName(), "%s | %s", httpSource, jdbcSink);
+		httpSource.ensureReady().postData("Hi there!");
+
+		String query = String.format("SELECT payload FROM %s", tableName);
+		assertEquals(
+				"Hi there!",
+				jdbcSink.getJdbcTemplate().queryForObject(query, String.class));
+	}
+
+	@Test
+	public void testJdbcSinkWithCustomColumnNames() throws Exception {
+		JdbcSink jdbcSink = newJdbcSink().columns("foo,bar").start();
+
+		HttpSource httpSource = newHttpSource();
+
+
+		String streamName = generateStreamName().replaceAll("-", "_");
+		stream().create(streamName, "%s | %s", httpSource, jdbcSink);
+		String json = "{\"foo\":5, \"bar\": \"hello\"}";
+		httpSource.ensureReady().postData(json);
+
+		String query = String.format("SELECT foo, bar FROM %s", streamName);
+		Result result = jdbcSink.getJdbcTemplate().queryForObject(query, new BeanPropertyRowMapper<>(Result.class));
+		assertEquals("hello", result.getBar());
+		assertEquals(5, result.getFoo());
+	}
+
+	@Test
+	public void testJdbcSinkWithCustomColumnNamesWithUnderscores() throws Exception {
+		JdbcSink jdbcSink = newJdbcSink().columns("foo_bar,bar_foo").start();
+
+		HttpSource httpSource = newHttpSource();
+
+		String streamName = generateStreamName().replaceAll("-", "_");
+		stream().create(streamName, "%s | %s", httpSource, jdbcSink);
+		String json = "{\"fooBar\":5, \"barFoo\": \"hello\"}";
+		httpSource.ensureReady().postData(json);
+
+		String query = String.format("SELECT foo_bar, bar_foo FROM %s", streamName);
+		Map<String, Object> result = jdbcSink.getJdbcTemplate().queryForMap(query);
+		assertEquals("hello", result.get("bar_foo"));
+		assertEquals("5", result.get("foo_bar"));
+	}
+
+	public static class Result {
+
+		private String bar;
+
+		private int foo;
+
+
+		public String getBar() {
+			return bar;
+		}
+
+
+		public int getFoo() {
+			return foo;
+		}
+
+
+		public void setBar(String bar) {
+			this.bar = bar;
+		}
+
+
+		public void setFoo(int foo) {
+			this.foo = foo;
+		}
+
+
+	}
+
+}

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/HttpSource.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/HttpSource.java
@@ -81,7 +81,7 @@ public class HttpSource extends AbstractModuleFixture {
 	public HttpSource postData(String payload) {
 		String command = String.format(
 				"http post --target http://localhost:%d --data \"%s\"",
-				port, payload.replaceAll("\"", "\\\\\""));
+				port, payload.replace("\"", "\\\""));
 		if (contentType != null) {
 			command += String.format(" --contentType \"%s\"", contentType);
 		}

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/JdbcSink.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/JdbcSink.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.shell.command.fixtures;
+
+import org.hsqldb.jdbc.JDBCDriver;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+
+
+/**
+ * Represents the {@code jdbc} sink module. Maintains an in memory relational database and exposes a
+ * {@link JdbcTemplate} so that assertions can be made against it.
+ * 
+ * @author Florent Biville
+ */
+public class JdbcSink extends AbstractModuleFixture implements Disposable {
+
+	private JdbcTemplate jdbcTemplate;
+
+	private String jdbcUrl;
+
+	private String tableName;
+
+	private String columns;
+
+	private String dbname = "foo";
+
+	public JdbcSink dbname(String dbname) {
+		this.dbname = dbname;
+		return this;
+	}
+
+	public JdbcSink start() throws Exception {
+		initDatasource();
+
+		return this;
+	}
+
+	public JdbcTemplate getJdbcTemplate() {
+		return jdbcTemplate;
+	}
+
+	@Override
+	protected String toDSL() {
+		String dsl = "jdbc --initializeDatabase=true --url=" + jdbcUrl;
+		if (tableName != null) {
+			dsl += " --tableName=" + tableName;
+		}
+		if (columns != null) {
+			dsl += " --columns=" + columns;
+		}
+		return dsl;
+	}
+
+	private void initDatasource() throws Exception {
+
+		jdbcUrl = String.format("jdbc:hsqldb:mem:%s", dbname);
+
+		SimpleDriverDataSource dataSource = new SimpleDriverDataSource();
+		dataSource.setDriverClass(JDBCDriver.class);
+		dataSource.setUrl(jdbcUrl);
+		jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	@Override
+	public void cleanup() {
+		jdbcTemplate.execute("SHUTDOWN");
+	}
+
+	public JdbcSink tableName(String tableName) {
+		this.tableName = tableName;
+		return this;
+	}
+
+	public JdbcSink columns(String columns) {
+		this.columns = columns;
+		return this;
+	}
+}


### PR DESCRIPTION
Worked with @fbiville to add some tests to jdbc module. Discovered some bugs along the way.

Not sure what to do about XD-1162 though (is the problem the fact that we can't support a json map where the keys actually contain an underscore (which _is_ legitimate IMO, but not sure we understand the jira correctly))
