### PR TITLE
XD-1344 Cannot undeploy stream that was created and deployed with a '.' ...

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
@@ -73,12 +73,11 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 		tokenStreamPointer = 0;
 		StreamNode ast = eatStream();
 
-		// Check the stream name
-		if (ast.getName() != null) {
-			if (!isValidStreamName(ast.getName())) {
-				throw new StreamDefinitionException(ast.getName(), 0, XDDSLMessages.ILLEGAL_STREAM_NAME, ast.getName());
-			}
+		// Check the stream name, however it was specified
+		if (ast.getName() != null && !isValidStreamName(ast.getName())) {
+			throw new StreamDefinitionException(ast.getName(), 0, XDDSLMessages.ILLEGAL_STREAM_NAME, ast.getName());
 		}
+
 		if (name != null && !isValidStreamName(name)) {
 			throw new StreamDefinitionException(name, 0, XDDSLMessages.ILLEGAL_STREAM_NAME, name);
 		}
@@ -505,7 +504,8 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 	}
 
 	/**
-	 * Verify the supplied name is a valid stream name. Valid stream names obey the same rules as Java identifiers.
+	 * Verify the supplied name is a valid stream name. Valid stream names must follow the same rules as java
+	 * identifiers, with the additional option to use a hyphen ('-') after the first character.
 	 *
 	 * @param streamname the name to validate
 	 * @return true if name is valid

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -738,7 +738,6 @@ public class StreamConfigParserTests {
 		catch (StreamDefinitionException e) {
 			assertEquals(XDDSLMessages.ILLEGAL_STREAM_NAME, e.getMessageCode());
 			assertEquals(0, e.getPosition());
-			e.printStackTrace();
 			assertEquals(streamName, e.getInserts()[0]);
 		}
 	}


### PR DESCRIPTION
...in the name

The rule supported here is:
- first character must obey isJavaIdentifierStart()
- remaining characters must be isJavaIdentifierPart() or hyphen ('-')

I am not able to run all the tests locally so can't verify if there are some tests that use funky stream names which are now failing due to this change.
