### PR TITLE
Pluralize ZK Admin group node name

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServer.java
@@ -56,7 +56,7 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
 /**
  * Server that watches ZooKeeper for Container arrivals and departures from the XD cluster. Each AdminServer instance
  * will attempt to request leadership, but at any given time only one AdminServer instance in the cluster will have
- * leadership status. Those instances not elected will watch the {@link Paths#ADMIN} znode so that one of
+ * leadership status. Those instances not elected will watch the {@link Paths#ADMINS} znode so that one of
  * them will take over leadership if the leader admin closes or crashes.
  *
  * @author Patrick Peralta
@@ -215,7 +215,7 @@ public class AdminServer implements ContainerRepository, ApplicationListener<App
 			Paths.ensurePath(client, Paths.JOBS);
 
 			if (leaderSelector == null) {
-				leaderSelector = new LeaderSelector(client, Paths.build(Paths.ADMIN), leaderListener);
+				leaderSelector = new LeaderSelector(client, Paths.build(Paths.ADMINS), leaderListener);
 				leaderSelector.setId(getId());
 				leaderSelector.start();
 			}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/Paths.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/Paths.java
@@ -40,9 +40,9 @@ public class Paths {
 	public static final String XD_NAMESPACE = "xd";
 
 	/**
-	 * Name of admin leader node.
+	 * Name of admins (that could participate to become leader) node. Admins are written as children of this node.
 	 */
-	public static final String ADMIN = "admin";
+	public static final String ADMINS = "admins";
 
 	/**
 	 * Name of containers node. Containers are written as children of this node.


### PR DESCRIPTION
- Since we support multiple admin servers and all of them
  participate in leadership election, it might be good pluralizing
  the leadership group path's node name
