### PR TITLE
XD-1642 Fail fast admin on startup failure

### DIFF
--- a/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HSQLServerBean.java
+++ b/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HSQLServerBean.java
@@ -44,7 +44,7 @@ public class HSQLServerBean implements InitializingBean, DisposableBean {
 	/**
 	 * Commons Logging instance.
 	 */
-	private static final Log log = LogFactory.getLog(HSQLServerBean.class);
+	private static final Log logger = LogFactory.getLog(HSQLServerBean.class);
 
 	/**
 	 * Properties used to customize instance.
@@ -78,12 +78,12 @@ public class HSQLServerBean implements InitializingBean, DisposableBean {
 		server.setNoSystemExit(true);
 		server.setProperties(configProps);
 
-		log.debug("HSQL Database path: " + server.getDatabasePath(0, true));
+		logger.debug("HSQL Database path: " + server.getDatabasePath(0, true));
 		startServer();
 	}
 
 	private void startServer() throws Exception {
-		log.info("Starting HSQL Server database '" + server.getDatabaseName(0, true) + "' listening on port: "
+		logger.info("Starting HSQL Server database '" + server.getDatabaseName(0, true) + "' listening on port: "
 				+ server.getPort());
 
 		int tries = 0;
@@ -125,7 +125,7 @@ public class HSQLServerBean implements InitializingBean, DisposableBean {
 				if (t instanceof SocketException && "Invalid argument".equals(t.getMessage())) {
 					long fileCount = getOpenFileDescriptorCount();
 
-					log.debug(
+					logger.debug(
 							String.format(
 									"Caught SocketException (likely due to excessive file descriptors open; current count: %d)",
 									fileCount), t);
@@ -136,7 +136,7 @@ public class HSQLServerBean implements InitializingBean, DisposableBean {
 						fileCount = getOpenFileDescriptorCount();
 					}
 
-					log.debug(String.format("Open files: %d", getOpenFileDescriptorCount()));
+					logger.debug(String.format("Open files: %d", getOpenFileDescriptorCount()));
 				}
 				else {
 					// if the server fails to start for any other reason,
@@ -149,7 +149,7 @@ public class HSQLServerBean implements InitializingBean, DisposableBean {
 		while (!started && ++tries < 5);
 
 		if (started) {
-			log.info("Started HSQL Server");
+			logger.info("Started HSQL Server");
 		}
 		else {
 			String msg = String.format("HSQLDB could not be started on %s:%d, state: %s",
@@ -184,7 +184,7 @@ public class HSQLServerBean implements InitializingBean, DisposableBean {
 	}
 
 	private void shutdownServer() {
-		log.info("HSQL Server Shutdown sequence initiated");
+		logger.info("HSQL Server Shutdown sequence initiated");
 		if (server != null) {
 			server.signalCloseAllServerConnections();
 			server.stop();
@@ -202,7 +202,7 @@ public class HSQLServerBean implements InitializingBean, DisposableBean {
 				catch (InterruptedException e) {
 				}
 			}
-			log.info("HSQL Server Shutdown completed");
+			logger.info("HSQL Server Shutdown completed");
 			server = null;
 		}
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/converter/ConversionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/integration/x/bus/converter/ConversionException.java
@@ -20,6 +20,7 @@ import org.springframework.xd.dirt.core.XDRuntimeException;
 
 
 /**
+ * Exception thrown when an error is encountered during message conversion.
  * 
  * @author David Turanski
  */

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/BatchJobAlreadyExistsException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/BatchJobAlreadyExistsException.java
@@ -20,6 +20,7 @@ import org.springframework.xd.dirt.core.XDRuntimeException;
 
 
 /**
+ * Exception thrown when the batch job with the given name already exists.
  * 
  * @author Ilayaperumal Gopinathan
  */

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionAlreadyRunningException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionAlreadyRunningException.java
@@ -19,6 +19,8 @@ package org.springframework.xd.dirt.job;
 import org.springframework.xd.dirt.core.XDRuntimeException;
 
 /**
+ * Exception that is raised when {@link JobExecution} is already running.
+ *
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceAlreadyCompleteException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceAlreadyCompleteException.java
@@ -16,9 +16,12 @@
 
 package org.springframework.xd.dirt.job;
 
+import org.springframework.batch.core.JobInstance;
 import org.springframework.xd.dirt.core.XDRuntimeException;
 
 /**
+ * Exception thrown when the {@link JobInstance} is already complete.
+ *
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobParametersInvalidException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobParametersInvalidException.java
@@ -19,6 +19,8 @@ package org.springframework.xd.dirt.job;
 import org.springframework.xd.dirt.core.XDRuntimeException;
 
 /**
+ * Exception thrown when the job parameters are invalid.
+ *
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobRestartException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobRestartException.java
@@ -19,6 +19,8 @@ package org.springframework.xd.dirt.job;
 import org.springframework.xd.dirt.core.XDRuntimeException;
 
 /**
+ * Exception thrown where the batch job is not restartable.
+ *
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobException.java
@@ -19,6 +19,7 @@ package org.springframework.xd.dirt.job;
 import org.springframework.xd.dirt.core.XDRuntimeException;
 
 /**
+ * Exception thrown when there is no such batch job with the given name.
  * 
  * @author Ilayaperumal Gopinathan
  */

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobInstanceException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobInstanceException.java
@@ -19,6 +19,7 @@ package org.springframework.xd.dirt.job;
 import org.springframework.xd.dirt.core.XDRuntimeException;
 
 /**
+ * Exception thrown when there is no such batch job instance with the given instanceId.
  * 
  * @author Ilayaperumal Gopinathan
  */

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleNotDeployedException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleNotDeployedException.java
@@ -19,7 +19,7 @@ package org.springframework.xd.dirt.module;
 import org.springframework.xd.dirt.core.XDRuntimeException;
 
 /**
- * Thrown when a module is not deployed but the deployment request expects the module is deployed.
+ * Exception thrown when a module is not deployed but the deployment request expects the module is deployed.
  * 
  * @author Ilayaperumal Gopinathan
  */

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminPortNotAvailableException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminPortNotAvailableException.java
@@ -20,6 +20,7 @@ import org.springframework.xd.dirt.core.XDRuntimeException;
 
 
 /**
+ * Exception thrown when the configured admin port is not available to use.
  * 
  * @author Ilayaperumal Gopinathan
  */

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/AdminServerApplication.java
@@ -60,7 +60,7 @@ import org.springframework.xd.dirt.util.XdProfiles;
 @Import(RestConfiguration.class)
 public class AdminServerApplication {
 
-	private static final Log log = LogFactory.getLog(AdminServerApplication.class);
+	private static final Log logger = LogFactory.getLog(AdminServerApplication.class);
 
 	private static final String MBEAN_EXPORTER_BEAN_NAME = "XDAdminMBeanExporter";
 
@@ -109,7 +109,7 @@ public class AdminServerApplication {
 		else {
 			errorMessage = e.getMessage();
 		}
-		log.error(errorMessage);
+		logger.error(errorMessage);
 		System.exit(1);
 	}
 
@@ -150,7 +150,6 @@ public class AdminServerApplication {
 					}
 					catch (IOException e) {
 						// It is very unlikely to get an exception here.
-						e.printStackTrace();
 					}
 				}
 			}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerServerApplication.java
