### PR TITLE
XD-1456 Using Spring Boot as base for Acc tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1478,6 +1478,8 @@ project('spring-xd-test-fixtures') {
 		compile "commons-collections:commons-collections:$commonsCollectionsVersion"
 		compile "com.icegreen:greenmail:1.3.1b"
 		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+		compile "org.springframework:spring-jms:$springVersion"
+		compile "org.apache.activemq:activemq-core:5.6.0"
 		compile "org.springframework:spring-web:$springVersion"
 		runtime "log4j:log4j:$log4jVersion",
 				"org.slf4j:jcl-over-slf4j:$slf4jVersion",
@@ -1492,23 +1494,6 @@ project('spring-xd-integration-test') {
 	description = 'Spring Integration tests'
 
 	test {
-		systemProperties = [
-			xd_admin_host: System.getProperty('xd_admin_host', 'http://localhost:9393'),
-			xd_containers: System.getProperty('xd_containers', 'http://localhost:9393'),
-			xd_http_port: System.getProperty('xd_http_port', '9000'),
-			xd_jmx_port: System.getProperty('xd_jmx_port', '15005'),
-			xd_container_log_dir: System.getProperty('xd_container_log_dir', "/home/ubuntu/spring-xd-$version/xd/logs/container.log"),
-			xd_base_dir: System.getProperty('xd_base_dir', "/home/ubuntu/spring-xd-$version/xd/"),
-			xd_run_on_ec2: System.getProperty('xd_run_on_ec2', 'false'),
-			xd_pause_time: System.getProperty('xd_pause_time', '1'),
-			xd_private_key_file: System.getProperty('xd_private_key_file', ''),
-			jdbc_username: System.getProperty('jdbc_username', 'sa'),
-			jdbc_database: System.getProperty('jdbc_database', 'xdjob'),
-			jdbc_password: System.getProperty('jdbc_password', ''),
-			jdbc_driver: System.getProperty('jdbc_driver', 'org.hsqldb.jdbc.JDBCDriver'),
-			jdbc_url: System.getProperty('jdbc_url', 'jdbc:hsqldb:hsql://localhost:9101/%s')
-			]
-
 		onlyIf {
 			System.getProperty('run_integration_tests', 'false')=='true'
 		}
@@ -1522,8 +1507,10 @@ project('spring-xd-integration-test') {
 		compile "org.apache.jclouds.provider:aws-sts:$jcloudsVersion"
 		compile "org.apache.jclouds.driver:jclouds-sshj:$jcloudsVersion"
 		compile "org.springframework.shell:spring-shell:$springShellVersion"
-
+		compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
 		compile "org.springframework:spring-web:$springVersion"
+		compile "org.springframework:spring-jms:$springVersion"
+		compile "org.apache.activemq:activemq-core:5.6.0" 
 		testCompile group: 'junit', name: 'junit', version: '4.+'
 		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 		runtime "log4j:log4j:$log4jVersion",

--- a/spring-xd-integration-test/README.md
+++ b/spring-xd-integration-test/README.md
@@ -11,7 +11,7 @@ Make sure that the following environment variables are set either the servers.ym
 	export endpoints_jolokia_enabled=true
 	export XD_JMX_ENABLED=true
 	export management_port=15001
-	export server.port=9393
+	export server_port=9393
 	export PORT=9001
 
 	#For the XD Container
@@ -147,43 +147,107 @@ Make sure that the following environment variables are set either the servers.ym
 
 ##  Running The Test
 
-### Running on Local Host
-#### Running build from Command Line
-##### Gradle Single admin and single container on same machine
-* By default the tests are not active.
-* To run the tests execute the following:
+### Profiles
+
+The acceptance tests utilizes Spring profiles to to configure the run.  This way if you want to run against a local instances of XD and then run the same test against an XD instance on EC2 all you need to do is change your active profile.
+Out of the box the acceptance tests will be configured using the provided application-singlenode.properties.  To create and use a new profile:
+
+1. Create a new properties file with the following format for the name application-*__profile name__*.properties.  For example application-__mycluster__.properties
+2. Copy the contents of the application-singlenode.properties to you new properties file.
+3. Change the settings to your needs.
+4. Save the changes.
+5. In your environment set the new spring\_profiles\_active
+  1. On Mac and Unix:  export spring\_profiles\_active=mycluster
+6. Now your profile  __mycluster__ is active and when you startup up acceptance tests it will use the application-mycluster.properties to setup you acceptance tests.
+
+### Running on Local Host SingleNode
+
+There are 2 steps to running a your acceptance tests.  
+1) Set your XD_HOME
+* While in your spring-xd project, use your favorite editor to open spring-xd-integration-test/src/test/resources/application-singlenode.properties
+* set the XD_HOME property to the location where you XD is deployed. For Example:
 
 ```
-./gradlew -Drun_integration_tests=true -Dxd_container_log_dir=<your dir>/container.log :spring-xd-integration-test:build
+#Location
+XD_HOME=/Users/renfrg/projects/spring-xd/build/dist/spring-xd
 ```
-##### Gradle SingleNode
-* By default the tests are not active.  To run the tests execute the following:
+2) Run All Acceptance tests
 
 ```
-./gradlew -Drun_integration_tests=true -Dxd_container_log_dir=<your dir>/singlenode.log :spring-xd-integration-test:build
+./gradlew -Drun_integration_tests=true :spring-xd-integration-test:build
+```
+
+**What if I want to run just a single test?**  
+In this case you can add the -Dtest.single=  along with the test you want ot run.  For Example:
+```
+./gradlew -Drun_integration_tests=true -Dtest.single=HttpTest :spring-xd-integration-test:build
+```
+### Running on Local Host XD Clustered
+
+Following the Singlenode instructions above, you will only need to make one additional change (Assuming you are running the hsqldb-server).  Since we will be running an Admin and Container combination, the logs for which the Acceptance tests will be monitoring will be the container's.  So, the xd\_container\_log\_dir will have to be updated as shown below:
+```
+xd_container_log_dir=${XD_HOME}/xd/logs/container.log
 ```
 
 ### Running on EC2
+Using the application-ec2.properties provided you will need to update the following properties:
+
+1. xd\_admin\_host
+2. xd\_containers
+3. xd\_private\_keyfile 
+4. JDBC Settings 
+  * jdbc_url
+  * jdbc_driver
+  * jdbc_password
+  * jdbc_database
+  * jdbc_username
+
+For Example:
+```
+xd_admin_host=http://ec2-23-22-34-139.compute-1.amazonaws.com:9393
+xd_containers=http://ec2-54-82-119-240.compute-1.amazonaws.com:9393
+...
+
+#Ec2 Settings
+xd_pvt_keyfile=/Users/renfrg/ec2/xd-key-pair.pem
+...
+
+#JDBC Test Setting
+jdbc_url=jdbc:mysql://xdjobrepo.adsfa.us-east-1.rds.amazonaws.com:3306/%s
+jdbc_driver=com.mysql.jdbc.Driver
+jdbc_password=mypassword
+jdbc_database=xdjob
+jdbc_username=myuser
+```
+
 #### Running build from Command Line
 
+1) Set the spring\_profiles\_active environment variable to ec2.  For Example (Mac/Unix):
+
 ```
-./gradlew  -Dxd_admin_host=http://ec2-54-197-41-192.compute-1.amazonaws.com:9393
--Dxd_containers=http://ec2-54-196-248-248.compute-1.amazonaws.com:9393 -Dxd_http_port=15000 -Dxd_jmx_port=15005 -Dxd_private_key_file=<your dir>/xd-key-pair.pem -Dxd_run_on_ec2=true -Drun_integration_tests=true :spring-xd-integration-test:build
+export spring_profiles_active=ec2
+```
+2) Run the Acceptance Tests.
+
+```
+./gradlew  -Drun_integration_tests=true :spring-xd-integration-test:build
 ```
 
