### PR TITLE
XD-1598 Use Msgbus binding to start

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/LocalMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/LocalMessageBus.java
@@ -303,12 +303,11 @@ public class LocalMessageBus extends MessageBusSupport implements ApplicationCon
 			Binding binding = isInbound ? Binding.forConsumer(cefb.getObject(), to)
 					: Binding.forProducer(from, cefb.getObject());
 			addBinding(binding);
+			binding.start();
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(e);
 		}
-
-		cefb.start();
 		return handler;
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/rabbit/RabbitMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/rabbit/RabbitMessageBus.java
@@ -88,7 +88,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		this.rabbitAdmin.afterPropertiesSet();
 		this.mapper = new DefaultAmqpHeaderMapper();
 		this.mapper.setRequestHeaderNames(new String[] { AbstractHeaderMapper.STANDARD_REQUEST_HEADER_NAME_PATTERN,
-			ORIGINAL_CONTENT_TYPE_HEADER });
+				ORIGINAL_CONTENT_TYPE_HEADER });
 		this.setCodec(codec);
 	}
 
@@ -136,13 +136,14 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		adapter.setHeaderMapper(this.mapper);
 		adapter.setBeanName("inbound." + name);
 		adapter.afterPropertiesSet();
-		addBinding(Binding.forConsumer(adapter, moduleInputChannel));
+		Binding consumerBinding = Binding.forConsumer(adapter, moduleInputChannel);
+		addBinding(consumerBinding);
 		ReceivingHandler convertingBridge = new ReceivingHandler();
 		convertingBridge.setOutputChannel(moduleInputChannel);
 		convertingBridge.setBeanName(name + ".convert.bridge");
 		convertingBridge.afterPropertiesSet();
 		bridgeToModuleChannel.subscribe(convertingBridge);
-		adapter.start();
+		consumerBinding.start();
 	}
 
 	@Override
@@ -188,8 +189,9 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		consumer.setBeanFactory(this.getBeanFactory());
 		consumer.setBeanName("outbound." + name);
 		consumer.afterPropertiesSet();
-		addBinding(Binding.forProducer(moduleOutputChannel, consumer));
-		consumer.start();
+		Binding producerBinding = Binding.forProducer(moduleOutputChannel, consumer);
+		addBinding(producerBinding);
+		producerBinding.start();
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/redis/RedisMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/redis/RedisMessageBus.java
@@ -106,13 +106,14 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		adapter.setOutputChannel(bridgeToModuleChannel);
 		adapter.setBeanName("inbound." + name);
 		adapter.afterPropertiesSet();
-		addBinding(Binding.forConsumer(adapter, moduleInputChannel));
+		Binding consumerBinding = Binding.forConsumer(adapter, moduleInputChannel);
+		addBinding(consumerBinding);
 		ReceivingHandler convertingBridge = new ReceivingHandler();
 		convertingBridge.setOutputChannel(moduleInputChannel);
 		convertingBridge.setBeanName(name + ".convert.bridge");
 		convertingBridge.afterPropertiesSet();
 		bridgeToModuleChannel.subscribe(convertingBridge);
-		adapter.start();
+		consumerBinding.start();
 	}
 
 	@Override
@@ -146,8 +147,9 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		consumer.setBeanFactory(this.getBeanFactory());
 		consumer.setBeanName("outbound." + name);
 		consumer.afterPropertiesSet();
-		addBinding(Binding.forProducer(moduleOutputChannel, consumer));
-		consumer.start();
+		Binding producerBinding = Binding.forProducer(moduleOutputChannel, consumer);
+		addBinding(producerBinding);
+		producerBinding.start();
 	}
 
 	@Override


### PR DESCRIPTION
- The messagebus implementations, upon registration of consumer and producer from/to messagebus
  the corresponding endpoints start.
  - Instead of directly calling the start() on adapter/consumer we can call the corresponding Binding's start()
    - This is in-line with the way the corresponding endpoints are stopped (using Binding's stop()) during
      undeploy/destroy