@@ -74,7 +74,7 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
 @Import(PropertyPlaceholderAutoConfiguration.class)
 public class ContainerServerApplication implements EnvironmentAware {
 
-	private static final Log log = LogFactory.getLog(ContainerServerApplication.class);
+	private static final Log logger = LogFactory.getLog(ContainerServerApplication.class);
 
 	private static final String CONTAINER_ATTRIBUTES_PREFIX = "xd.container.";
 
@@ -92,7 +92,7 @@ public class ContainerServerApplication implements EnvironmentAware {
 			return (ConfigurableApplicationContext) this.containerContext.getParent();
 		}
 		else {
-			log.error("The container has not been initialized yet.");
+			logger.error("The container has not been initialized yet.");
 			return null;
 		}
 	}
@@ -171,7 +171,7 @@ public class ContainerServerApplication implements EnvironmentAware {
 		if (e.getCause() instanceof BindException) {
 			BindException be = (BindException) e.getCause();
 			for (FieldError error : be.getFieldErrors()) {
-				log.error(String.format("the value '%s' is not allowed for property '%s'",
+				logger.error(String.format("the value '%s' is not allowed for property '%s'",
 						error.getRejectedValue(),
 						error.getField()));
 			}

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsStoreMessageHandler.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsStoreMessageHandler.java
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
  */
 public class HdfsStoreMessageHandler extends AbstractMessageHandler implements SmartLifecycle {
 
-	private static final Log log = LogFactory.getLog(HdfsStoreMessageHandler.class);
+	private static final Log logger = LogFactory.getLog(HdfsStoreMessageHandler.class);
 
 	private volatile boolean autoStartup = true;
 
@@ -76,12 +76,12 @@ public class HdfsStoreMessageHandler extends AbstractMessageHandler implements S
 			if (!this.running) {
 				this.doStart();
 				this.running = true;
-				if (log.isInfoEnabled()) {
-					log.info("started " + this);
+				if (logger.isInfoEnabled()) {
+					logger.info("started " + this);
 				}
 				else {
-					if (log.isDebugEnabled()) {
-						log.debug("already started " + this);
+					if (logger.isDebugEnabled()) {
+						logger.debug("already started " + this);
 					}
 				}
 			}
@@ -98,13 +98,13 @@ public class HdfsStoreMessageHandler extends AbstractMessageHandler implements S
 			if (this.running) {
 				this.doStop();
 				this.running = false;
-				if (log.isInfoEnabled()) {
-					log.info("stopped " + this);
+				if (logger.isInfoEnabled()) {
+					logger.info("stopped " + this);
 				}
 			}
 			else {
-				if (log.isDebugEnabled()) {
-					log.debug("already stopped " + this);
+				if (logger.isDebugEnabled()) {
+					logger.debug("already stopped " + this);
 				}
 			}
 		}
@@ -181,7 +181,7 @@ public class HdfsStoreMessageHandler extends AbstractMessageHandler implements S
 			storeWriter.close();
 		}
 		catch (Exception e) {
-			log.error("Error closing writer", e);
+			logger.error("Error closing writer", e);
 		}
 	};
 


### PR DESCRIPTION
- Add `AdminPortAvailablityInitializer` to check if the admin port being used is already in use
  - Throw `AdminPortNotAvailableException` if the port is in use
- Handle any `EmbeddedServletContainerException` and exit the admin server if thrown
