### PR TITLE
Fix DIRT dependency on xerces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -400,6 +400,7 @@ project('spring-xd-dirt') {
 		compile "org.springframework.integration:spring-integration-ftp:$springIntegrationVersion"
 		compile "org.springframework.integration:spring-integration-groovy:$springIntegrationVersion"
 		compile "org.springframework.integration:spring-integration-http:$springIntegrationVersion"
+		configurations.compile.exclude(group: "xerces")
 		compile "org.springframework.integration:spring-integration-jmx:$springIntegrationVersion"
 		compile "org.springframework.integration:spring-integration-redis:$springIntegrationVersion"
 		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
@@ -1414,7 +1415,6 @@ project('spring-xd-shell') {
 				"org.codehaus.jackson:jackson-mapper-asl:$jackson1Version"
 		compile "commons-io:commons-io:$commonsIoVersion"
 		compile "org.apache.ftpserver:ftpserver-core:$ftpServerVersion"
-
 	}
 
 	// skip the startScripts task to avoid default start script generation


### PR DESCRIPTION
- Exclude `xerces` from spring-xd-dirt compile dependency
