### PR TITLE
Enable parallel tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1387,7 +1387,10 @@ project('spring-xd-shell') {
 	mainClassName = "org.springframework.shell.Bootstrap"
 	run { standardInput = System.in }
 
-	test { include '**/*TestSuite*' }
+	test {
+		include '**/*TestSuite*'
+		forkEvery 20
+	}
 
 	dependencies {
 		compile "org.springframework.shell:spring-shell:$springShellVersion"

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/RandomConfigurationSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/RandomConfigurationSupport.java
@@ -87,10 +87,15 @@ public class RandomConfigurationSupport {
 	}
 
 	@AfterClass
-	public static void cleanup() throws IOException {
+	public static void cleanup() {
 		// By default the data directory is located inside ${xd.data.home}/jobs
 		// Refer batch.xml
-		FileUtils.deleteDirectory(new File(batchJobsDirectory + "/jobs"));
+		try {
+			FileUtils.deleteDirectory(new File(batchJobsDirectory + "/jobs"));
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+		}
 		batchJobsDirectory = tmpDir;
 	}
 }


### PR DESCRIPTION
- Modify RandomConfigurationSupport's deleteFiles to print stacktrace in case of failure while
  deleting
- Increase `forkEvery` to 20 in case of spring-xd-shell
- Running -PmaxParallelForks=<?> improves build time depending on the dev machine configuration
