### PR TITLE
XD-1460 Enable JMX by default

### DIFF
--- a/config/xd-config.yml
+++ b/config/xd-config.yml
@@ -46,6 +46,16 @@
 #    active: default,postgresql
 
 ---
+# Config to enable/disable JMX/jolokia endpoints
+#XD_JMX_ENABLED: true
+#endpoints:
+#  jolokia:
+#    enabled: ${XD_JMX_ENABLED:true}
+#  jmx:
+#    enabled: ${XD_JMX_ENABLED:true}
+#    uniqueNames: true
+
+---
 # Redis properties
 #spring:
 #  redis:

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServerApplication.java
@@ -92,7 +92,7 @@ public class AdminServerApplication {
 		return new SourceFilteringListener(context, delegate);
 	}
 
-	@ConditionalOnExpression("${XD_JMX_ENABLED:false}")
+	@ConditionalOnExpression("${XD_JMX_ENABLED:true}")
 	@EnableMBeanExport(defaultDomain = "xd.admin")
 	protected static class JmxConfiguration {
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerServerApplication.java
@@ -58,8 +58,6 @@ public class ContainerServerApplication {
 
 	private static final Log log = LogFactory.getLog(ContainerServerApplication.class);
 
-	private static final String MBEAN_EXPORTER_BEAN_NAME = "XDLauncherMBeanExporter";
-
 	public static final String NODE_PROFILE = "node";
 
 	private ConfigurableApplicationContext containerContext;
@@ -135,19 +133,6 @@ public class ContainerServerApplication {
 		System.exit(1);
 	}
 
-	@ConditionalOnExpression("${XD_JMX_ENABLED:false}")
-	@EnableMBeanExport(defaultDomain = "xd.container")
-	protected static class JmxConfiguration {
-
-		@Bean(name = MBEAN_EXPORTER_BEAN_NAME)
-		public IntegrationMBeanExporter integrationMBeanExporter() {
-			IntegrationMBeanExporter exporter = new IntegrationMBeanExporter();
-			exporter.setDefaultDomain("xd.container");
-			return exporter;
-		}
-	}
-
-
 	private class IdInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
 		@Override
@@ -163,6 +148,7 @@ public class ContainerServerApplication {
  * Container Application Context
  * 
  * @author David Turanski
+ * @author Ilayaperumal Gopinathan
  */
 @Configuration
 @ImportResource({
@@ -170,6 +156,8 @@ public class ContainerServerApplication {
 })
 @EnableAutoConfiguration
 class ContainerConfiguration {
+
+	private static final String MBEAN_EXPORTER_BEAN_NAME = "XDContainerMBeanExporter";
 
 	@Autowired
 	private ContainerMetadata containerMetadata;
@@ -187,5 +175,18 @@ class ContainerConfiguration {
 	@Bean
 	public ContainerRegistrar containerRegistrar() {
 		return new ContainerRegistrar(containerMetadata, zooKeeperConnection);
+	}
+
+	// TODO: Should this be removed once the control transport is removed?
+	@ConditionalOnExpression("${XD_JMX_ENABLED:true}")
+	@EnableMBeanExport(defaultDomain = "xd.container")
+	protected static class JmxConfiguration {
+
+		@Bean(name = MBEAN_EXPORTER_BEAN_NAME)
+		public IntegrationMBeanExporter integrationMBeanExporter() {
+			IntegrationMBeanExporter exporter = new IntegrationMBeanExporter();
+			exporter.setDefaultDomain("xd.container");
+			return exporter;
+		}
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SharedServerContextConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SharedServerContextConfiguration.java
@@ -54,7 +54,7 @@ public class SharedServerContextConfiguration {
 
 	private static final String MBEAN_EXPORTER_BEAN_NAME = "XDSharedServerMBeanExporter";
 
-	@ConditionalOnExpression("${XD_JMX_ENABLED:false}")
+	@ConditionalOnExpression("${XD_JMX_ENABLED:true}")
 	@EnableMBeanExport(defaultDomain = "xd.shared.server")
 	protected static class JmxConfiguration {
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
@@ -30,25 +30,12 @@ public class CommonOptions {
 	@Option(name = "--help", usage = "Show this help screen", aliases = { "-?", "-h" })
 	private boolean showHelp = false;
 
-	@Option(name = "--jmxEnabled", usage = "Whether to enable JMX exposition of beans")
-	private Boolean jmxEnabled;
-
 	@Option(name = "--mgmtPort", usage = "The port for the management server", metaVar = "<mgmtPort>")
 	private Integer mgmtPort;
 
 	// Using wrapped here so that "showHelp" is not returned as a property by BeanPropertiesPropertySource
 	public Boolean isShowHelp() {
 		return showHelp ? true : null;
-	}
-
-
-	public Boolean getXD_JMX_ENABLED() {
-		return jmxEnabled;
-	}
-
-
-	public void setXD_JMX_ENABLED(Boolean jmxEnabled) {
-		this.jmxEnabled = jmxEnabled;
 	}
 
 	public Integer getXD_MGMT_PORT() {

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -10,9 +10,9 @@ spring:
     show_banner: false
 endpoints:
   jolokia:
-    enabled: ${XD_JMX_ENABLED:false}
+    enabled: ${XD_JMX_ENABLED:true}
   jmx:
-    enabled: ${XD_JMX_ENABLED:false}
+    enabled: ${XD_JMX_ENABLED:true}
     uniqueNames: true
 
 XD_ANALYTICS: ${analytics:redis}
@@ -20,7 +20,7 @@ XD_TRANSPORT: ${transport:redis}
 XD_CONTROL_TRANSPORT: ${controlTransport:${XD_TRANSPORT}}
 XD_STORE: ${store:redis}
 XD_HOME: ${xdHomeDir:..}
-XD_JMX_ENABLED: ${jmxEnabled:false}
+XD_JMX_ENABLED: true
 
 xd:
   data:

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/StreamTestSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/StreamTestSupport.java
@@ -59,7 +59,9 @@ public class StreamTestSupport {
 	@BeforeClass
 	public static void startXDSingleNode() throws Exception {
 		application = new TestApplicationBootstrap().getSingleNodeApplication().run("--analytics", "memory",
-				"--store", "memory", "--jmxEnabled");
+				"--store", "memory");
+		// Explicitly set this to true since RandomConfigurationSupport disables JMX by default.
+		System.setProperty("XD_JMX_ENABLED", "true");
 		adminContext = application.adminContext();
 		SingleNodeIntegrationTestSupport integrationTestSupport = new SingleNodeIntegrationTestSupport(application,
 				"classpath:/testmodules/");

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/RandomConfigurationSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/RandomConfigurationSupport.java
@@ -66,6 +66,7 @@ public class RandomConfigurationSupport {
 		setupRandomControlTransportChannels();
 		setupRandomAdminServerPort();
 		setupRandomHSQLDBConfig();
+		disableJmx();
 	}
 
 	private void setupRandomControlTransportChannels() {
@@ -95,6 +96,10 @@ public class RandomConfigurationSupport {
 
 	private void setupRandomAdminServerPort() {
 		System.setProperty(ADMIN_SERVER_PORT, String.valueOf(adminPort));
+	}
+
+	private void disableJmx() {
+		System.setProperty("XD_JMX_ENABLED", "false");
 	}
 
 	public String getAdminServerPort() {


### PR DESCRIPTION
- Removed jmxEnabled commandLine option
- Set XD_JMX_ENABLED by default in application.yml
- Added configs in xd-config.yml
- Disable JMX by default in RandomConfigurationSupport
  - This will allow the tests to run without JMX enabled.
- Fixed xd.container JMX MbeanExporter bean configuration
  - Moved the bean configuration from ContainerServerApplication to ContainerConfiguration
