### PR TITLE
Set the contextPath to "".

### DIFF
--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -41,7 +41,7 @@ server:
   port: ${PORT:9393}
 management:
   port: ${XD_MGMT_PORT:${PORT:9393}}
-  contextPath: /management
+  contextPath: 
 ---
 zk:
   client:
@@ -71,7 +71,7 @@ server:
   port: ${PORT:0}
 management:
   port: ${XD_MGMT_PORT:${PORT:}}
-  contextPath: /management
+  contextPath: 
 ---
 
 spring:


### PR DESCRIPTION
Jolokia currently doesn't work if contextpath is set to /management.
Once XD-1494 has been resolved by Spring boot 1.2.1, we will need to set the
context path back to /management.
