### PR TITLE
XD-1596 Expose Common Rabbit Source/Sink Options

### DIFF
--- a/modules/sink/rabbit/config/rabbit.xml
+++ b/modules/sink/rabbit/config/rabbit.xml
@@ -13,14 +13,21 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<int-amqp:outbound-channel-adapter
-		id="input" amqp-template="rabbitTemplate" exchange-name="${exchange}"
+		id="input"
+		default-delivery-mode="${deliveryMode}"
+		amqp-template="rabbitTemplate"
+		exchange-name="${exchange}"
 		routing-key-expression="${routingKey}" />
 
-	<rabbit:template id="rabbitTemplate" connection-factory="rabbitConnectionFactory"/>
+	<rabbit:template id="rabbitTemplate"
+		connection-factory="rabbitConnectionFactory"
+		message-converter="messageConverter" />
 
 	<rabbit:connection-factory id="rabbitConnectionFactory" host="${host}"
 		port="${port}" virtual-host="${vhost}"
 		username="${username}" password="${password}"/>
+
+	<bean id="messageConverter" class="${converterClass}" />
 
 	<beans profile="cloud" xmlns="http://www.springframework.org/schema/beans">
 		<cloud:rabbit-connection-factory id="rabbitConnectionFactory"

--- a/modules/source/rabbit/config/rabbit.xml
+++ b/modules/source/rabbit/config/rabbit.xml
@@ -13,14 +13,31 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<int-amqp:inbound-channel-adapter
-		auto-startup="false" queue-names="${queues}"
-		channel="output" connection-factory="rabbitConnectionFactory" />
+		auto-startup="false"
+		channel="output"
+		listener-container="listenerContainer"
+		message-converter="messageConverter" />
+
+	<bean id="listenerContainer" class="org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer">
+		<property name="connectionFactory" ref="rabbitConnectionFactory" />
+		<property name="acknowledgeMode" value="#{T(org.springframework.amqp.core.AcknowledgeMode).${ackMode}}" />
+		<property name="autoStartup" value="false" />
+		<property name="channelTransacted" value="${transacted}" />
+		<property name="concurrentConsumers" value="${concurrency}" />
+		<property name="defaultRequeueRejected" value="${requeue}" />
+		<property name="maxConcurrentConsumers" value="${maxConcurrency}" />
+		<property name="prefetchCount" value="${prefetch}" />
+		<property name="queueNames" value="${queues}" />
+		<property name="txSize" value="${txSize}" />
+	</bean>
+
+	<bean id="messageConverter" class="${converterClass}" />
 
 	<int:channel id="output" />
 
 	<rabbit:connection-factory id="rabbitConnectionFactory" host="${host}"
 		port="${port}" virtual-host="${vhost}"
