### PR TITLE
XD-1501 Empty defaultData for znode paths

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnection.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnection.java
@@ -163,7 +163,7 @@ public class ZooKeeperConnection implements SmartLifecycle {
 
 	/**
 	 * Set the Curator retry policy.
-	 *
+	 * 
 	 * @param retryPolicy Curator client {@link RetryPolicy}
 	 */
 	public void setRetryPolicy(RetryPolicy retryPolicy) {
@@ -173,7 +173,7 @@ public class ZooKeeperConnection implements SmartLifecycle {
 
 	/**
 	 * Return the Curator retry policy.
-	 *
+	 * 
 	 * @return the Curator retry policy
 	 */
 	public RetryPolicy getRetryPolicy() {
@@ -204,6 +204,8 @@ public class ZooKeeperConnection implements SmartLifecycle {
 	public synchronized void start() {
 		if (!this.running) {
 			this.curatorFramework = CuratorFrameworkFactory.builder()
+					// Set the defaultData to be empty byte array so that there is no default data when creating path
+					.defaultData(new byte[0])
 					// todo: make namespace pluggable so this class can be generic
 					.namespace(Paths.XD_NAMESPACE)
 					.retryPolicy(this.retryPolicy)


### PR DESCRIPTION
- By default CuratorFrameworkFactory.Builder sets the defaultData to local host address.
  This causes the local host address being updated inside the znode path.
  - Set Builder's defaultData to empty byte array so that it is empty by default
    when  PathAndBytesable.forPath(String) is used
