### PR TITLE
XD-1408 ensure singleton ContainerMetadata

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerServerApplication.java
@@ -67,18 +67,7 @@ public class ContainerServerApplication {
 
 	public static final String NODE_PROFILE = "node";
 
-	private final ContainerMetadata containerMetadata;
-
 	private ConfigurableApplicationContext containerContext;
-
-	public ContainerServerApplication() {
-		this.containerMetadata = new ContainerMetadata();
-	}
-
-	@Bean
-	public ContainerMetadata containerMetadata() {
-		return this.containerMetadata;
-	}
 
 	public static void main(String[] args) {
 		new ContainerServerApplication().run(args);
@@ -193,6 +182,7 @@ public class ContainerServerApplication {
 
 		@Override
 		public void initialize(ConfigurableApplicationContext applicationContext) {
+			ContainerMetadata containerMetadata = applicationContext.getParent().getBean(ContainerMetadata.class);
 			applicationContext.setId(containerMetadata.getId());
 		}
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.context.annotation.Profile;
 import org.springframework.integration.monitor.IntegrationMBeanExporter;
+import org.springframework.xd.dirt.container.ContainerMetadata;
 import org.springframework.xd.dirt.util.ConfigLocations;
 
 @EnableAutoConfiguration(exclude = ServerPropertiesAutoConfiguration.class)
@@ -39,6 +40,11 @@ import org.springframework.xd.dirt.util.ConfigLocations;
 public class ParentConfiguration {
 
 	private static final String MBEAN_EXPORTER_BEAN_NAME = "XDParentConfigMBeanExporter";
+
+	@Bean
+	public ContainerMetadata containerMetadata() {
+		return new ContainerMetadata();
+	}
 
 	@Configuration
 	@Profile("cloud")


### PR DESCRIPTION
For now ContainerMetadata is created in ParentConfiguration. Zookeeper Deployment implementation will likely need revisit this.
