### PR TITLE
XD-1396 Fix ContainerRegistrar event handler

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
@@ -75,12 +75,17 @@ public class ContainerRegistrar implements ApplicationListener<ContextRefreshedE
 
 	@Override
 	public void onApplicationEvent(ContextRefreshedEvent event) {
-		this.context = event.getApplicationContext();
-		if (zkConnection.isConnected()) {
-			registerWithZooKeeper(zkConnection.getClient());
-			context.publishEvent(new ContainerStartedEvent(containerMetadata));
+		String containerId = this.containerMetadata.getId();
+		String contextId = event.getApplicationContext().getId();
+		// Only allow container server application context event
+		if (contextId != null & contextId.equals(containerId)) {
+			this.context = event.getApplicationContext();
+			if (zkConnection.isConnected()) {
+				registerWithZooKeeper(zkConnection.getClient());
+				context.publishEvent(new ContainerStartedEvent(containerMetadata));
+			}
+			zkConnection.addListener(new ContainerMetadataRegisteringZooKeeperConnectionListener());
 		}
-		zkConnection.addListener(new ContainerMetadataRegisteringZooKeeperConnectionListener());
 	}
 
 	/**


### PR DESCRIPTION
The ContainerRegistrar should only process the ContextRefreshedEvent from
the ContainerServerApplication's context refresh event. When an external
management server used, then its context refresh also triggers the
ContainerStartedEvent.
- Fix ContainerRegistrar's event handler to process the event's source
  applicaton context ID equals to that of containerID from ContainerMetadata.
