### PR TITLE
XD-1532 Unregister MBeans on module start() failure

### DIFF
--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/CompositeModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/CompositeModule.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
@@ -245,7 +246,13 @@ public class CompositeModule extends AbstractModule {
 				Module module = this.modules.get(i);
 				module.start();
 			}
-			this.context.start();
+			try {
+				this.context.start();
+			}
+			catch (BeansException be) {
+				this.context.destroy();
+				throw be;
+			}
 			if (logger.isInfoEnabled()) {
 				logger.info("started module: " + this.toString());
 			}

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/SimpleModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/SimpleModule.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.autoconfigure.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.builder.ParentContextCloserApplicationListener;
@@ -245,7 +246,15 @@ public class SimpleModule extends AbstractModule {
 
 	@Override
 	public void start() {
-		context.start();
+		try {
+			context.start();
+		}
+		catch (BeansException be) {
+			// Make sure the context is destroyed; this will allow possible destruction of life-cycle beans registered
+			// (example: MBeans)
+			destroy();
+			throw be;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
- When the module start() life-cycle method fails, the registered MBeans for the module should
  be unregistered so that when the module gets deployed again, it won't see a duplicate MBean
  - Catch BeansException on module start() and destroy the context if exception thrown
    - Fixed on both SimpleModule and ComposedModule
