### PR TITLE
Renamed classes

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerListener.java
@@ -76,7 +76,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 	 */
 	private final ContainerRepository containerRepository;
 
-	// todo: make this pluggable and/or refactor to avoid duplication with StreamListener
+	// todo: make this pluggable and/or refactor to avoid duplication with StreamDeploymentListener
 	private final ContainerMatcher containerMatcher = new DefaultContainerMatcher();
 
 	/**
@@ -176,7 +176,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 	 * @param data node data for the container that arrived
 	 */
 	private void onChildAdded(CuratorFramework client, ChildData data) throws Exception {
-		// TODO: there is duplicate code here and JobListener/StreamListener. These
+		// TODO: there is duplicate code here and JobDeploymentListener/StreamDeploymentListener. These
 		// should be refactored into a JobDeployer/StreamDeployer class
 
 		final Container container = new Container(Paths.stripPath(data.getPath()), mapBytesUtility.toMap(data.getData()));
@@ -202,8 +202,8 @@ public class ContainerListener implements PathChildrenCacheListener {
 			Stat stat = client.checkExists().forPath(
 					new JobDeploymentsPath().setJobName(jobName).setModuleLabel(moduleLabel).build());
 			// if stat is null, this means that the job deployment request was written out
-			// to ZK but JobListener hasn't picked it up yet; in that case skip this job
-			// deployment since JobListener will handle it
+			// to ZK but JobDeploymentListener hasn't picked it up yet; in that case skip this job
+			// deployment since JobDeploymentListener will handle it
 			if (stat != null && stat.getNumChildren() == 0) {
 				// no ephemeral nodes under the job module path; this job should be deployed
 				try {
@@ -380,7 +380,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 				String moduleLabel = moduleDeploymentsPath.getModuleLabel();
 
 				if (ModuleType.job.toString().equals(moduleType)) {
-					Iterator<Container> iterator = containerMatcher.match(JobListener.createJobModuleDescriptor(streamName),
+					Iterator<Container> iterator = containerMatcher.match(JobDeploymentListener.createJobModuleDescriptor(streamName),
 							containerRepository).iterator();
 					if (iterator.hasNext()) {
 						Container target = iterator.next();

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
@@ -91,7 +91,6 @@ import org.springframework.xd.module.support.ParentLastURLClassLoader;
  * @author David Turanski
  */
 // todo: Rename ContainerServer or ModuleDeployer since it's driven by callbacks and not really a "server".
-// Likewise consider the AdminServer being renamed to StreamDeployer since that is also callback-driven.
 public class ContainerRegistrar implements ApplicationListener<ContextRefreshedEvent>, ApplicationContextAware,
 		BeanClassLoaderAware {
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
@@ -52,12 +52,12 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
  * @author Patrick Peralta
  * @author Mark Fisher
  */
-public class JobListener implements PathChildrenCacheListener {
+public class JobDeploymentListener implements PathChildrenCacheListener {
 
 	/**
 	 * Logger.
 	 */
-	private static final Logger LOG = LoggerFactory.getLogger(JobListener.class);
+	private static final Logger LOG = LoggerFactory.getLogger(JobDeploymentListener.class);
 
 	/**
 	 * Provides access to the current container list.
@@ -86,13 +86,13 @@ public class JobListener implements PathChildrenCacheListener {
 	private final XDStreamParser parser;
 
 	/**
-	 * Construct a JobListener.
+	 * Construct a JobDeploymentListener.
 	 *
 	 * @param containerRepository repository to obtain container data
 	 * @param moduleDefinitionRepository repository to obtain module data
 	 * @param moduleOptionsMetadataResolver resolver for module options metadata
 	 */
-	public JobListener(ContainerRepository containerRepository,
+	public JobDeploymentListener(ContainerRepository containerRepository,
 			ModuleDefinitionRepository moduleDefinitionRepository,
 			ModuleOptionsMetadataResolver moduleOptionsMetadataResolver) {
 		this.containerRepository = containerRepository;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
@@ -53,12 +53,12 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
  * @author Patrick Peralta
  * @author Mark Fisher
  */
-public class StreamListener implements PathChildrenCacheListener {
+public class StreamDeploymentListener implements PathChildrenCacheListener {
 
 	/**
 	 * Logger.
 	 */
-	private final Logger logger = LoggerFactory.getLogger(StreamListener.class);
+	private final Logger logger = LoggerFactory.getLogger(StreamDeploymentListener.class);
 
 	/**
 	 * Provides access to the current container list.
@@ -85,7 +85,7 @@ public class StreamListener implements PathChildrenCacheListener {
 	 * {@link org.apache.curator.framework.recipes.cache.PathChildrenCache}.
 	 *
 	 * @see #childEvent
-	 * @see org.springframework.xd.dirt.server.StreamListener.EventHandler
+	 * @see StreamDeploymentListener.EventHandler
 	 */
 	private final ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactory() {
 		@Override
@@ -97,13 +97,13 @@ public class StreamListener implements PathChildrenCacheListener {
 	});
 
 	/**
-	 * Construct a StreamListener.
+	 * Construct a StreamDeploymentListener.
 	 *
 	 * @param containerRepository repository to obtain container data
 	 * @param moduleDefinitionRepository repository to obtain module data
 	 * @param moduleOptionsMetadataResolver resolver for module options metadata
 	 */
-	public StreamListener(ContainerRepository containerRepository,
+	public StreamDeploymentListener(ContainerRepository containerRepository,
 			StreamDefinitionRepository streamDefinitionRepository,
 			ModuleDefinitionRepository moduleDefinitionRepository,
 			ModuleOptionsMetadataResolver moduleOptionsMetadataResolver) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperJobRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperJobRepository.java
@@ -96,13 +96,13 @@ public class ZooKeeperJobRepository implements JobRepository, InitializingBean {
 
 	@Override
 	public <S extends Job> S save(S entity) {
-		// job instances are "saved" when a JobListener deploys a job
+		// job instances are "saved" when a JobDeploymentListener deploys a job
 		return entity;
 	}
 
 	@Override
 	public <S extends Job> Iterable<S> save(Iterable<S> entities) {
-		// job instances are "saved" when a JobListener deploys a job
+		// job instances are "saved" when a JobDeploymentListener deploys a job
 		return entities;
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamRepository.java
@@ -107,13 +107,13 @@ public class ZooKeeperStreamRepository implements StreamRepository, Initializing
 
 	@Override
 	public <S extends Stream> S save(S entity) {
-		// stream instances are "saved" when a StreamListener deploys a stream
+		// stream instances are "saved" when a StreamDeploymentListener deploys a stream
 		return entity;
 	}
 
 	@Override
 	public <S extends Stream> Iterable<S> save(Iterable<S> entities) {
-		// stream instances are "saved" when a StreamListener deploys a stream
+		// stream instances are "saved" when a StreamDeploymentListener deploys a stream
 		return entities;
 	}
 

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/admin-server.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/internal/admin-server.xml
@@ -10,7 +10,7 @@
 
 	<context:component-scan base-package="org.springframework.xd.dirt.stream.completion" />
 
-	<bean id="adminServer" class="org.springframework.xd.dirt.server.AdminServer">
+	<bean id="deploymentSupervisor" class="org.springframework.xd.dirt.server.DeploymentSupervisor">
 		<constructor-arg ref="zooKeeperConnection"/>
 		<constructor-arg ref="streamDefinitionRepository"/>
 		<constructor-arg ref="moduleDefinitionRepository"/>


### PR DESCRIPTION
`JobListener` and `StreamListener` were renamed to `JobDeploymentListener` and `StreamDeploymentListener` to more accurately reflect their roles. `AdminServer` was
renamed to `DeploymentSupervisor` since this class is not actually a server in a traditional sense
(i.e. it does not directly respond to requests) but instead is the single process in the system that
is responsible for managing containers and deployments.
