### PR TITLE
XD-1278 Renaming avro sink to hdfs-dataset

### DIFF
--- a/modules/sink/hdfs-dataset.properties
+++ b/modules/sink/hdfs-dataset.properties
@@ -8,3 +8,11 @@ options.directory.type = String
 options.idleTimeout.description = idle timeout in milliseconds when Hadoop file resource is automatically closed
 options.idleTimeout.type = Long
 options.idleTimeout.default = -1
+
+options.allowNullValues.description = whether null property values are allowed, if set to true then schema will use UNION for each field
+options.allowNullValues.type = boolean
+options.allowNullValues.default = true
+
+options.format.description = the format to use, valid options are avro and parquet
+options.format.type = String
+options.format.default = avro

--- a/modules/sink/hdfs-dataset.xml
+++ b/modules/sink/hdfs-dataset.xml
@@ -36,10 +36,16 @@
 		<property name="timeoutOnIdle" value="true"/>
 	</bean>
 
-	<int-hadoop:avro-outbound-channel-adapter id="objects" dataset-operations="datasetOperations"/>
+	<int-hadoop:dataset-outbound-channel-adapter id="objects" dataset-operations="datasetOperations"/>
 
     <bean id="datasetOperations" class="org.springframework.data.hadoop.store.dataset.DatasetTemplate">
 		<property name="datasetRepositoryFactory" ref="datasetRepositoryFactory"/>
+		<property name="defaultDatasetDefinition">
+			<bean class="org.springframework.data.hadoop.store.dataset.DatasetDefinition">
+				<constructor-arg index="0" value="${allowNullValues}"/>
+				<constructor-arg index="1" value="${format}"/>
+			</bean>
+		</property>
 	</bean>
 
 	<bean id="datasetRepositoryFactory" class="org.springframework.data.hadoop.store.dataset.DatasetRepositoryFactory">

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetWriter.java
@@ -30,13 +30,13 @@ import java.util.Collections;
  * 
  * @author Thomas Risberg
  */