-### Eclipse localhost
-In the run configuration of your tests add the environment variables to your VMArgs.  Use the environment variables below:
-```
-        -Dxd_admin_host=http://localhost:9393
-        -Dxd_containers=http://localhost:9393
-        -Dxd_http_port=9000
-        -Dxd_jmx_port=15005
-        -Dxd_private_key_file=<location of your ec2 private key file> // if you are testing ec2 cluster
-        -Dxd_run_on_ec2=[false if you are testing locally | true if you are testing on ec2]
-        -Dxd_container_log_dir=<the location of container/singlenode log>
-```
-* Execute the tests via the "Run As"->"JUnit Tests" infrastructure.
-* Using the artifact
+### Eclipse 
+You can run acceptance tests from Eclipse. 
+
+#### Single Node Acceptance Tests:
+
+1. Make sure that you have setup the acceptance-singlenode.properties according to Step 1 in the " Running on Local Host SingleNode" section of this document.  
+2. In the run configuration of your tests select Environment tab. 
+3. Click the new button
+4. In the name field enter, __spring_profiles_active__
+5. In the value field enter the profile you are using.  For example: singlenode
+6. Click the ok button.
+7. Execute the tests via the "Run As"->"JUnit Tests" infrastructure.
+
+
+##### Using the artifact
   * Setup the environment by using the ec2servers.csv file
     * Create an artifact file named ec2servers.csv and place it in the root spring-xd-integration-test directory.  The file looks like the following:
 