-		username="${username}" password="${password}"/>
+		username="${username}" password="${password}" />
 
 	<beans profile="cloud" xmlns="http://www.springframework.org/schema/beans">
 		<cloud:rabbit-connection-factory id="rabbitConnectionFactory"

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSinkOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSinkOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,27 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
-import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_STREAM_NAME;
-
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
+import org.springframework.xd.module.options.spi.ModulePlaceholders;
+
 
 /**
  * Captures options to the {@code rabbit} sink module.
- * 
+ *
  * @author Eric Bottard
+ * @author Gary Russell
  */
 @Mixin(RabbitConnectionMixin.class)
 public class RabbitSinkOptionsMetadata {
 
 	private String exchange = "";
 
-	private String routingKey = "'" + XD_STREAM_NAME + "'";
+	private String routingKey = "'" + ModulePlaceholders.XD_STREAM_NAME + "'";
+
+	private String deliveryMode = "PERSISTENT";
+
+	private String converterClass = "org.springframework.amqp.support.converter.SimpleMessageConverter";
 
 
 	public String getExchange() {
@@ -51,6 +56,24 @@ public class RabbitSinkOptionsMetadata {
 	@ModuleOption("the routing key to be passed with the message, as a SpEL expression")
 	public void setRoutingKey(String routingKey) {
 		this.routingKey = routingKey;
+	}
+
+	public String getDeliveryMode() {
+		return deliveryMode;
+	}
+
+	@ModuleOption("the delivery mode (PERSISTENT, NON_PERSISTENT)")
+	public void setDeliveryMode(String deliveryMode) {
+		this.deliveryMode = deliveryMode;
+	}
+
+	public String getConverterClass() {
+		return converterClass;
+	}
+
+	@ModuleOption("the class name of the message converter")
+	public void setConverterClass(String converterClass) {
+		this.converterClass = converterClass;
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSourceOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,38 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
-import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_STREAM_NAME;
-
 import org.hibernate.validator.constraints.NotBlank;
 
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
+import org.springframework.xd.module.options.spi.ModulePlaceholders;
 
 /**
  * Describes options to the {@code rabbit} source module.
- * 
+ *
  * @author Eric Bottard
+ * @author Gary Russell
  */
 @Mixin(RabbitConnectionMixin.class)
 public class RabbitSourceOptionsMetadata {
 
-	private String queues = XD_STREAM_NAME;
+	private String queues = ModulePlaceholders.XD_STREAM_NAME;
+
+	private String ackMode = "AUTO";
+
+	private boolean transacted = false;
+
+	private int concurrency = 1;
+
+	private boolean requeue = true;
+
+	private int maxConcurrency = 1;
+
+	private int prefetch = 1;
+
+	private int txSize = 1;
+
+	private String converterClass = "org.springframework.amqp.support.converter.SimpleMessageConverter";
 
 	@NotBlank
 	public String getQueues() {
@@ -42,4 +58,78 @@ public class RabbitSourceOptionsMetadata {
 	public void setQueues(String queues) {
 		this.queues = queues;
 	}
+
+	@NotBlank
+	public String getAckMode() {
+		return ackMode.toUpperCase();
+	}
+
+	@ModuleOption("the acknowledge mode (AUTO, NONE, MANUAL)")
+	public void setAckMode(String ackMode) {
+		this.ackMode = ackMode;
+	}
+
+	public boolean isTransacted() {
+		return transacted;
+	}
+
+	@ModuleOption("true if the channel is to be transacted")
+	public void setTransacted(boolean transacted) {
+		this.transacted = transacted;
+	}
+
+	public int getConcurrency() {
+		return concurrency;
+	}
+
+	@ModuleOption("the minimum number of consumers")
+	public void setConcurrency(int concurrency) {
+		this.concurrency = concurrency;
+	}
+
+	public boolean isRequeue() {
+		return requeue;
+	}
+
+	@ModuleOption("whether rejected messages will be requeued by default")
+	public void setRequeue(boolean requeue) {
+		this.requeue = requeue;
+	}
+
+	public int getMaxConcurrency() {
+		return maxConcurrency;
+	}
+
+	@ModuleOption("the maximum number of consumers")
+	public void setMaxConcurrency(int maxConcurrency) {
+		this.maxConcurrency = maxConcurrency;
+	}
+
+	public int getPrefetch() {
+		return prefetch;
+	}
+
+	@ModuleOption("the prefetch size")
+	public void setPrefetch(int prefetch) {
+		this.prefetch = prefetch;
+	}
+
+	public int getTxSize() {
+		return txSize;
+	}
+
+	@ModuleOption("the number of messages to process before acking")
+	public void setTxSize(int txSize) {
+		this.txSize = txSize;
+	}
+
+	public String getConverterClass() {
+		return converterClass;
+	}
+
+	@ModuleOption("the class name of the message converter")
+	public void setConverterClass(String converterClass) {
+		this.converterClass = converterClass;
+	}
+
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-1596

Source:

Declare the container as a `<bean/>` and expose common
configuration options (concurrency etc), including
`maxConcurrency` which is not currently available on the
Spring Integration namespace.

Sink:

Add delivery mode.

Both:

Allow configuration of the message converter by class
name (e.g. Simple Vs. JSON).

Exercised by `RabbitSourceAndRabbitSinkTests`
