### PR TITLE
XD-1516: Deploy "orphaned" jobs to new containers

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
@@ -311,7 +311,7 @@ public class AdminServer implements ContainerRepository, ApplicationListener<App
 				containerListener = new ContainerListener(AdminServer.this,
 						streamDefinitionRepository,
 						moduleDefinitionRepository,
-						moduleOptionsMetadataResolver, streamDeployments, streams);
+						moduleOptionsMetadataResolver, streamDeployments, streams, jobDeployments);
 
 				PathChildrenCache containersCache = new PathChildrenCache(client, Paths.CONTAINERS, true,
 						ThreadUtils.newThreadFactory("ContainersPathChildrenCache"));


### PR DESCRIPTION
When a new container starts, determine if there are any deployed jobs that currently are not running on a container; if so then deploy them to the new container.

There is some copy/paste code here (see comment in `ContainerListener` line 179, method `onChildAdded`) that needs to be refactored later on.
