### PR TITLE
Fix Job Repo\Plugin tests

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -101,7 +100,6 @@ public class JobPluginTests extends RandomConfigurationSupport {
 	@ImportResource({ "classpath:/META-INF/spring-xd/batch/batch.xml",
 		"classpath:/META-INF/spring-xd/transports/local-bus.xml" })
 	@EnableAutoConfiguration
-	@EnableBatchProcessing
 	public static class SharedConfiguration {
 
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobRepoTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobRepoTests.java
@@ -34,13 +34,13 @@ import org.springframework.batch.core.job.SimpleJob;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.test.SpringApplicationContextLoader;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.xd.batch.hsqldb.server.HsqlDatasourceConfiguration;
 import org.springframework.xd.batch.hsqldb.server.HsqlServerApplication;
 import org.springframework.xd.dirt.server.ParentConfiguration;
 import org.springframework.xd.test.RandomConfigurationSupport;
@@ -54,7 +54,7 @@ import org.springframework.xd.test.RandomConfigurationSupport;
  * 
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = { HsqlDatasourceConfiguration.class, HsqlServerApplication.class,
+@ContextConfiguration(classes = { EmbeddedDataSourceConfiguration.class, HsqlServerApplication.class,
 	ParentConfiguration.class }, loader = SpringApplicationContextLoader.class)
 @ActiveProfiles({ HsqlServerApplication.HSQLDBSERVER_PROFILE })
 @DirtiesContext


### PR DESCRIPTION
- Fix the `JobRepoTests` to use embedded datasource rather than explicit datasource
- Remove `EnableBatchProcessing` from JobPluginTests