-public class AvroWriter implements HdfsWriter {
+public class DatasetWriter implements HdfsWriter {
 
 	private final Log logger = LogFactory.getLog(this.getClass());
 
 	private DatasetOperations datasetOperations;
 
-	public AvroWriter(DatasetOperations datasetOperations) {
+	public DatasetWriter(DatasetOperations datasetOperations) {
 		Assert.notNull(datasetOperations, "DatasetTemplate must not be null.");
 		logger.info("Configured with datasetOperations: " + datasetOperations);
 		this.datasetOperations = datasetOperations;

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetWriterFactory.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetWriterFactory.java
@@ -23,18 +23,18 @@ import org.springframework.util.Assert;
  * 
  * @author Thomas Risberg
  */
-public class AvroWriterFactory implements HdfsWriterFactory {
+public class DatasetWriterFactory implements HdfsWriterFactory {
 
 	private DatasetOperations datasetOperations;
 
-	public AvroWriterFactory(DatasetOperations datasetOperations) {
+	public DatasetWriterFactory(DatasetOperations datasetOperations) {
 		Assert.notNull(datasetOperations, "DatasetTemplate must not be null.");
 		this.datasetOperations = datasetOperations;
 	}
 
 	@Override
 	public HdfsWriter createWriter() {
-		AvroWriter writer = new AvroWriter(datasetOperations);
+		DatasetWriter writer = new DatasetWriter(datasetOperations);
 		return writer;
 	}
 

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParser.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParser.java
@@ -25,15 +25,15 @@ import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
 /**
- * Parser for the 'avro-outbound-channel-adapter' element.
+ * Parser for the 'dataset-outbound-channel-adapter' element.
  * 
  * @author Thomas Risberg
  */
-public class AvroOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
+public class DatasetOutboundChannelAdapterParser extends AbstractOutboundChannelAdapterParser {
 
 	@Override
 	protected AbstractBeanDefinition parseConsumer(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(AvroWritingMessageHandlerFactoryBean.class);
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(DatasetWritingMessageHandlerFactoryBean.class);
 		String datasetOperations = element.getAttribute("dataset-operations");
 		if (!StringUtils.hasText(datasetOperations)) {
 			parserContext.getReaderContext().error("dataset-operations is required", element);

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/DatasetWritingMessageHandlerFactoryBean.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/DatasetWritingMessageHandlerFactoryBean.java
@@ -19,13 +19,13 @@ package org.springframework.xd.integration.hadoop.config;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.data.hadoop.store.dataset.DatasetOperations;
 import org.springframework.util.Assert;
-import org.springframework.xd.hadoop.fs.AvroWriterFactory;
+import org.springframework.xd.hadoop.fs.DatasetWriterFactory;
 import org.springframework.xd.integration.hadoop.outbound.HdfsWritingMessageHandler;
 
 /**
  * @author Thomas Risberg
  */
-public class AvroWritingMessageHandlerFactoryBean implements FactoryBean<HdfsWritingMessageHandler> {
+public class DatasetWritingMessageHandlerFactoryBean implements FactoryBean<HdfsWritingMessageHandler> {
 
 	private final DatasetOperations datasetOperations;
 
@@ -33,7 +33,7 @@ public class AvroWritingMessageHandlerFactoryBean implements FactoryBean<HdfsWri
 
 	private volatile HdfsWritingMessageHandler handler;
 
-	public AvroWritingMessageHandlerFactoryBean(DatasetOperations datasetOperations) {
+	public DatasetWritingMessageHandlerFactoryBean(DatasetOperations datasetOperations) {
 		Assert.notNull(datasetOperations, "datasetOperations must not be null");
 		this.datasetOperations = datasetOperations;
 	}
@@ -55,7 +55,7 @@ public class AvroWritingMessageHandlerFactoryBean implements FactoryBean<HdfsWri
 	@Override
 	public synchronized HdfsWritingMessageHandler getObject() throws Exception {
 		if (handler == null) {
-			AvroWriterFactory writerFactory = new AvroWriterFactory(this.datasetOperations);
+			DatasetWriterFactory writerFactory = new DatasetWriterFactory(this.datasetOperations);
 			this.handler = new HdfsWritingMessageHandler(writerFactory);
 			if (this.autoStartup != null) {
 				this.handler.setAutoStartup(this.autoStartup);

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HadoopNamespaceHandler.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HadoopNamespaceHandler.java
@@ -32,7 +32,7 @@ public class HadoopNamespaceHandler extends AbstractIntegrationNamespaceHandler 
 		registerBeanDefinitionParser("naming-strategy", new NamingStrategyParser());
 		registerBeanDefinitionParser("rollover-strategy", new RolloverStrategyParser());
 		registerBeanDefinitionParser("hdfs-outbound-channel-adapter", new HdfsOutboundChannelAdapterParser());
-		registerBeanDefinitionParser("avro-outbound-channel-adapter", new AvroOutboundChannelAdapterParser());
+		registerBeanDefinitionParser("dataset-outbound-channel-adapter", new DatasetOutboundChannelAdapterParser());
 	}
 
 }

--- a/spring-xd-hadoop/src/main/resources/org/springframework/xd/integration/hadoop/config/spring-integration-hadoop.xsd
+++ b/spring-xd-hadoop/src/main/resources/org/springframework/xd/integration/hadoop/config/spring-integration-hadoop.xsd
@@ -91,10 +91,10 @@
 		</xsd:complexType>
 	</xsd:element>
 
-	<xsd:element name="avro-outbound-channel-adapter">
+	<xsd:element name="dataset-outbound-channel-adapter">
 		<xsd:annotation>
 			<xsd:documentation>
-	Defines an outbound HDFS Avro writing Channel Adapter.
+	Defines an outbound HDFS Dataset writing Channel Adapter.
 			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterIntegrationTests.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterIntegrationTests.java
@@ -29,13 +29,13 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Thomas Risberg
  */
-public class AvroOutboundChannelAdapterIntegrationTests {
+public class DatasetOutboundChannelAdapterIntegrationTests {
 
 	@Test
-	public void test() throws Exception {
+	public void testWritingDataset() throws Exception {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-				"org/springframework/xd/integration/hadoop/config/AvroOutboundChannelAdapterIntegrationTests.xml");
-		MessageChannel channel = context.getBean("avroOut", MessageChannel.class);
+				"org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterIntegrationTests.xml");
+		MessageChannel channel = context.getBean("datasetOut", MessageChannel.class);
 		channel.send(MessageBuilder.withPayload("foo").build());
 		channel.send(MessageBuilder.withPayload("bar").build());
 		DatasetOperations datasetOperations = context.getBean("datasetOperations", DatasetOperations.class);

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParserTests.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParserTests.java
@@ -21,7 +21,7 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.data.hadoop.store.dataset.DatasetOperations;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
-import org.springframework.xd.hadoop.fs.AvroWriterFactory;
+import org.springframework.xd.hadoop.fs.DatasetWriterFactory;
 import org.springframework.xd.integration.hadoop.outbound.HdfsWritingMessageHandler;
 
 import static org.junit.Assert.assertEquals;
@@ -29,17 +29,17 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author Thomas Risberg
  */
-public class AvroOutboundChannelAdapterParserTests {
+public class DatasetOutboundChannelAdapterParserTests {
 
 	@Test
-	public void test() {
+	public void testParser() {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
-				"org/springframework/xd/integration/hadoop/config/AvroOutboundChannelAdapterParserTests.xml");
+				"org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParserTests.xml");
 		EventDrivenConsumer adapter = context.getBean("adapter", EventDrivenConsumer.class);
 		HdfsWritingMessageHandler handler = (HdfsWritingMessageHandler) new DirectFieldAccessor(adapter).getPropertyValue("handler");
 		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
 		assertEquals(false, handlerAccessor.getPropertyValue("autoStartup"));
-		AvroWriterFactory writerFactory = (AvroWriterFactory) handlerAccessor.getPropertyValue("hdfsWriterFactory");
+		DatasetWriterFactory writerFactory = (DatasetWriterFactory) handlerAccessor.getPropertyValue("hdfsWriterFactory");
 		DatasetOperations datasetOperations = (DatasetOperations) new DirectFieldAccessor(writerFactory).getPropertyValue("datasetOperations");
 		assertEquals(context.getBean("datasetOperations"), datasetOperations);
 		context.close();

--- a/spring-xd-hadoop/src/test/resources/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterIntegrationTests.xml
+++ b/spring-xd-hadoop/src/test/resources/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterIntegrationTests.xml
@@ -28,8 +28,8 @@
         <property name="datasetRepositoryFactory" ref="datasetFactory"/>
     </bean>
 
-	<int-hadoop:avro-outbound-channel-adapter
-		id="avroOut"
+	<int-hadoop:dataset-outbound-channel-adapter
+		id="datasetOut"
         dataset-operations="datasetOperations"/>
 
 </beans>

--- a/spring-xd-hadoop/src/test/resources/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParserTests.xml
+++ b/spring-xd-hadoop/src/test/resources/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParserTests.xml
@@ -9,12 +9,12 @@
 
 	<bean id="datasetOperations" class="org.springframework.xd.hadoop.fs.StubDatasetOperations"/>
 
-	<int-hadoop:avro-outbound-channel-adapter
+	<int-hadoop:dataset-outbound-channel-adapter
 		id="adapter"
-		channel="avroOut"
+		channel="datasetOut"
 		dataset-operations="datasetOperations"
 		auto-startup="false"/>
 
-	<int:channel id="avroOut"/>
+	<int:channel id="datasetOut"/>
 
 </beans>


### PR DESCRIPTION
- Adding support for parquet in addition to avro
  - use new option --format=parquet
  - for this option to work the payload currently MUST be a JavaBean with properties for all fields to be stored
- Adding support for not allowing nulls
  - this avoids generating an Avro UNION for every field in the schema
  - use new option --allowNullValues=false
