### PR TITLE
XD-1550 Propagate BeanFactory to Hand-Built Beans

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/LocalMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/LocalMessageBus.java
@@ -46,7 +46,7 @@ import org.springframework.util.Assert;
  * {@link DirectChannel} or a {@link QueueChannel} depending on whether the binding is aliased or not then bridges the
  * passed {@link MessageChannel} to the channel which is registered in the given application context. If that channel
  * does not yet exist, it will be created.
- * 
+ *
  * @author David Turanski
  * @author Mark Fisher
  * @author Gary Russell
@@ -86,6 +86,7 @@ public class LocalMessageBus extends MessageBusSupport implements ApplicationCon
 		@Override
 		protected QueueChannel createSharedChannel(String name) {
 			QueueChannel queueChannel = new QueueChannel(queueSize);
+			queueChannel.setBeanFactory(applicationContext);
 			return queueChannel;
 		}
 	};
@@ -95,7 +96,9 @@ public class LocalMessageBus extends MessageBusSupport implements ApplicationCon
 
 		@Override
 		protected PublishSubscribeChannel createSharedChannel(String name) {
-			return new PublishSubscribeChannel();
+			PublishSubscribeChannel publishSubscribeChannel = new PublishSubscribeChannel();
+			publishSubscribeChannel.setBeanFactory(applicationContext);
+			return publishSubscribeChannel;
 		}
 	};
 
@@ -226,6 +229,7 @@ public class LocalMessageBus extends MessageBusSupport implements ApplicationCon
 		ExecutorChannel channel = this.requestReplyChannels.get(name);
 		if (channel == null) {
 			channel = new ExecutorChannel(this.executor);
+			channel.setBeanFactory(applicationContext);
 			this.requestReplyChannels.put(name, channel);
 		}
 		return channel;
@@ -274,6 +278,7 @@ public class LocalMessageBus extends MessageBusSupport implements ApplicationCon
 
 		};
 
+		handler.setBeanFactory(applicationContext.getBeanFactory());
 		handler.setOutputChannel(to);
 		handler.setBeanName(bridgeName);
 		handler.afterPropertiesSet();
