### PR TITLE
XD-1827: Reject taps on non-existent streams.

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
@@ -87,7 +87,7 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 	}
 
 	// (name =)
-	public String maybeEatStreamName() {
+	private String maybeEatStreamName() {
 		String streamName = null;
 		if (lookAhead(1, TokenKind.EQUALS)) {
 			if (peekToken(TokenKind.IDENTIFIER)) {
@@ -505,7 +505,7 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 	/**
 	 * Return the startPos of the first token in the list (must be non empty).
 	 */
-	public int startPos(Iterable<Token> many) {
+	private int startPos(Iterable<Token> many) {
 		Iterator<Token> iterator = many.iterator();
 		Assert.isTrue(iterator.hasNext(), "list of tokens must not be empty");
 		return iterator.next().startpos;
@@ -514,7 +514,7 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 	/**
 	 * Return the endPos of the end token in the list (must be non empty).
 	 */
-	public int endPos(Iterable<Token> many) {
+	private int endPos(Iterable<Token> many) {
 		int result = -1;
 		for (Token t : many) {
 			result = t.endpos;
@@ -526,7 +526,7 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 	/**
 	 * Return the concatenation of the data of many tokens.
 	 */
-	public String data(Iterable<Token> many) {
+	private String data(Iterable<Token> many) {
 		StringBuilder result = new StringBuilder();
 		for (Token t : many) {
 			if (t.getKind().hasPayload()) {
@@ -591,7 +591,7 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 		lastGoodPoint = tokenStreamPointer;
 	}
 
-	public String toString(Token t) {
+	private String toString(Token t) {
 		if (t.getKind().hasPayload()) {
 			return t.stringValue();
 		}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/XDStreamParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/XDStreamParserTests.java
@@ -174,9 +174,12 @@ public class XDStreamParserTests {
 
 	@Test
 	public void tap() throws Exception {
+		StreamDefinitionRepository streamRepo = mock(StreamDefinitionRepository.class);
+		parser = new XDStreamParser(streamRepo, moduleDefinitionRepository(), new DefaultModuleOptionsMetadataResolver());
+		when(streamRepo.findOne("xxx")).thenReturn(new StreamDefinition("xxx", "http | file"));
 		List<ModuleDeploymentRequest> requests = parser.parse("test", "tap:stream:xxx.http > file", stream);
 		assertEquals(1, requests.size());
-		assertEquals("tap:xxx.http", requests.get(0).getSourceChannelName());
+		assertEquals("tap:xxx.http.0", requests.get(0).getSourceChannelName());
 		assertEquals(ModuleType.sink, requests.get(0).getType());
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -263,6 +263,16 @@ public class StreamConfigParserTests {
 		assertEquals("[(tap:stream:mystream.foobar.1:0>26)>(ModuleNode:file:29>33)]", sn.stringify(true));
 	}
 
+	@Test(expected = StreamDefinitionException.class)
+	public void tapOnNonExistentStreamFails() throws Exception {
+		parse("tap:stream:mystream.foobar > file");
+	}
+
+	@Test(expected = StreamDefinitionException.class)
+	public void tapOnNonExistentStreamFails2() throws Exception {
+		parse("tap:stream:mystream.foobar.1 > file");
+	}
+
 	@Test
 	public void expressions_xd159() {
 		StreamNode ast = parse("foo | transform --expression=--payload | bar");


### PR DESCRIPTION
When calling ChannelNode.resolve on a stream tap, a lookup on the stream name
is performed before continuing and an exception raised if no matching stream
is found.
