### PR TITLE
Modification made to call toString on the JsonNode, rather than asText, ...

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/json/JsonNodeFieldExtractor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/json/JsonNodeFieldExtractor.java
@@ -30,6 +30,6 @@ public class JsonNodeFieldExtractor {
 	}
 
 	public String extract(JsonNode node) {
-		return node.get(this.fieldName).asText();
+		return node.get(this.fieldName).toString();
 	}
 }


### PR DESCRIPTION
Modification made to call toString on the JsonNode, rather than asText, which only allows extraction from value nodes. This change allows the json-field-extractor to be chained and nested fields to be accessed.

I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.
