### PR TITLE
Fix servlet-api dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1398,6 +1398,7 @@ project('spring-xd-shell') {
 		compile "org.springframework.shell:spring-shell:$springShellVersion"
 		compile project(":spring-xd-rest-client")
 		compile ("org.springframework.data:spring-data-hadoop:$springDataHadoopVersion") {
+			exclude group: 'javax.servlet'
 			exclude group: 'org.mortbay.jetty'
 			exclude group: 'hsqldb'
 		}
@@ -1479,7 +1480,9 @@ project('spring-xd-test-fixtures') {
 		compile "com.icegreen:greenmail:1.3.1b"
 		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
 		compile "org.springframework:spring-jms:$springVersion"
-		compile "org.apache.activemq:activemq-core:5.6.0"
+		compile ("org.apache.activemq:activemq-core:5.6.0") {
+			exclude group: 'org.mortbay.jetty'
+		}
 		compile "org.springframework:spring-web:$springVersion"
 		runtime "log4j:log4j:$log4jVersion",
 				"org.slf4j:jcl-over-slf4j:$slf4jVersion",


### PR DESCRIPTION
- Fix servlet-api dependency in `spring-xd-test-fixtures` and `spring-xd-shell` sub-projects
