### PR TITLE
XD-1533: Clean up failed deploy attempts

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerListener.java
@@ -282,7 +282,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 									.setContainer(containerName).build();
 
 							// todo: make timeout configurable
-							long timeout = System.currentTimeMillis() + 30000;
+							long timeout = System.currentTimeMillis() + 10000;
 							boolean deployed;
 							do {
 								Thread.sleep(10);


### PR DESCRIPTION
If a container fails to deploy a module, the admin needs to clean up the `/xd/deployments/modules/CONTAINER-ID/module` path so that another attempt can be made to deploy that module to that container.
