### PR TITLE
Runtime modules cmd - minor fixes

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ZooKeeperModuleMetadataRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ZooKeeperModuleMetadataRepository.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
 import org.springframework.xd.dirt.util.MapBytesUtility;
 import org.springframework.xd.dirt.zookeeper.Paths;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
@@ -87,7 +88,8 @@ public class ZooKeeperModuleMetadataRepository implements ModuleMetadataReposito
 				String moduleId = getModuleId(metadataPath);
 				String containerId = getContainerId(metadataPath);
 				for (String propertyKey : map.keySet()) {
-					if (!propertyKey.startsWith(XD_MODULE_PROPERTIES_PREFIX)) {
+					if (!propertyKey.startsWith(XD_MODULE_PROPERTIES_PREFIX)
+							&& !StringUtils.isEmpty(map.get(propertyKey))) {
 						metadataMap.put(propertyKey, map.get(propertyKey));
 					}
 				}

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RuntimeCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RuntimeCommands.java
@@ -99,7 +99,7 @@ public class RuntimeCommands implements CommandMarker {
 		}
 		final Table table = new Table();
 		table.addHeader(1, new TableHeader("Module")).addHeader(2, new TableHeader("Container Id")).addHeader(
-				3, new TableHeader("Properties"));
+				3, new TableHeader("Options"));
 		for (ModuleMetadataResource module : runtimeModules) {
 			final TableRow row = table.newRow();
 			row.addValue(1, module.getModuleId()).addValue(2, module.getContainerId()).addValue(3,


### PR DESCRIPTION
- Rename "Properties" column to "Options"
- Filter out options with empty values
