### PR TITLE
Fix SingleNode container started event

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
@@ -75,10 +75,9 @@ public class ContainerRegistrar implements ApplicationListener<ContextRefreshedE
 
 	@Override
 	public void onApplicationEvent(ContextRefreshedEvent event) {
-		String containerId = this.containerMetadata.getId();
 		String contextId = event.getApplicationContext().getId();
-		// Only allow container server application context event
-		if (contextId != null & contextId.equals(containerId)) {
+		// Should not allow child management context to fire container started event.
+		if (contextId != null & !contextId.endsWith("management")) {
 			this.context = event.getApplicationContext();
 			if (zkConnection.isConnected()) {
 				registerWithZooKeeper(zkConnection.getClient());


### PR DESCRIPTION
- Check if the context is not management context instead of checking if the context id is
  container id as single node application will have a different id
