### PR TITLE
Stream deployment test improvements

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
@@ -76,7 +76,8 @@ import org.springframework.xd.tuple.Tuple;
  *
  * Additionally, extensions of this class should initialize the {@link #testMessageBus}
  * member via an {@link org.junit.rules.ExternalResource} static member annotated with
- * {@link org.junit.ClassRule}.
+ * {@link org.junit.ClassRule} if the tests require a specific
+ * {@link org.springframework.integration.x.bus.MessageBus} implementation.
  *
  * @author David Turanski
  * @author Gunnar Hillert
@@ -120,7 +121,7 @@ public abstract class AbstractSingleNodeStreamDeploymentIntegrationTests {
 	};
 
 	/**
-	 * Provides random configuration information for a test single node application.
+	 * Provides random configuration information for testing a single node application.
 	 */
 	protected static TestApplicationBootstrap testApplicationBootstrap;
 
@@ -138,7 +139,8 @@ public abstract class AbstractSingleNodeStreamDeploymentIntegrationTests {
 	/**
 	 * Message bus used for testing. This member should be initialized by
 	 * extensions of this class via an {@link org.junit.rules.ExternalResource}
-	 * static member annotated with {@link org.junit.ClassRule}.
+	 * static member annotated with {@link org.junit.ClassRule} if the tests
+	 * require a specific {@code MessageBus} implementation.
 	 */
 	protected static AbstractTestMessageBus testMessageBus;
 


### PR DESCRIPTION
Changes in `AbstractSingleNodeStreamDeploymentIntegrationTests`:
- Updated existing JavaDoc and added new doc, including instructions on how to extend.
- Introduced constants for some queue names
- Rearranged setup/teardown and utility code to
  appear at the top of the class.