@@ -313,7 +318,7 @@ public class LocalMessageBus extends MessageBusSupport implements ApplicationCon
 
 	/**
 	 * Looks up or optionally creates a new channel to use.
-	 * 
+	 *
 	 * @author Eric Bottard
 	 */
 	private abstract class SharedChannelProvider<T extends AbstractMessageChannel> {

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/MessageBusSupport.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/MessageBusSupport.java
@@ -29,6 +29,9 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.http.MediaType;
 import org.springframework.integration.support.MessageBuilder;
@@ -48,7 +51,7 @@ import org.springframework.util.MimeType;
  * @author David Turanski
  * @author Gary Russell
  */
-public abstract class MessageBusSupport implements MessageBus {
+public abstract class MessageBusSupport implements MessageBus, BeanFactoryAware {
 
 	protected final Log logger = LogFactory.getLog(getClass());
 
@@ -63,6 +66,17 @@ public abstract class MessageBusSupport implements MessageBus {
 	private final List<Binding> bindings = Collections.synchronizedList(new ArrayList<Binding>());
 
 	private final IdGenerator idGenerator = new AlternativeJdkIdGenerator();
+
+	private volatile BeanFactory beanFactory;
+
+	@Override
+	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+		this.beanFactory = beanFactory;
+	}
+
+	protected BeanFactory getBeanFactory() {
+		return beanFactory;
+	}
 
 	public void setCodec(MultiTypeCodec<Object> codec) {
 		this.codec = codec;

--- a/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests.java
@@ -57,8 +57,8 @@ import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.x.bus.BusTestUtils;
 import org.springframework.integration.x.bus.LocalMessageBus;
-import org.springframework.integration.x.bus.MessageBus;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
 import org.springframework.test.context.ContextConfiguration;
@@ -68,7 +68,7 @@ import org.springframework.util.FileCopyUtils;
 
 
 /**
- * 
+ *
  * @author Gary Russell
  */
 @ContextConfiguration
@@ -102,9 +102,9 @@ public class RemoteFileToTmpTests {
 	@Qualifier("stepExecutionReplies.input")
 	private MessageChannel repliesIn;
 
-	private MessageBus bus;
+	private LocalMessageBus bus;
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Before
 	public void setup() throws Exception {
 		byte[] bytes = "foo".getBytes();
@@ -123,6 +123,7 @@ public class RemoteFileToTmpTests {
 		when(session.list("/foo/")).thenReturn(fileList);
 
 		this.bus = new LocalMessageBus();
+		this.bus.setApplicationContext(BusTestUtils.MOCK_AC);
 		this.bus.bindRequestor("foo", this.requestsOut, this.repliesIn);
 		this.bus.bindReplier("foo", this.requestsIn, this.repliesOut);
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/AbstractTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/AbstractTestMessageBus.java
@@ -24,8 +24,9 @@ import org.springframework.messaging.MessageChannel;
 
 /**
  * Abstract class that adds test support for {@link MessageBus}.
- * 
+ *
  * @author Ilayaperumal Gopinathan
+ * @author Gary Russell
  */
 public abstract class AbstractTestMessageBus implements MessageBus {
 
@@ -33,9 +34,10 @@ public abstract class AbstractTestMessageBus implements MessageBus {
 
 	protected Set<String> topics = new HashSet<String>();
 
-	private final MessageBus messageBus;
+	private final MessageBusSupport messageBus;
 
-	public AbstractTestMessageBus(MessageBus messageBus) {
+	public AbstractTestMessageBus(MessageBusSupport messageBus) {
+		messageBus.setBeanFactory(BusTestUtils.MOCK_BF);
 		this.messageBus = messageBus;
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/BusTestUtils.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/BusTestUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.x.bus;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.support.DefaultMessageBuilderFactory;
+import org.springframework.integration.support.MessageBuilderFactory;
+
+
+/**
+ *
+ * @author Gary Russell
+ */
+public class BusTestUtils {
+
+	private static final MessageBuilderFactory mbf = new DefaultMessageBuilderFactory();
+
+	public static final AbstractApplicationContext MOCK_AC = mock(AbstractApplicationContext.class);
+
+	public static final ConfigurableListableBeanFactory MOCK_BF = mock(ConfigurableListableBeanFactory.class);
+
+	static {
+		when(MOCK_BF.getBean(IntegrationContextUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
+				MessageBuilderFactory.class)).thenReturn(mbf);
+		when(MOCK_AC.getBean(IntegrationContextUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
+				MessageBuilderFactory.class)).thenReturn(mbf);
+		when(MOCK_AC.getBeanFactory()).thenReturn(MOCK_BF);
+	}
+
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/LocalMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/LocalMessageBusTests.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
@@ -44,6 +46,9 @@ public class LocalMessageBusTests extends AbstractMessageBusTests {
 	protected MessageBus getMessageBus() throws Exception {
 		LocalMessageBus bus = new LocalMessageBus();
 		GenericApplicationContext applicationContext = new GenericApplicationContext();
+		applicationContext.getBeanFactory().registerSingleton(
+				IntegrationContextUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
+				new DefaultMessageBuilderFactory());
 		applicationContext.refresh();
 		bus.setApplicationContext(applicationContext);
 		bus.afterPropertiesSet();

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/MessageBusAwareChannelResolverTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/bus/MessageBusAwareChannelResolverTests.java
@@ -32,7 +32,9 @@ import org.junit.Test;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.scheduling.PollerMetadata;
+import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -63,6 +65,8 @@ public class MessageBusAwareChannelResolverTests {
 				this.resolver);
 		context.registerSingleton("other", DirectChannel.class);
 		context.registerSingleton("taskScheduler", ThreadPoolTaskScheduler.class);
+		context.registerSingleton(IntegrationContextUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
+				DefaultMessageBuilderFactory.class);
 		context.refresh();
 
 		PollerMetadata poller = new PollerMetadata();
@@ -103,7 +107,7 @@ public class MessageBusAwareChannelResolverTests {
 	public void resolveTopicChannel() {
 		MessageChannel registered = resolver.resolveDestination("topic:bar");
 		PublishSubscribeChannel[] testChannels = {
-			new PublishSubscribeChannel(), new PublishSubscribeChannel(), new PublishSubscribeChannel()
+				new PublishSubscribeChannel(), new PublishSubscribeChannel(), new PublishSubscribeChannel()
 		};
 		final CountDownLatch latch = new CountDownLatch(testChannels.length);
 		final List<Message<?>> received = new ArrayList<Message<?>>();

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/redis/RedisPublishingMessageHandlerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/redis/RedisPublishingMessageHandlerTests.java
@@ -36,12 +36,13 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.integration.redis.outbound.RedisPublishingMessageHandler;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.x.bus.BusTestUtils;
 import org.springframework.xd.test.redis.RedisTestSupport;
 
 /**
  * Temporary copy of SI RedisPublishingMessageHandlerTests that adds tests that publish messages with data types other
  * than String
- * 
+ *
  * @author Mark Fisher
  * @author Jennifer Hickey
  * @author Gary Russell
@@ -70,6 +71,7 @@ public class RedisPublishingMessageHandlerTests {
 	public void testWithDefaultSerializer() throws Exception {
 		setupListener(new StringRedisSerializer());
 		final RedisPublishingMessageHandler handler = new RedisPublishingMessageHandler(connectionFactory);
+		handler.setBeanFactory(BusTestUtils.MOCK_BF);
 		handler.setTopic(TOPIC);
 		handler.afterPropertiesSet();
 		for (int i = 0; i < NUM_MESSAGES; i++) {
@@ -84,6 +86,7 @@ public class RedisPublishingMessageHandlerTests {
 	public void testWithNoSerializer() throws Exception {
 		setupListener(null);
 		final RedisPublishingMessageHandler handler = new RedisPublishingMessageHandler(connectionFactory);
+		handler.setBeanFactory(BusTestUtils.MOCK_BF);
 		handler.setTopic(TOPIC);
 		handler.afterPropertiesSet();
 		for (int i = 0; i < NUM_MESSAGES; i++) {
@@ -99,6 +102,7 @@ public class RedisPublishingMessageHandlerTests {
 		GenericToStringSerializer<Long> serializer = new GenericToStringSerializer<Long>(Long.class);
 		setupListener(serializer);
 		final RedisPublishingMessageHandler handler = new RedisPublishingMessageHandler(connectionFactory);
+		handler.setBeanFactory(BusTestUtils.MOCK_BF);
 		handler.setTopic(TOPIC);
 		handler.setSerializer(serializer);
 		handler.afterPropertiesSet();

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/redis/RedisQueueInboundChannelAdapterTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/redis/RedisQueueInboundChannelAdapterTests.java
@@ -39,6 +39,7 @@ import org.springframework.data.redis.serializer.SerializationException;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.redis.inbound.RedisQueueMessageDrivenEndpoint;
+import org.springframework.integration.x.bus.BusTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
@@ -47,7 +48,7 @@ import org.springframework.xd.test.redis.RedisTestSupport;
 
 /**
  * Integration test of {@link RedisQueueInboundChannelAdapter}
- * 
+ *
  * @author Jennifer Hickey
  */
 public class RedisQueueInboundChannelAdapterTests {
@@ -68,8 +69,10 @@ public class RedisQueueInboundChannelAdapterTests {
 		messages.clear();
 		this.connectionFactory = redisAvailableRule.getResource();
 		DirectChannel outputChannel = new DirectChannel();
+		outputChannel.setBeanFactory(BusTestUtils.MOCK_BF);
 		outputChannel.subscribe(new TestMessageHandler());
 		adapter = new RedisQueueMessageDrivenEndpoint(QUEUE_NAME, connectionFactory);
+		adapter.setBeanFactory(BusTestUtils.MOCK_BF);
 		adapter.setOutputChannel(outputChannel);
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/integration/x/redis/RedisQueueOutboundChannelAdapterTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/integration/x/redis/RedisQueueOutboundChannelAdapterTests.java
@@ -35,13 +35,14 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.SerializationException;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.integration.redis.outbound.RedisQueueOutboundChannelAdapter;
+import org.springframework.integration.x.bus.BusTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.xd.test.redis.RedisTestSupport;
 
 /**
  * Integration test of {@link RedisQueueOutboundChannelAdapter}
- * 
+ *
  * @author Jennifer Hickey
  * @author Gary Russell
  */
@@ -60,6 +61,7 @@ public class RedisQueueOutboundChannelAdapterTests {
 	public void setUp() {
 		this.connectionFactory = redisAvailableRule.getResource();
 		adapter = new RedisQueueOutboundChannelAdapter(QUEUE_NAME, connectionFactory);
+		adapter.setBeanFactory(BusTestUtils.MOCK_BF);
 	}
 
 	@After

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/ModuleDeploymentTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/ModuleDeploymentTests.java
@@ -24,6 +24,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.redis.outbound.RedisQueueOutboundChannelAdapter;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.x.bus.BusTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.xd.dirt.module.ModuleDeploymentRequest;
 import org.springframework.xd.module.ModuleType;
@@ -47,6 +48,7 @@ public class ModuleDeploymentTests {
 		LettuceConnectionFactory connectionFactory = redisAvailableRule.getResource();
 		RedisQueueOutboundChannelAdapter adapter = new RedisQueueOutboundChannelAdapter(deployerQueue,
 				connectionFactory);
+		adapter.setBeanFactory(BusTestUtils.MOCK_BF);
 		adapter.setExtractPayload(false);
 		adapter.afterPropertiesSet();
 		ModuleDeploymentRequest request = new ModuleDeploymentRequest();
@@ -63,6 +65,7 @@ public class ModuleDeploymentTests {
 		LettuceConnectionFactory connectionFactory = redisAvailableRule.getResource();
 		RedisQueueOutboundChannelAdapter adapter = new RedisQueueOutboundChannelAdapter(deployerQueue,
 				connectionFactory);
+		adapter.setBeanFactory(BusTestUtils.MOCK_BF);
 		adapter.setExtractPayload(false);
 		adapter.afterPropertiesSet();
 		ModuleDeploymentRequest sinkRequest = new ModuleDeploymentRequest();

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/Dependencies.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/Dependencies.java
@@ -34,6 +34,7 @@ import org.springframework.batch.core.repository.dao.JdbcExecutionContextDao;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.x.bus.LocalMessageBus;
 import org.springframework.integration.x.bus.MessageBus;
@@ -71,11 +72,12 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
 /**
  * Provide a mockito mock for any of the business layer dependencies. Adding yet another configuration class on top, one
  * can selectively override those mocks (with <i>e.g.</i> in memory implementations).
- * 
+ *
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
  */
 @Configuration
+@EnableIntegration
 public class Dependencies {
 
 	@Bean
@@ -147,7 +149,8 @@ public class Dependencies {
 
 	@Bean
 	public JobDeployer jobDeployer() {
-		return new JobDeployer(zooKeeperConnection(), jobDefinitionRepository(), xdJobRepository(), parser(), messageBus());
+		return new JobDeployer(zooKeeperConnection(), jobDefinitionRepository(), xdJobRepository(), parser(),
+				messageBus());
 	}
 
 	@Bean

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/CompositeModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/CompositeModule.java
@@ -115,6 +115,7 @@ public class CompositeModule extends AbstractModule {
 			}
 			if (previousOutputChannel != null) {
 				BridgeHandler handler = new BridgeHandler();
+				handler.setBeanFactory(this.context.getBeanFactory());
 				handler.setOutputChannel(inputChannel);
 				handler.afterPropertiesSet();
 				ConsumerEndpointFactoryBean bridgeFactoryBean = new ConsumerEndpointFactoryBean();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-1550

SI Components need access to a BF to get the message builder
factory.

Use mocks where needed for test cases.

Ran with SI 4.0.0.BUILD-SNAPSHOT with environment variable:

```
SI_FATAL_WHEN_NO_BEANFACTORY=true
```

which forces a hard failure instead of just a log message.