@@ -192,21 +256,10 @@ In the run configuration of your tests add the environment variables to your VMA
 			containerNode,localhost,9393,15000,15005
 ```
 
-**Note:**
-*You will still need to use set the environment variables xd_private_key_file & xd_run_on_ec2.*
-
-### Environment variables
-  * xd_admin_host - the ip and port of the administrator server
-  * xd_containers - the ip and port of the container server
-  * xd_http_port - the http source port
-  * xd_http_jmx_port - the port for JMX communications
-  * xd_private_key_file - the URI of the ec2 private key
-  * xd_run_on_ec2 - If set to true, system will pull result file and logs from remote servers.
-
 
 ## Module Configuration
 
-Out of the box all modules should require no additional setup for local testing.  However in a distributed environment resources such as databases, Message Queues and Hadoop servers lie in different locations.  This section will discuss how to configure these modules to work in  a distributed environment
+Some modules require additional setup for resources such as databases, Message Queues and Hadoop servers lie in different locations.  This section will discuss how to configure these modules to work in  a distributed environment
 
 ### JDBC
 
@@ -223,3 +276,7 @@ When running an acceptance test on a singlenode on another machine or a XD Clust
 The %s in the jdbc_url will be populated by the jdbc_database.
 An example command line would look like this if running on an acceptance test on a remote XD cluster.
 
+### MQTT
+
+1. Verify that your MQTT plugin is installed on your rabbit instance.  If not, install it based on rabbit's instructions.
+2. The JmxTest will look for the Rabbit MQTT instance on the host declared by the xd\_admin\_host declared in the application-<your profile>.properties file that you are using. 

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sinks.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sinks.java
@@ -16,6 +16,7 @@
 
 package org.springframework.xd.integration.fixtures;
 
+import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,6 +24,7 @@ import org.springframework.xd.integration.util.XdEnvironment;
 import org.springframework.xd.test.fixtures.AbstractModuleFixture;
 import org.springframework.xd.test.fixtures.JdbcSink;
 import org.springframework.xd.test.fixtures.LogSink;
+import org.springframework.xd.test.fixtures.MqttSink;
 import org.springframework.xd.test.fixtures.SimpleFileSink;
 import org.springframework.xd.test.fixtures.TcpSink;
 
@@ -34,7 +36,7 @@ import org.springframework.xd.test.fixtures.TcpSink;
  */
 public class Sinks {
 
-	private static int TCP_SINK_PORT = 1234;
+	private final static int TCP_SINK_PORT = 1234;
 
 	private Map<String, AbstractModuleFixture> sinks;
 
@@ -84,6 +86,10 @@ public class Sinks {
 		return new TcpSink(port);
 	}
 
+	public MqttSink mqtt() throws MalformedURLException {
+		return new MqttSink(environment.getAdminServer().getHost(), 1883);
+	}
+
 	public SimpleFileSink file(String dir, String fileName) {
 		return new SimpleFileSink(dir, fileName);
 	}
@@ -92,7 +98,6 @@ public class Sinks {
 		if (environment.getJdbcUrl() == null) {
 			return null;
 		}
-
 		jdbcSink = new JdbcSink();
 		jdbcSink.url(environment.getJdbcUrl()).driver(environment.getJdbcDriver()).database(
 				environment.getJdbcDatabase());

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
@@ -19,7 +19,8 @@ package org.springframework.xd.integration.fixtures;
 import java.net.URL;
 import java.util.List;
 
-import org.springframework.shell.core.JLineShellComponent;
+import org.springframework.xd.test.fixtures.JmsSource;
+import org.springframework.xd.test.fixtures.MqttSource;
 import org.springframework.xd.test.fixtures.SimpleFileSource;
 import org.springframework.xd.test.fixtures.SimpleHttpSource;
 import org.springframework.xd.test.fixtures.SimpleTailSource;
@@ -27,7 +28,7 @@ import org.springframework.xd.test.fixtures.TcpSource;
 
 
 /**
- *
+ * 
  * @author Glenn Renfro
  */
 public class Sources {
@@ -36,21 +37,27 @@ public class Sources {
 
 	private List<URL> containers = null;
 
-	private JLineShellComponent shell = null;
-
 	private SimpleHttpSource httpSource = null;
 
 	private TcpSource tcpSource = null;
 
 	private int httpPort = 9000;
 
-	private static int TCP_SINK_PORT = 1234;
+	private int mqttPort = 1883;
 
-	public Sources(URL adminServer, List<URL> containers, JLineShellComponent shell, int httpPort) {
+	private String jmsHost;
+
+	private int jmsPort;
+
+	private final static int TCP_SINK_PORT = 1234;
+
+	public Sources(URL adminServer, List<URL> containers, int httpPort, String jmsHost,
+			int jmsPort) {
 		this.adminServer = adminServer;
 		this.containers = containers;
-		this.shell = shell;
 		this.httpPort = httpPort;
+		this.jmsHost = jmsHost;
+		this.jmsPort = jmsPort;
 	}
 
 	public SimpleHttpSource http() throws Exception {
@@ -79,7 +86,21 @@ public class Sources {
 		return new SimpleTailSource(delay, fileName);
 	}
 
+	public JmsSource jms() {
+		return new JmsSource(jmsHost, jmsPort);
+	}
+
+	public MqttSource mqtt() {
+		return new MqttSource(adminServer.getHost(), mqttPort);
+	}
+
 	public SimpleFileSource file(String dir, String fileName) throws Exception {
 		return new SimpleFileSource(dir, fileName);
 	}
+
+	public String jmsConfig() {
+		String result = "amq.url=tcp://" + jmsHost + ":" + jmsPort;
+		return result;
+	}
+
 }

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/ConfigUtil.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/ConfigUtil.java
@@ -30,7 +30,7 @@ import org.jclouds.sshj.SshjSshClient;
 
 /**
  * Tools to setup an XD Instance with the correct configuration files for a stream's modules.
- *
+ * 
  * @author Glenn Renfro
  */
 public class ConfigUtil {
@@ -46,9 +46,9 @@ public class ConfigUtil {
 	}
 
 	/**
-	 *
+	 * 
 	 * Creates a properties file with the content you specify in the config directory of the host you specify.
-	 *
+	 * 
 	 * @param fileName The name of the properties file.
 	 * @param content The configuration data that should be put in the config.properties file.
 	 * @throws IOException
@@ -70,7 +70,7 @@ public class ConfigUtil {
 	}
 
 	@SuppressWarnings("deprecation")
-	private void sshCopy(File file, String fileName, String host) {
+	private void sshCopy(File file, String fileName, String host) throws IOException {
 		final LoginCredentials credential = LoginCredentials
 				.fromCredentials(new Credentials("ubuntu", environment.getPrivateKey()));
 		final com.google.common.net.HostAndPort socket = com.google.common.net.HostAndPort

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
@@ -23,6 +23,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
@@ -30,6 +31,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.client.HttpClientErrorException;
@@ -46,7 +48,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * 
  * @author Glenn Renfro
  */
-
+@Configuration
 public class XdEc2Validation {
 
 	private final transient RestTemplate restTemplate;
@@ -86,7 +88,7 @@ public class XdEc2Validation {
 	 * @throws Exception
 	 */
 	public void verifyAtLeastOneContainerAvailable(final List<URL> containers,
-			int jmxPort) throws Exception {
+			int jmxPort) throws MalformedURLException {
 		boolean result = false;
 		final Iterator<URL> containerIter = containers.iterator();
 		while (containerIter.hasNext()) {
@@ -142,13 +144,14 @@ public class XdEc2Validation {
 	 */
 	public void verifyTestContent(XdEnvironment hosts, URL url, String fileName,
 			String data) throws IOException {
+		String resultFileName = fileName;
 		if (hosts.isOnEc2()) {
-			fileName = StreamUtils.transferResultsToLocal(hosts, url, fileName);
+			resultFileName = StreamUtils.transferResultsToLocal(hosts, url, fileName);
 		}
-		File file = new File(fileName);
+		File file = new File(resultFileName);
 
 		try {
-			Reader fileReader = new InputStreamReader(new FileInputStream(fileName));
+			Reader fileReader = new InputStreamReader(new FileInputStream(resultFileName));
 			String result = FileCopyUtils.copyToString(fileReader);
 
 			if (!(data).equals(result)) {
@@ -189,7 +192,7 @@ public class XdEc2Validation {
 			if (!file.exists()) {
 				throw new IllegalArgumentException(
 						"The Log File for the container is not present.  Please be sure to set the "
-								+ XdEnvironment.XD_CONTAINER_LOG_DIR + " on your gradle build.");
+								+ "xd_container_log_dir on your gradle build.");
 			}
 			BufferedReader fileReader = new BufferedReader(new FileReader(logLocation));
 			boolean result = false;

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractIntegrationTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractIntegrationTest.java
@@ -26,8 +26,12 @@ import java.util.List;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.springframework.shell.Bootstrap;
-import org.springframework.shell.core.JLineShellComponent;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.xd.integration.fixtures.Sinks;
 import org.springframework.xd.integration.fixtures.Sources;
 import org.springframework.xd.integration.util.ConfigUtil;
@@ -37,19 +41,25 @@ import org.springframework.xd.integration.util.XdEnvironment;
 import org.springframework.xd.test.fixtures.AbstractModuleFixture;
 import org.springframework.xd.test.fixtures.LogSink;
 import org.springframework.xd.test.fixtures.SimpleFileSink;
-import org.springframework.xd.test.RandomConfigurationSupport;
 
 /**
  * Base Class for Spring XD Integration classes
  * 
  * @author Glenn Renfro
  */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = XdEnvironment.class)
 public abstract class AbstractIntegrationTest {
 
 	private final static String STREAM_NAME = "ec2Test3";
 
-	protected XdEnvironment environment;
+	protected final static String XD_DELIMETER = " | ";
 
+
+	@Autowired
+	protected XdEnvironment xdEnvironment;
+
+	@Autowired
 	protected XdEc2Validation validation;
 
 	protected URL adminServer;
@@ -58,30 +68,25 @@ public abstract class AbstractIntegrationTest {
 
 	protected List<String> streamNames;
 
-	protected int pauseTime;
+	@Value("${xd_pause_time}")
+	protected transient int pauseTime;
 
-	protected String XD_DELIMETER = " | ";
+	@Value("${xd_run_on_ec2}")
+	protected boolean isOnEc2;
 
-	private JLineShellComponent shell;
+	@Autowired
+	protected Sources sources;
 
-	protected Sources sources = null;
+	@Autowired
+	protected Sinks sinks;
 
-	protected Sinks sinks = null;
+	@Autowired
+	protected ConfigUtil configUtil;
 
-	private boolean initialized = false;
+	private transient boolean initialized = false;
 
-	ConfigUtil configUtil = null;
 
 	public AbstractIntegrationTest() {
-		try {
-			environment = new XdEnvironment();
-		}
-		catch (Exception ex) {
-			throw new IllegalArgumentException(ex.getMessage());
-		}
-		httpPort = environment.getHttpPort();
-		sinks = new Sinks(environment);
-
 	}
 
 	/**
@@ -91,29 +96,17 @@ public abstract class AbstractIntegrationTest {
 	 */
 	public void initializer() throws Exception {
 		if (!initialized) {
-			adminServer = environment.getAdminServer();
-			validation = new XdEc2Validation();
+			httpPort = xdEnvironment.getHttpPort();
+			adminServer = xdEnvironment.getAdminServer();
 			validation.verifyXDAdminReady(adminServer);
-			pauseTime = environment.getPauseTime();
-			validation.verifyAtLeastOneContainerAvailable(environment.getContainers(),
-					environment.getJMXPort());
-			RandomConfigurationSupport configSupport = new RandomConfigurationSupport();
-			Bootstrap bootstrap = new Bootstrap(new String[] { "--port",
-				configSupport.getAdminServerPort() });
-
-			shell = bootstrap.getJLineShellComponent();
-			sources = new Sources(adminServer, environment.getContainers(), shell, httpPort);
-			configUtil = new ConfigUtil(environment.isOnEc2(), environment);
+			validation.verifyAtLeastOneContainerAvailable(xdEnvironment.getContainers(),
+					xdEnvironment.getJMXPort());
 			initialized = true;
 		}
 	}
 
-	public JLineShellComponent getShell() {
-		return shell;
-	}
-
 	@AfterClass
-	public static void tearDownAfterClass() throws Exception {
+	public static void tearDownAfterClass() {
 		File file = new File(StreamUtils.TMP_DIR);
 		if (file.exists()) {
 			file.delete();
@@ -167,7 +160,7 @@ public abstract class AbstractIntegrationTest {
 	 */
 	public URL getContainerForStream(String streamName) {
 		// Assuming one container for now.
-		return environment.getContainers().get(0);
+		return xdEnvironment.getContainers().get(0);
 	}
 
 	/**
@@ -179,7 +172,7 @@ public abstract class AbstractIntegrationTest {
 		waitForXD();
 
 		validation.assertReceived(StreamUtils.replacePort(
-				getContainerForStream(STREAM_NAME), environment.getJMXPort()), STREAM_NAME,
+				getContainerForStream(STREAM_NAME), xdEnvironment.getJMXPort()), STREAM_NAME,
 				"http");
 	}
 
@@ -214,7 +207,7 @@ public abstract class AbstractIntegrationTest {
 		waitForXD(pauseTime * 2000);
 		String fileName = XdEnvironment.RESULT_LOCATION + "/" + streamName
 				+ ".out";
-		validation.verifyTestContent(environment, url, fileName, data);
+		validation.verifyTestContent(xdEnvironment, url, fileName, data);
 	}
 
 	/**
@@ -227,7 +220,7 @@ public abstract class AbstractIntegrationTest {
 	private void assertLogEntry(String data, URL url)
 			throws IOException {
 		waitForXD();
-		validation.verifyLogContent(environment, url, environment.getContainerLogLocation(), data);
+		validation.verifyLogContent(xdEnvironment, url, xdEnvironment.getContainerLogLocation(), data);
 	}
 
 	protected void waitForXD() {
@@ -244,10 +237,8 @@ public abstract class AbstractIntegrationTest {
 
 	}
 
-
 	public XdEnvironment getEnvironment() {
-		return environment;
+		return xdEnvironment;
 	}
-
 
 }

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HttpTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HttpTest.java
@@ -16,14 +16,9 @@
 
 package org.springframework.xd.integration.test;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.UUID;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 import org.springframework.xd.test.fixtures.AbstractModuleFixture;
 import org.springframework.xd.test.fixtures.LogSink;
@@ -32,43 +27,40 @@ import org.springframework.xd.test.fixtures.SimpleFileSink;
 /**
  * @author Glenn Renfro
  */
-@RunWith(Parameterized.class)
 public class HttpTest extends AbstractIntegrationTest {
 
-	private AbstractModuleFixture sink;
-
-	public HttpTest(Class<?> sinkClass) {
-		this.sink = sinks.getSink(sinkClass);
-	}
+	// Removed the parameratized test because requires only one zero argument public constructor
 
 	/**
-	 * Test the http source for retrieving information, and outputs the data to the sink that is specified by the
-	 * parameterized sink.
+	 * Test the http source for retrieving information, and outputs the data to the file sink.
 	 * 
 	 * @throws Exception
 	 */
 	@Test
-	public void testHttp() throws Exception {
+	public void testHttpFileSink() throws Exception {
+		genericTest(sinks.getSink(SimpleFileSink.class));
+	}
 
+	/**
+	 * Test the http source for retrieving information, and outputs the data to the log sink.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testHttplogSink() throws Exception {
+		genericTest(sinks.getSink(LogSink.class));
+	}
+
+
+	private void genericTest(AbstractModuleFixture sink) throws Exception {
 		String data = UUID.randomUUID().toString();
 		stream(sources.http() + XD_DELIMETER + sink);
 		waitForXD();
 		sources.http().postData(data);
 		waitForXD(2000);
 		assertReceived();
-		assertValid(data, this.sink);
-	}
+		assertValid(data, sink);
 
-	/**
-	 * The list of sinks for the stream to use in this test.
-	 * 
-	 * @return
-	 */
-	@Parameters
-	public static Collection<Object[]> sink() {
-		Object[][] sink = { { SimpleFileSink.class }, { LogSink.class } };
-		return Arrays.asList(sink);
 	}
-
 
 }

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/MqttTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/MqttTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.integration.test;
+
+import java.util.UUID;
+
+import org.junit.Test;
+
+import org.springframework.xd.test.fixtures.SimpleFileSink;
+
+
+/**
+ * Runs a basic suite of JMS Source tests on an XD Cluster instance.
+ * 
+ * @author Glenn Renfro
+ */
+public class MqttTest extends AbstractIntegrationTest {
+
+
+	/**
+	 * Verifies that the MQTT Source that terminates with a CRLF returns the correct data.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testMqttSource() throws Exception {
+		String data = UUID.randomUUID().toString();
+		stream(sources.mqtt() + XD_DELIMETER + sinks.getSink(SimpleFileSink.class));
+		sources.mqtt().ensureReady();
+		sources.mqtt().sendData(data);
+		waitForXD(2000);
+		assertReceived();
+		assertValid(data, sinks.getSink(SimpleFileSink.class));
+	}
+
+	@Test
+	public void testMqttSink() throws Exception {
+		String data = UUID.randomUUID().toString();
+		stream(sources.mqtt() + XD_DELIMETER + sinks.getSink(SimpleFileSink.class));
+		waitForXD(2000);
+		stream("mqttSender", "trigger --payload='" + data + "'" + XD_DELIMETER + sinks.mqtt());
+		waitForXD(2000);
+		assertReceived();
+		assertValid(data, sinks.getSink(SimpleFileSink.class));
+
+	}
+
+}

--- a/spring-xd-integration-test/src/test/resources/application-ec2.properties
+++ b/spring-xd-integration-test/src/test/resources/application-ec2.properties
@@ -1,0 +1,26 @@
+#Housekeeping settings
+xd_pause_time=2
+xd_run_on_ec2=true
+xd_admin_host=http://<admin-host>:9393
+xd_containers=http://<container-host>.com:9393
+xd_http_port=9000
+xd_jmx_port=15000
+
+#Location
+XD_HOME=/home/ubuntu/spring-xd-1.0.0.BUILD-SNAPSHOT
+xd_container_log_dir=${XD_HOME}/xd/logs/singlenode.log
+xd_base_dir=${XD_HOME}/xd
+
+#Ec2 Settings
+xd_pvt_keyfile=<location to your private key>
+
+#JDBC Test Setting
+jdbc_url=<connection url to your RDBMS>
+jdbc_driver=<jdbc driver name>
+jdbc_password=
+jdbc_database=
+jdbc_username=
+
+#JMS Settings
+jms_host=localhost
+jms_port=61616

--- a/spring-xd-integration-test/src/test/resources/application-singlenode.properties
+++ b/spring-xd-integration-test/src/test/resources/application-singlenode.properties
@@ -1,0 +1,23 @@
+#Housekeeping settings
+xd_pause_time=2
+xd_run_on_ec2=false
+xd_admin_host=http://localhost:9393
+xd_containers=http://localhost:9393
+xd_http_port=9000
+xd_jmx_port=15005
+
+#Location
+XD_HOME=<Your XD Home Dir>
+xd_container_log_dir=${XD_HOME}/xd/logs/singlenode.log
+xd_base_dir=${XD_HOME}/xd
+
+#JDBC Test Setting
+jdbc_url=jdbc:hsqldb:hsql://localhost:9101/%s
+jdbc_driver=org.hsqldb.jdbc.JDBCDriver
+jdbc_password=
+jdbc_database=xdjob
+jdbc_username=sa
+
+#JMS Settings
+jms_host=localhost
+jms_port=61616

--- a/spring-xd-integration-test/src/test/resources/application.properties
+++ b/spring-xd-integration-test/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+spring.profiles.active=localsingle
+

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JmsSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JmsSource.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.test.fixtures;
+
+import java.io.IOException;
+import java.net.Socket;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+
+import org.springframework.jms.core.JmsTemplate;
+
+
+/**
+ * A test fixture that allows testing of the 'jms' source module.
+ * 
+ * @author Glenn Renfro
+ */
+public class JmsSource extends AbstractModuleFixture {
+
+	protected int port = 61616;
+
+	private String host;
+
+
+	public JmsSource() {
+
+	}
+
+	public JmsSource(String host, int port) {
+		this.host = host;
+		this.port = port;
+	}
+
+
+	@Override
+	protected String toDSL() {
+		return "jms ";
+	}
+
+	public JmsSource ensureReady() {
+		return ensureReady(2000);
+	}
+
+	public JmsSource ensureReady(int timeout) {
+		long giveUpAt = System.currentTimeMillis() + timeout;
+		while (System.currentTimeMillis() < giveUpAt) {
+			try {
+				new Socket(host, port);
+				return this;
+			}
+			catch (IOException e) {
+				try {
+					Thread.sleep(100);
+				}
+				catch (InterruptedException e1) {
+					Thread.currentThread().interrupt();
+				}
+			}
+		}
+		throw new IllegalStateException(String.format(
+				"Source [%s] does not seem to be listening after waiting for %dms", this, timeout));
+	}
+
+
+	public void sendData(String data) throws Exception {
+		System.out.println("tcp://" + host + ":" + port);
+		JmsTemplate template = new JmsTemplate(new ActiveMQConnectionFactory("tcp://" + host + ":" + port));
+		template.convertAndSend("ec2Test3", data);
+	}
+}

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MqttSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MqttSink.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.test.fixtures;
+
+
+/**
+ * Test fixture that creates a mqtt sink.
+ * 
+ * @author Glenn Renfro
+ */
+public class MqttSink extends AbstractModuleFixture {
+
+	protected int port = 1883;
+
+	private String host;
+
+
+	public MqttSink(String host, int port) {
+		this.host = host;
+		this.port = port;
+	}
+
+	@Override
+	protected String toDSL() {
+		return "mqtt --url='tcp://" + host + ":" + port + "'";
+	}
+
+
+}

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MqttSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MqttSource.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.test.fixtures;
+
+import java.io.IOException;
+import java.net.Socket;
+
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
+
+
+/**
+ * A test fixture that allows testing of the 'jms' source module.
+ * 
+ * @author Glenn Renfro
+ */
+public class MqttSource extends AbstractModuleFixture {
+
+	protected int port = 1883;
+
+	private String host;
+
+
+	public MqttSource() {
+
+	}
+
+	public MqttSource(String host, int port) {
+		this.host = host;
+		this.port = port;
+	}
+
+
+	@Override
+	protected String toDSL() {
+		return "mqtt --url='tcp://" + host + ":" + port + "' --topics='xd.mqtt.test'";
+	}
+
+	public MqttSource ensureReady() {
+		return ensureReady(2000);
+	}
+
+	public MqttSource ensureReady(int timeout) {
+		long giveUpAt = System.currentTimeMillis() + timeout;
+		while (System.currentTimeMillis() < giveUpAt) {
+			try {
+				new Socket(host, port);
+				return this;
+			}
+			catch (IOException e) {
+				try {
+					Thread.sleep(100);
+				}
+				catch (InterruptedException e1) {
+					Thread.currentThread().interrupt();
+				}
+			}
+		}
+		throw new IllegalStateException(String.format(
+				"Source [%s] does not seem to be listening after waiting for %dms", this, timeout));
+	}
+
+
+	public void sendData(String data) throws Exception {
+		DefaultMqttPahoClientFactory factory;
+		MqttClient client = null;
+		factory = new DefaultMqttPahoClientFactory();
+		factory.setPassword("guest");
+		factory.setUserName("foobar");
+		MqttMessage mqttMessage = new MqttMessage();
+		mqttMessage.setPayload(data.getBytes());
+		client = factory.getClientInstance("tcp://" + host + ":" + port, "guest");
+		client.connect();
+		client.publish("xd.mqtt.test", mqttMessage);
+		try {
+			Thread.sleep(1000);
+		}
+		catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		client.disconnect();
+		client.close();
+
+	}
+}


### PR DESCRIPTION
The previous version of Acceptance tests was driven by environment variables to configure
the tests and this became unwieldy.   This PR setup acceptance tests to use @SpringApplicationConfiguration and XDEnvironment to configure the tests. The other benefit is that through the use of profiles a user can setup test scenarios as different profiles.

Other things done:
- Added MQTT Test
- Foundation for JMS test (JMS Source ) has been added, but left out the test because it already has its own Jira.
- Created singlenode and ec2 properties for users.
- Removed all test configuration properties from build.gradle
- Instructions now reflect the use of SpringApplicationConfiguration
