### PR TITLE
XD-1528 Singlenode external batch db support

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -15,6 +15,13 @@
 #       enabled: false
 
 ---
+#Config for singlenode embedded hsql
+#spring:
+#  profiles: singlenode
+#singlenode:
+#  embeddedHsql: true
+
+---
 #Config for use with HSQLDB
 #
 #Change the database host, port and name

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -85,7 +85,8 @@ spring:
 transport: local
 store: memory
 analytics: memory
-
+singlenode:
+  embeddedHsql: ${XD_SINGLENODE_EMBEDHSQL:true}
 ---
 
 # HSQL database configuration


### PR DESCRIPTION
- Add HsqldbServerProfileActivator initializer in SingleNodeApplication's adminContext
  -  This initializer activates the hsqldbServer profile (which manages lifecycle operations on HSQLServerBean) only when the hsqldb datasource and embedded hsqldb are selected
  - Intrduced `singlenode.embeddedHsql` property that sets the option to use embedded hsqldb in case of singlenode server
    - Updated config/servers.yml for the same property to override in case of non-embedded hsqldb
