### PR TITLE
XD-1365 Set ModuleDefinitions while deleteAll()

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -167,7 +167,9 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 
 	@Override
 	public void deleteAll() {
-		repository.deleteAll();
+		for (D d : findAll()) {
+			delete(d.getName());
+		}
 	}
 
 	protected CrudRepository<D, String> getDefinitionRepository() {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDeployer.java
@@ -89,7 +89,6 @@ public class StreamDeployer extends AbstractInstancePersistingDeployer<StreamDef
 			}
 		}
 		definition.setModuleDefinitions(moduleDefinitions);
-		basicUndeploy(definition.getName());
 	}
 
 }


### PR DESCRIPTION
- When using AbstractDeployer.deleteAll(), the composed module definitions for the stream definition
  is not set. Hence, the dependencies are not deleted from the ZK repository.
  - Fix `deleteAll()` to iteratively call delete(definitionName) which sets the ModuleDefinitions `beforeDelete`
- Remove calling `basicUndeploy()` at beforeDelete() in StreamDeployer
