### PR TITLE
Fix RemoteFileToHadoopTest

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests-context.xml
+++ b/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests-context.xml
@@ -47,12 +47,4 @@
 		<constructor-arg value="org.springframework.integration.file.remote.session.SessionFactory" />
 	</bean>
 
-	<bean id="messageBus" class="org.springframework.integration.x.bus.LocalMessageBus">
-		<property name="queueSize"
-			value="${xd.local.transport.named.queueSize: #{T(Integer).MAX_VALUE}}" />
-		<property name="poller">
-			<int:poller fixed-rate="${xd.local.transport.named.polling:1000}" />
-		</property>
-	</bean>
-
 </beans>

--- a/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests.java
@@ -46,6 +46,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
+import org.springframework.integration.x.bus.LocalMessageBus;
 import org.springframework.integration.x.bus.MessageBus;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.xd.test.hadoop.HadoopFileSystemTestSupport;
@@ -110,7 +111,8 @@ public class RemoteFileToHadoopTests {
 		this.repliesOut = ctx.getBean("stepExecutionReplies.output", MessageChannel.class);
 		this.repliesIn = ctx.getBean("stepExecutionReplies.input", MessageChannel.class);
 
-		this.bus = (MessageBus) ctx.getBean("messageBus");
+		this.bus = new LocalMessageBus();
+		((LocalMessageBus) this.bus).setApplicationContext(ctx);
 		this.bus.bindRequestor("foo", this.requestsOut, this.repliesIn);
 		this.bus.bindReplier("foo", this.requestsIn, this.repliesOut);
 	}


### PR DESCRIPTION
- Add `local` messagebus bean inside the test context so that beanFactory is not null when find/create requestor/replier channels inside testSimple method
