### PR TITLE
Fixed AbstractSingleNodeStreamDeploymentIntegrationTests

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
@@ -196,8 +196,11 @@ public abstract class AbstractSingleNodeStreamDeploymentIntegrationTests {
 		testApplicationBootstrap = new TestApplicationBootstrap();
 		singleNodeApplication = testApplicationBootstrap.getSingleNodeApplication().run("--transport", transport);
 		integrationSupport = new SingleNodeIntegrationTestSupport(singleNodeApplication);
-		if (testMessageBus != null && !transport.equalsIgnoreCase("local")) {
+		if (!transport.equalsIgnoreCase("local")) {
 			TestMessageBusInjection.injectMessageBus(singleNodeApplication, testMessageBus);
+		}
+		else {
+			testMessageBus = null;
 		}
 		ContainerAttributes attribs = singleNodeApplication.containerContext().getBean(ContainerAttributes.class);
 		integrationSupport.addPathListener(Paths.build(Paths.MODULE_DEPLOYMENTS, attribs.getId()), deploymentsListener);


### PR DESCRIPTION
Fixes the ubuntu build issue. There was apparently some crosstalk with other AbstractSingleNodeStreamDeploymentIntegrationTests which set the testMessageBus in LocalSingleNodeStreamDeploymentIntegrationTests. The TMB is a wrapper to clean up transport resources gracefully and is expected to be null in the Local case. Running the build on Ubuntu exposed a bug where the local test was actually using a separate instance of RedisMessageBus to check the bindings. 
