### PR TITLE
Speedup build process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,11 +169,19 @@ configure(javaProjects) { subproject ->
 	compileJava {
 		sourceCompatibility=1.6
 		targetCompatibility=1.6
+		options.fork = true
+		options.forkOptions.with {
+                        memoryMaximumSize = "512m"
+                }
 	}
 
 	compileTestJava {
 		sourceCompatibility=1.7
 		targetCompatibility=1.7
+		options.fork = true
+		options.forkOptions.with {
+			memoryMaximumSize = "512m"
+		}
 	}
 
 	eclipse {
@@ -236,14 +244,17 @@ configure(javaProjects) { subproject ->
 	test {
 		// suppress all console output during testing unless running `gradle -i`
 		logging.captureStandardOutput(LogLevel.INFO)
-		jvmArgs "-XX:MaxPermSize=256m"
+		minHeapSize = "128m"
+		maxHeapSize = "512m"
+		jvmArgs "-XX:MaxPermSize=512m"
 		jvmArgs "-Djava.net.preferIPv4Stack=true"
 		jvmArgs "-XX:+HeapDumpOnOutOfMemoryError"
 		// 	useful for debugging the GradleWorkerMain
 		//		jvmArgs "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8000"
 		//		jvmArgs "-Dlog4j.debug=true"
 		//		classpath = files('/some/dir/with/props') + project.sourceSets.test.runtimeClasspath
-
+		maxParallelForks = java.lang.Runtime.getRuntime().availableProcessors() as int
+		forkEvery = 10 
 		ignoreFailures = project.hasProperty('ignoreTestFailures') ? getProperty('ignoreTestFailures') : false
 	}
 
@@ -482,7 +493,7 @@ project('spring-xd-dirt') {
 
 	test {
 		systemProperties["xd.home"] = "${rootProject.projectDir}"
-		forkEvery = 10
+		forkEvery = 40
 	}
 
 	task configFiles {

--- a/gradlew
+++ b/gradlew
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GRADLE_OPTS="-XX:MaxPermSize=256m $GRADLE_OPTS"
+GRADLE_OPTS="-Xms128m -Xmx512m -XX:MaxPermSize=512m $GRADLE_OPTS"
 
 if [ x != x"$XD_HOME" ]; then
 	unset XD_HOME

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
@@ -41,6 +41,7 @@ import org.springframework.integration.x.bus.serializer.kryo.PojoCodec;
 import org.springframework.integration.x.bus.serializer.kryo.TupleCodec;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.util.SocketUtils;
 import org.springframework.xd.dirt.config.TestMessageBusInjection;
 import org.springframework.xd.dirt.integration.test.SingleNodeIntegrationTestSupport;
 import org.springframework.xd.dirt.integration.test.sink.NamedChannelSink;
@@ -236,7 +237,8 @@ public abstract class AbstractSingleNodeStreamDeploymentIntegrationTests {
 		int i = 0;
 		for (i = 0; i < ITERATIONS; i++) {
 			StreamDefinition definition = new StreamDefinition("test" + i,
-					"http | transform --expression=payload | filter --expression=true | log");
+					"http --port=" + SocketUtils.findAvailableTcpPort()
+							+ "| transform --expression=payload | filter --expression=true | log");
 			integrationSupport.streamDeployer().save(definition);
 			assertTrue("stream not deployed", integrationSupport.deployStream(definition));
 			assertEquals(1, integrationSupport.streamRepository().count());

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/RandomConfigurationSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/RandomConfigurationSupport.java
@@ -48,7 +48,9 @@ public class RandomConfigurationSupport {
 
 	private static final String HSQLDB_DATABASE = "hsql.server.database";
 
-	private static final String tmpDir = FileUtils.getTempDirectory().toString();
+	private static String tmpDir = FileUtils.getTempDirectory().toString();
+
+	private static String batchJobsDirectory = tmpDir;
 
 	private final long now;
 
@@ -63,6 +65,7 @@ public class RandomConfigurationSupport {
 		adminPort = SocketUtils.findAvailableTcpPort();
 		deployerQueue = "xd.deployer." + now;
 		undeployerTopic = "xd.undeployer." + now;
+		batchJobsDirectory = tmpDir + now;
 		setupRandomControlTransportChannels();
 		setupRandomAdminServerPort();
 		setupRandomHSQLDBConfig();
@@ -85,7 +88,7 @@ public class RandomConfigurationSupport {
 	private void setupRandomHSQLDBConfig(String host) {
 		System.setProperty(HSQLDB_HOST, host);
 		System.setProperty(HSQLDB_PORT, String.valueOf(SocketUtils.findAvailableTcpPort()));
-		System.setProperty(XD_DATA_HOME, tmpDir);
+		System.setProperty(XD_DATA_HOME, batchJobsDirectory);
 		System.setProperty(HSQLDB_DBNAME, "dbname-" + now);
 		System.setProperty(HSQLDB_DATABASE, "database-" + now);
 	}
@@ -110,6 +113,7 @@ public class RandomConfigurationSupport {
 	public static void cleanup() throws IOException {
 		// By default the data directory is located inside ${xd.data.home}/jobs
 		// Refer batch.xml
-		FileUtils.deleteDirectory(new File(tmpDir + "/jobs"));
+		FileUtils.deleteDirectory(new File(batchJobsDirectory + "/jobs"));
+		batchJobsDirectory = tmpDir;
 	}
 }


### PR DESCRIPTION
- Support tests to run in parallel
  - Fix some of the tests so that they can run in parallel.
  - Configure maxParallelForks to use available core
  - Increase forkEvery value for spring-xd-dirt tests and for the rest of the tests.
- Modify jvm args for compile and test
