### PR TITLE
[zk-runtime] Uniquely identify deployed modules

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ModuleDescriptor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ModuleDescriptor.java
@@ -197,7 +197,7 @@ public class ModuleDescriptor {
 	 * @return key that can be used to refer to this object
 	 */
 	public Key newKey() {
-		return new Key(moduleDefinition.getType(), label);
+		return new Key(streamName, moduleDefinition.getType(), label);
 	}
 
 	/**
@@ -216,6 +216,11 @@ public class ModuleDescriptor {
 	public static class Key implements Comparable<Key> {
 
 		/**
+		 * Stream name.
+		 */
+		private final String stream;
+
+		/**
 		 * Module type.
 		 */
 		private final ModuleType type;
@@ -227,15 +232,27 @@ public class ModuleDescriptor {
 
 		/**
 		 * Construct a key.
-		 * 
-		 * @param type module type
-		 * @param label module label
+		 *
+		 * @param stream stream name
+		 * @param type   module type
+		 * @param label  module label
 		 */
-		public Key(ModuleType type, String label) {
+		public Key(String stream, ModuleType type, String label) {
+			Assert.notNull(stream, "Stream is required");
 			Assert.notNull(type, "Type is required");
 			Assert.hasText(label, "Label is required");
+			this.stream = stream;
 			this.type = type;
 			this.label = label;
+		}
+
+		/**
+		 * Return the name of the stream.
+		 *
+		 * @return stream name
+		 */
+		public String getStream() {
+			return stream;
 		}
 
 		/**
@@ -279,7 +296,8 @@ public class ModuleDescriptor {
 
 			if (o instanceof Key) {
 				Key other = (Key) o;
-				return type.equals(other.getType()) && label.equals(other.getLabel());
+				return stream.equals(other.getStream())
+						&& type.equals(other.getType()) && label.equals(other.getLabel());
 			}
 
 			return false;
@@ -290,7 +308,8 @@ public class ModuleDescriptor {
 		 */
 		@Override
 		public int hashCode() {
-			int result = type.hashCode();
+			int result = stream.hashCode();
+			result = 31 * result + type.hashCode();
 			result = 31 * result + label.hashCode();
 			return result;
 		}
@@ -301,9 +320,11 @@ public class ModuleDescriptor {
 		@Override
 		public String toString() {
 			return "Key{" +
-					"type=" + type +
+					"stream='" + stream + '\'' +
+					", type=" + type +
 					", label='" + label + '\'' +
 					'}';
 		}
+
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
@@ -220,12 +220,13 @@ public class ContainerRegistrar implements ApplicationListener<ContextRefreshedE
 
 	/**
 	 * Undeploy the requested module. </p> TODO: this is a placeholder
-	 * 
+	 *
+	 * @param streamName  name of the stream for the module
 	 * @param moduleLabel module label
-	 * @param moduleType module type
+	 * @param moduleType  module type
 	 */
-	protected void undeployModule(String moduleLabel, String moduleType) {
-		ModuleDescriptor.Key key = new ModuleDescriptor.Key(ModuleType.valueOf(moduleType), moduleLabel);
+	protected void undeployModule(String streamName, String moduleLabel, String moduleType) {
+		ModuleDescriptor.Key key = new ModuleDescriptor.Key(streamName, ModuleType.valueOf(moduleType), moduleLabel);
 		ModuleDescriptor descriptor = mapDeployedModules.get(key);
 		if (descriptor == null) {
 			LOG.trace("Module {} already undeployed", moduleLabel);
@@ -427,19 +428,20 @@ public class ContainerRegistrar implements ApplicationListener<ContextRefreshedE
 	 */
 	private void onChildRemoved(CuratorFramework client, ChildData data) throws Exception {
 		DeploymentsPath deploymentsPath = new DeploymentsPath(data.getPath());
+		String streamName = deploymentsPath.getStreamName();
 		String moduleType = deploymentsPath.getModuleType();
 		String moduleLabel = deploymentsPath.getModuleLabel();
 
-		undeployModule(moduleLabel, moduleType);
+		undeployModule(streamName, moduleLabel, moduleType);
 
-		String path = null;
+		String path;
 		if (ModuleType.job.toString().equals(moduleType)) {
-			path = new JobsPath().setJobName(deploymentsPath.getStreamName())
+			path = new JobsPath().setJobName(streamName)
 					.setModuleLabel(moduleLabel)
 					.setContainer(containerMetadata.getId()).build();
 		}
 		else {
-			path = new StreamsPath().setStreamName(deploymentsPath.getStreamName())
+			path = new StreamsPath().setStreamName(streamName)
 					.setModuleType(moduleType)
 					.setModuleLabel(moduleLabel)
 					.setContainer(containerMetadata.getId()).build();
@@ -525,7 +527,7 @@ public class ContainerRegistrar implements ApplicationListener<ContextRefreshedE
 				String moduleType = streamsPath.getModuleType();
 				String moduleLabel = streamsPath.getModuleLabel();
 
-				undeployModule(moduleLabel, moduleType);
+				undeployModule(streamName, moduleLabel, moduleType);
 
 				String deploymentPath = new DeploymentsPath()
 						.setContainer(containerMetadata.getId())
@@ -563,7 +565,7 @@ public class ContainerRegistrar implements ApplicationListener<ContextRefreshedE
 				String jobName = jobsPath.getJobName();
 				String moduleLabel = jobsPath.getModuleLabel();
 
-				undeployModule(jobName, ModuleType.job.toString());
+				undeployModule(jobName, jobName, ModuleType.job.toString());
 
 				String deploymentPath = new DeploymentsPath()
 						.setContainer(containerMetadata.getId())


### PR DESCRIPTION
**Note:** this pull request is for `zk-runtime`, _not_ `master`.

`ContainerRegistrar` maintains a map of deployed modules via `ModuleDescriptor.Key`. The key uses module type and label to identify a module. This prevents the tracking of multiple modules of the same type and label for different streams.

One of the problems this causes is the inability to undeploy a module for a stream if a previous stream had the same module label and type undeployed before it.

This fix introduces the stream name to the key in order to correctly identify the module runtime instance.
