### PR TITLE
Use EventuallyMatcher for module tests

### DIFF
--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/RuntimeCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/RuntimeCommandTests.java
@@ -17,13 +17,18 @@
 package org.springframework.xd.shell.command;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.xd.shell.command.fixtures.XDMatchers.eventually;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
 import org.junit.Test;
 
 import org.springframework.shell.core.CommandResult;
@@ -33,9 +38,10 @@ import org.springframework.xd.shell.util.TableRow;
 
 
 /**
- * Runtime commands tests
+ * Runtime commands tests.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Patrick Peralta
  */
 public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 
@@ -48,7 +54,7 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 		Table table = (Table) cmdResult.getResult();
 		for (TableRow row : table.getRows()) {
 			// Verify host name & ip address are not empty
-			assertTrue(!StringUtils.isEmpty(row.getValue(2)) && !StringUtils.isEmpty(row.getValue(3)));
+			assertTrue(StringUtils.hasText(row.getValue(2)) && StringUtils.hasText(row.getValue(3)));
 		}
 		// Verify there should be at least one container in the list.
 		assertTrue(table.getRows().size() > 0);
@@ -59,16 +65,8 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 		logger.info("List runtime modules");
 		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
-		CommandResult cmdResult = executeCommand("runtime modules");
-		Table table = (Table) cmdResult.getResult();
-		List<TableRow> fooStreamModules = new ArrayList<TableRow>();
-		for (TableRow row : table.getRows()) {
-			// match by group name
-			if (row.getValue(1).contains(streamName)) {
-				fooStreamModules.add(row);
-			}
-		}
-		assertEquals(2, fooStreamModules.size());
+
+		assertThat(2, eventually(moduleCountForStream(streamName)));
 	}
 
 	@Test
@@ -78,17 +76,7 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 		stream().create(streamName, "time | log");
 		stream().undeploy(streamName);
 
-		CommandResult cmdResult = executeCommand("runtime modules");
-		Table table = (Table) cmdResult.getResult();
-		List<TableRow> fooStreamModules = new ArrayList<TableRow>();
-		for (TableRow row : table.getRows()) {
-			// match by group name
-			if (row.getValue(1).contains(streamName)) {
-				fooStreamModules.add(row);
-			}
-		}
-		assertEquals(String.format("modules still exist after undeploy: %s", fooStreamModules),
-				0, fooStreamModules.size());
+		assertThat(0, eventually(moduleCountForStream(streamName)));
 	}
 
 	@Test
@@ -97,20 +85,16 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
 
-		Table table = (Table) executeCommand("runtime modules").getResult();
-		List<TableRow> runtimeModules = new ArrayList<TableRow>();
-		for (TableRow row : table.getRows()) {
-			// match by group name
-			if (row.getValue(1).contains(streamName)) {
-				runtimeModules.add(row);
-			}
-		}
+		assertThat(2, eventually(moduleCountForStream(streamName)));
+
+		List<TableRow> runtimeModules = getRuntimeModulesForStream(streamName);
+
 		// Get containerId for a runtime module
 		String containerId = runtimeModules.get(0).getValue(2);
 		CommandResult cmdResult = executeCommand("runtime modules --containerId " + containerId);
-		Table table1 = (Table) cmdResult.getResult();
+		Table table = (Table) cmdResult.getResult();
 		List<TableRow> fooStreamModules = new ArrayList<TableRow>();
-		for (TableRow row : table1.getRows()) {
+		for (TableRow row : table.getRows()) {
 			// Verify all the rows have the same containerId
 			assertTrue(row.getValue(2).equals(containerId));
 			// match by group name
@@ -119,7 +103,7 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 			}
 		}
 		// Verify the module is listed for the containerId
-		assertTrue(!fooStreamModules.isEmpty());
+		assertFalse(fooStreamModules.isEmpty());
 	}
 
 	@Test
@@ -131,4 +115,94 @@ public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 		Table table = (Table) cmdResult.getResult();
 		assertEquals(0, table.getRows().size());
 	}
+
+	/**
+	 * Return a list of runtime modules for the stream name.
+	 *
+	 * @param streamName name of stream for which to obtain runtime modules
+	 * @return list of table rows containing runtime module information
+	 *         for the requested stream
+	 */
+	private List<TableRow> getRuntimeModulesForStream(String streamName) {
+		CommandResult cmdResult = executeCommand("runtime modules");
+		Table table = (Table) cmdResult.getResult();
+		List<TableRow> modules = new ArrayList<TableRow>();
+		for (TableRow row : table.getRows()) {
+			if (row.getValue(1).contains(streamName)) {
+				modules.add(row);
+			}
+		}
+		return modules;
+	}
+
+	/**
+	 * Return a matcher that determines if the number of deployed modules
+	 * for a stream matches the expected value.
+	 *
+	 * @param streamName name of stream for which to obtain number of deployed modules
+	 * @return matcher that determines if the number of modules matches
+	 */
+	private ModuleCountMatcher moduleCountForStream(String streamName) {
+		return new ModuleCountMatcher(streamName);
+	}
+
+
+	/**
+	 * Matcher that determines if the number of deployed modules for
+	 * a stream matches the expected value.
+	 */
+	class ModuleCountMatcher extends DiagnosingMatcher<Integer> {
+
+		/**
+		 * Name of stream for which to obtain number of deployed modules.
+		 */
+		private final String streamName;
+
+		/**
+		 * Construct a {@code ModuleCountMatcher}.
+		 * @param streamName name of stream for which to obtain
+		 *                   number of deployed modules.
+		 */
+		ModuleCountMatcher(String streamName) {
+			this.streamName = streamName;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 * <p>
+		 * Return true if the integer (passed in as {@code item})
+		 * matches the number of deployed modules.
+		 * </p>
+		 */
+		@Override
+		protected boolean matches(Object item, Description description) {
+			int size = (Integer) item;
+			List<TableRow> list = getRuntimeModulesForStream(streamName);
+			if (list.size() == size) {
+				return true;
+			}
+			else {
+				description.appendText("Expected ")
+						.appendValue(size)
+						.appendText(" number of modules for stream ")
+						.appendText(streamName)
+						.appendText(" in list ")
+						.appendValue(list)
+						.appendText("; instead there are ")
+						.appendValue(list.size())
+						.appendText(System.lineSeparator());
+				return false;
+			}
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("number of modules for stream ")
+					.appendText(streamName);
+		}
+	}
+
 }


### PR DESCRIPTION
Added custom matcher to invoke shell command to obtain stream modules. Combined with `EventuallyMatcher` this allows enough time to ensure that modules are deployed or undeployed without inserting arbitrary sleeps.
