### PR TITLE
XD-1581 Fix config location in scripts

### DIFF
--- a/scripts/xd/xd-admin
+++ b/scripts/xd/xd-admin
@@ -198,7 +198,7 @@ fi
 
 # set app name etc. via SPRING_XD_OPTS
 SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-admin-logger.properties -Dxd.home=$XD_HOME"
-SPRING_XD_OPTS="$SPRING_XD_OPTS -Dspring.config.location=file:$XD_CONFIG_LOCATION -Dspring.config.name=$XD_CONFIG_NAME"
+SPRING_XD_OPTS="$SPRING_XD_OPTS -Dspring.config.location=file:$XD_CONFIG_LOCATION -Dxd.config.home=file:$XD_CONFIG_LOCATION -Dspring.config.name=$XD_CONFIG_NAME"
 SPRING_XD_OPTS="$SPRING_XD_OPTS -Dxd.module.config.location=file:$XD_MODULE_CONFIG_LOCATION -Dxd.module.config.name=$XD_MODULE_CONFIG_NAME"
 
 # Split up the JVM_OPTS And SPRING_XD_OPTS values into an array, following the shell quoting and substitution rules

--- a/scripts/xd/xd-admin.bat
+++ b/scripts/xd/xd-admin.bat
@@ -117,7 +117,7 @@ if not defined XD_MODULE_CONFIG_NAME (
 set XD_MODULE_CONFIG_LOCATION=%XD_MODULE_CONFIG_LOCATION%/
 
 set SPRING_XD_OPTS=-Dspring.application.name=admin -Dlogging.config=file:%XD_HOME%/config/xd-admin-logger.properties -Dxd.home=%XD_HOME%
-set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dspring.config.location=file:%XD_CONFIG_LOCATION% -Dspring.config.name=%XD_CONFIG_NAME%
+set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dspring.config.location=file:%XD_CONFIG_LOCATION% -Dxd.config.home=file:%XD_CONFIG_LOCATION% -Dspring.config.name=%XD_CONFIG_NAME%
 set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dxd.module.config.location=file:%XD_MODULE_CONFIG_LOCATION% -Dxd.module.config.name=%XD_MODULE_CONFIG_NAME%
 
 @rem make sure to remove double quotes if any

--- a/scripts/xd/xd-container
+++ b/scripts/xd/xd-container
@@ -198,7 +198,7 @@ fi
 
 # set app name etc. via SPRING_XD_OPTS
 SPRING_XD_OPTS="-Dspring.application.name=container -Dlogging.config=file:$XD_HOME/config/xd-container-logger.properties -Dxd.home=$XD_HOME"
-SPRING_XD_OPTS="$SPRING_XD_OPTS -Dspring.config.location=file:$XD_CONFIG_LOCATION -Dspring.config.name=$XD_CONFIG_NAME"
+SPRING_XD_OPTS="$SPRING_XD_OPTS -Dspring.config.location=file:$XD_CONFIG_LOCATION -Dxd.config.home=file:$XD_CONFIG_LOCATION -Dspring.config.name=$XD_CONFIG_NAME"
 SPRING_XD_OPTS="$SPRING_XD_OPTS -Dxd.module.config.location=file:$XD_MODULE_CONFIG_LOCATION -Dxd.module.config.name=$XD_MODULE_CONFIG_NAME"
 
 # Split up the JVM_OPTS And SPRING_XD_OPTS values into an array, following the shell quoting and substitution rules

--- a/scripts/xd/xd-container.bat
+++ b/scripts/xd/xd-container.bat
@@ -117,7 +117,7 @@ if not defined XD_MODULE_CONFIG_NAME (
 set XD_MODULE_CONFIG_LOCATION=%XD_MODULE_CONFIG_LOCATION%/
 
 set SPRING_XD_OPTS=-Dspring.application.name=container -Dlogging.config=file:%XD_HOME%/config/xd-container-logger.properties -Dxd.home=%XD_HOME%
-set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dspring.config.location=file:%XD_CONFIG_LOCATION% -Dspring.config.name=%XD_CONFIG_NAME%
+set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dspring.config.location=file:%XD_CONFIG_LOCATION% -Dxd.config.home=file:%XD_CONFIG_LOCATION% -Dspring.config.name=%XD_CONFIG_NAME%
 set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dxd.module.config.location=file:%XD_MODULE_CONFIG_LOCATION% -Dxd.module.config.name=%XD_MODULE_CONFIG_NAME%
 
 @rem make sure to remove double quotes if any

--- a/scripts/xd/xd-singlenode
+++ b/scripts/xd/xd-singlenode
@@ -199,7 +199,7 @@ fi
 
 # set app name etc. via SPRING_XD_OPTS
 SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-singlenode-logger.properties -Dxd.home=$XD_HOME"
-SPRING_XD_OPTS="$SPRING_XD_OPTS -Dspring.config.location=file:$XD_CONFIG_LOCATION -Dspring.config.name=$XD_CONFIG_NAME"
+SPRING_XD_OPTS="$SPRING_XD_OPTS -Dspring.config.location=file:$XD_CONFIG_LOCATION -Dxd.config.home=file:$XD_CONFIG_LOCATION -Dspring.config.name=$XD_CONFIG_NAME"
 SPRING_XD_OPTS="$SPRING_XD_OPTS -Dxd.module.config.location=file:$XD_MODULE_CONFIG_LOCATION -Dxd.module.config.name=$XD_MODULE_CONFIG_NAME"
 
 # Split up the JVM_OPTS And SPRING_XD_OPTS values into an array, following the shell quoting and substitution rules

--- a/scripts/xd/xd-singlenode.bat
+++ b/scripts/xd/xd-singlenode.bat
@@ -118,7 +118,7 @@ if not defined XD_MODULE_CONFIG_NAME (
 set XD_MODULE_CONFIG_LOCATION=%XD_MODULE_CONFIG_LOCATION%/
 
 set SPRING_XD_OPTS=-Dspring.application.name=singlenode -Dlogging.config=file:%XD_HOME%/config/xd-singlenode-logger.properties -Dxd.home=%XD_HOME%
-set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dspring.config.location=file:%XD_CONFIG_LOCATION% -Dspring.config.name=%XD_CONFIG_NAME%
+set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dspring.config.location=file:%XD_CONFIG_LOCATION% -Dxd.config.home=file:%XD_CONFIG_LOCATION% -Dspring.config.name=%XD_CONFIG_NAME%
 set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dxd.module.config.location=file:%XD_MODULE_CONFIG_LOCATION% -Dxd.module.config.name=%XD_MODULE_CONFIG_NAME%
 
 @rem make sure to remove double quotes if any


### PR DESCRIPTION
- Set config locations prefix file: for non-batch files
- Always append "/" to XD_CONFIG_LOCATION so that when it gets appended for XD_MODULE_CONFIG_LOCATION it is valid
  - Also, having "//" (if the existing property already has "/" this change would still add one)
    on both *nix and windows seem to work fine.
