### PR TITLE
Override XD MBean exporters' domain names

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServerApplication.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchDatabaseInitializer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
@@ -45,7 +46,7 @@ import org.springframework.xd.dirt.util.XdConfigLoggingInitializer;
 import org.springframework.xd.dirt.util.XdProfiles;
 
 @Configuration
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = { BatchAutoConfiguration.class, JmxAutoConfiguration.class })
 @ImportResource("classpath:" + ConfigLocations.XD_INTERNAL_CONFIG_ROOT + "admin-server.xml")
 @Import(RestConfiguration.class)
 public class AdminServerApplication {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerServerApplication.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextInitializer;
@@ -59,7 +60,7 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
  * @author David Turanski
  */
 @Configuration
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = { BatchAutoConfiguration.class, JmxAutoConfiguration.class })
 @Import(PropertyPlaceholderAutoConfiguration.class)
 public class ContainerServerApplication {
 
@@ -153,7 +154,7 @@ public class ContainerServerApplication {
 @ImportResource({
 	"classpath:" + ConfigLocations.XD_INTERNAL_CONFIG_ROOT + "container-server.xml",
 })
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = { BatchAutoConfiguration.class, JmxAutoConfiguration.class })
 class ContainerConfiguration {
 
 	private static final String MBEAN_EXPORTER_BEAN_NAME = "XDContainerMBeanExporter";
@@ -210,7 +211,6 @@ class ContainerConfiguration {
 				zooKeeperConnection);
 	}
 
-	// TODO: Should this be removed once the control transport is removed?
 	@ConditionalOnExpression("${XD_JMX_ENABLED:true}")
 	@EnableMBeanExport(defaultDomain = "xd.container")
 	protected static class JmxConfiguration {


### PR DESCRIPTION
- Exclude JmxAutoConfiguration so that Integration MBean exporters defined in configuration classes based on the conditional
  expression ${XD_JMX_ENABLED:true} get to set their domain name
  - With this change,
    - the XD container will have MBeans with domain names `xd.parent`, `xd.shared.server` and `xd.container`
    - the XD admin will have MBeans with domain names `xd.parent`, `xd.shared.server` and `xd.admin`
    - the XD singlenode will have all the MBeans above
