### PR TITLE
[pending SHL-139] XD-1536: Add ability to inject delimiter on pre-packaged jobs that deal with files.

### DIFF
--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcHdfsOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcHdfsOptionsMetadata.java
@@ -6,15 +6,18 @@ import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_JO
 import javax.validation.constraints.AssertTrue;
 
 import org.springframework.util.StringUtils;
+import org.springframework.xd.module.options.mixins.BatchJobFieldDelimiterOptionMixin;
 import org.springframework.xd.module.options.mixins.BatchJobRestartableOptionMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
+
+import javax.validation.constraints.AssertTrue;
 
 /**
  * @author Luke Taylor
  * @author Ilayaperumal Gopinathan
  */
-@Mixin(BatchJobRestartableOptionMixin.class)
+@Mixin({BatchJobRestartableOptionMixin.class, BatchJobFieldDelimiterOptionMixin.class})
 public class JdbcHdfsOptionsMetadata extends AbstractJdbcOptionsMetadata {
 
 	private String tableName = "";

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/ResourcesIntoJdbcJobModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/ResourcesIntoJdbcJobModuleOptionsMetadata.java
@@ -17,19 +17,23 @@
 package org.springframework.xd.jdbc;
 
 import org.springframework.xd.module.options.mixins.BatchJobDeleteFilesOptionMixin;
+import org.springframework.xd.module.options.mixins.BatchJobFieldDelimiterOptionMixin;
 import org.springframework.xd.module.options.mixins.BatchJobFieldNamesOptionMixin;
 import org.springframework.xd.module.options.mixins.BatchJobResourcesOptionMixin;
 import org.springframework.xd.module.options.mixins.BatchJobRestartableOptionMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 
 /**
- * Typical class for metadata about jobs that slurp csv resources into jdbc. Can be used as is or extended if needed.
+ * Typical class for metadata about jobs that slurp delimited resources into jdbc. Can be used as is or extended if
+ * needed.
  * 
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
+ * @author Michael Minella
  */
 @Mixin({ BatchJobRestartableOptionMixin.class, BatchJobResourcesOptionMixin.class,
-	BatchJobDeleteFilesOptionMixin.class, BatchJobFieldNamesOptionMixin.class })
+	BatchJobDeleteFilesOptionMixin.class, BatchJobFieldNamesOptionMixin.class,
+	BatchJobFieldDelimiterOptionMixin.class})
 public class ResourcesIntoJdbcJobModuleOptionsMetadata extends
 		AbstractImportToJdbcOptionsMetadata {
 

--- a/modules/job/filejdbc/config/filejdbc.xml
+++ b/modules/job/filejdbc/config/filejdbc.xml
@@ -36,6 +36,7 @@
 				<property name="lineTokenizer">
 					<bean class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
 						<property name="names" value="${names}"/>
+						<property name="delimiter" value="${delimiter}"/>
 					</bean>
 				</property>
 				<property name="fieldSetMapper">

--- a/modules/job/hdfsjdbc/config/hdfsjdbc.xml
+++ b/modules/job/hdfsjdbc/config/hdfsjdbc.xml
@@ -30,6 +30,7 @@
 				<property name="lineTokenizer">
 					<bean class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
 						<property name="names" value="${names}"/>
+						<property name="delimiter" value="${delimiter}"/>
 					</bean>
 				</property>
 				<property name="fieldSetMapper">

--- a/modules/job/hdfsmongodb/config/hdfsmongodb.xml
+++ b/modules/job/hdfsmongodb/config/hdfsmongodb.xml
@@ -32,6 +32,7 @@
 				<property name="lineTokenizer">
 					<bean class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
 						<property name="names" value="${names}" />
+						<property name="delimiter" value="${delimiter}"/>
 					</bean>
 				</property>
 				<property name="fieldSetMapper">

--- a/modules/job/jdbchdfs/config/jdbchdfs.xml
+++ b/modules/job/jdbchdfs/config/jdbchdfs.xml
@@ -41,6 +41,7 @@
 				<property name="fieldExtractor">
 					<bean class="org.springframework.xd.tuple.batch.TupleFieldExtractor"/>
 				</property>
+				<property name="delimiter" value="${delimiter}"/>
 			</bean>
 		</property>
 		<property name="baseFilename" value="${fileName}"/>

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HdfsMongodbJobOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HdfsMongodbJobOptionsMetadata.java
@@ -21,6 +21,7 @@ import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_JO
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.Range;
 
+import org.springframework.xd.module.options.mixins.BatchJobFieldDelimiterOptionMixin;
 import org.springframework.xd.module.options.mixins.BatchJobFieldNamesOptionMixin;
 import org.springframework.xd.module.options.mixins.BatchJobResourcesOptionMixin;
 import org.springframework.xd.module.options.mixins.BatchJobRestartableOptionMixin;
@@ -33,7 +34,8 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * 
  * @author Ilayaperumal Gopinathan
  */
-@Mixin({ BatchJobRestartableOptionMixin.class, BatchJobResourcesOptionMixin.class, BatchJobFieldNamesOptionMixin.class })
+@Mixin({ BatchJobRestartableOptionMixin.class, BatchJobResourcesOptionMixin.class, BatchJobFieldNamesOptionMixin.class,
+		 BatchJobFieldDelimiterOptionMixin.class})
 public class HdfsMongodbJobOptionsMetadata {
 
 	private String databaseName = "xd";

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobFieldDelimiterOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobFieldDelimiterOptionMixin.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.module.options.mixins;
+
+import org.springframework.xd.module.options.spi.ModuleOption;
+
+import javax.validation.constraints.NotNull;
+
+
+/**
+ * Batch job option for the delimiter in the file (csv file etc.,).
+ * 
+ * @author Michael Minella
+ */
+public class BatchJobFieldDelimiterOptionMixin {
+
+	private String delimiter = ",";
+
+	@ModuleOption(value = "the delimiter for the delimited file", defaultValue = ",")
+	public void setDelimiter(String delimiter) {
+		this.delimiter = unescape(delimiter);
+	}
+
+	@NotNull
+	public String getDelimiter() {
+		return delimiter;
+	}
+
+	private String unescape(String st) {
+
+		StringBuilder sb = new StringBuilder(st.length());
+
+		for (int i = 0; i < st.length(); i++) {
+			char ch = st.charAt(i);
+			if (ch == '\\') {
+				char nextChar = (i == st.length() - 1) ? '\\' : st.charAt(i + 1);
+				// Octal escape?
+				if (nextChar >= '0' && nextChar <= '7') {
+					String code = "" + nextChar;
+					i++;
+					if ((i < st.length() - 1) && st.charAt(i + 1) >= '0'
+								&& st.charAt(i + 1) <= '7') {
+						code += st.charAt(i + 1);
+						i++;
+						if ((i < st.length() - 1) && st.charAt(i + 1) >= '0'
+									&& st.charAt(i + 1) <= '7') {
+							code += st.charAt(i + 1);
+							i++;
+						}
+					}
+					sb.append((char) Integer.parseInt(code, 8));
+					continue;
+				}
+				switch (nextChar) {
+					case '\\':
+						ch = '\\';
+						break;
+					case 'b':
+						ch = '\b';
+						break;
+					case 'f':
+						ch = '\f';
+						break;
+					case 'n':
+						ch = '\n';
+						break;
+					case 'r':
+						ch = '\r';
+						break;
+					case 't':
+						ch = '\t';
+						break;
+					case '\"':
+						ch = '\"';
+						break;
+					case '\'':
+						ch = '\'';
+						break;
+					case 'u':
+						if (i >= st.length() - 5) {
+							ch = 'u';
+							break;
+						}
+						int code = Integer.parseInt("" + st.charAt(i + 2) + st.charAt(i + 3)
+													   + st.charAt(i + 4) + st.charAt(i + 5), 16);
+						sb.append(Character.toChars(code));
+						i += 5;
+						continue;
+				}
+				i++;
+			}
+			sb.append(ch);
+		}
+		return sb.toString();	}
+}

--- a/src/test/scripts/jdbc_tests
+++ b/src/test/scripts/jdbc_tests
@@ -94,4 +94,42 @@ rows=`sqlite3 $DB_FILE 'select count(*) from JOB_DATA_TABLE'`
 echo "Checking row count in database table matches import from file..."
 assert_equals 584 $rows
 
+
+echo -e "\n\n Test 5. Load single tab delimited file using filejdbc job with defaults, deleting file after import\n"
+cp $PWD/csv/data.csv $TEST_DIR/delete_after_use.csv
+sed 's/\,/	/g' $TEST_DIR/delete_after_use.csv > $TEST_DIR/delete_after_use_tabs.csv
+
+create_job csvjdbcjob0 "filejdbc $JDBC_PARAMS --names=col1,col2,col3 --resources=file://$TEST_DIR/delete_after_use_tabs.csv --initializeDatabase=true --deleteFiles=true --delimiter=\\t" 'true'
+launch_job csvjdbcjob0
+sleep 5
+rows=`sqlite3 $DB_FILE 'select count(*) from csvjdbcjob0'`
+destroy_job csvjdbcjob0
+echo "Checking row count in database table matches import from file..."
+assert_equals 292 $rows
+sleep 5
+
+if [[ -f $TEST_DIR/delete_after_use_tabs.csv ]]
+then
+  echo "Tabbed data file was not deleted"
+  exit 1
+fi
+
+rm -R $TEST_DIR/delete_after_use.csv &> /dev/null
+
 echo -e '\nAll good :-)'
+
+
+commas_to_tabs() {
+	case "$OSTYPE" in
+	  darwin*)  echo "OSX" ;;
+	  linux*)   echo "LINUX" ;;
+	  bsd*)     echo "BSD" ;;
+	esac
+
+	if [ os == "OSX"]
+	then
+		sed 's/\,/	/g' $1 > $2
+	else
+		sed 's/\,/\t/g' $1 > $2
+	fi
+}


### PR DESCRIPTION
Updated pre-packaged jobs to allow a delimiter to be injected where appropriate.
- Updated configuration of `filejdbc`, `hdfsjdbc`, `hdfsmongodb`, and `jdbchdfs`
  jobs to allow for the delimiter to be injected
- Added `BatchJobFiledDelimiterOptionMixin` to provide metadata around
  new delimiter option
- Updated `jdbc_tests` script to test the processing of a job using a tab
  as a delimiter.

Notes:
1. `unescape` does not belong in `BatchJobFieldDelimiterOptionMixin`, but I don't have a better place to put it right now (not familiar enough with the XD structure to know where to put a utility class like that…and it really belongs in Spring Core IMHO).
2. I know sed works differently from OS X to Linux.  I haven't tested the Linux version of the commas_to_tabs function.  I'm running on the assumption that Linux supports the `\t` notation for a tab character (which OS X does not).
