### PR TITLE
XD-1389 Partitioned Batch Improvements

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpHdfsJobOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpHdfsJobOptionsMetadata.java
@@ -21,7 +21,7 @@ import org.springframework.xd.module.options.spi.ModuleOption;
 
 /**
  * Describes the options for the ftphdfs job.
- * 
+ *
  * @author Gary Russell
  */
 public class FtpHdfsJobOptionsMetadata {
@@ -34,7 +34,7 @@ public class FtpHdfsJobOptionsMetadata {
 
 	private String password;
 
-	private int stepConcurrency = 2;
+	private long partitionResultsTimeout = 300000;
 
 	public String getHost() {
 		return host;
@@ -72,13 +72,14 @@ public class FtpHdfsJobOptionsMetadata {
 		this.password = password;
 	}
 
-	public int getStepConcurrency() {
-		return stepConcurrency;
+
+	public long getPartitionResultsTimeout() {
+		return partitionResultsTimeout;
 	}
 
-	@ModuleOption("the maximum number of concurrent steps in each container")
-	public void setStepConcurrency(int stepConcurrency) {
-		this.stepConcurrency = stepConcurrency;
+	@ModuleOption("time (ms) that the partition handler will wait for results, default 5 mins")
+	public void setPartitionResultsTimeout(long partitionResultsTimeout) {
+		this.partitionResultsTimeout = partitionResultsTimeout;
 	}
 
 }

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
@@ -19,11 +19,7 @@
 
 	<!-- This is the "remote" worker -->
 
-	<int:channel id="stepExecutionRequests.input">
-		<int:dispatcher task-executor="stepExecutor" />
-	</int:channel>
-
-	<task:executor id="stepExecutor" pool-size="${stepConcurrency:2}" />
+	<int:channel id="stepExecutionRequests.input" />
 
 	<int:channel id="stepExecutionReplies.output" />
 
@@ -52,7 +48,7 @@
 		<property name="messagingOperations">
 			<bean class="org.springframework.integration.core.MessagingTemplate">
 				<property name="defaultChannel" ref="stepExecutionRequests.output" />
-				<property name="receiveTimeout" value="60000" />
+				<property name="receiveTimeout" value="${partitionResultsTimeout:3600000}" />
 			</bean>
 		</property>
 		<property name="stepName" value="step1" />

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/JobCommandWithHadoopTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/JobCommandWithHadoopTests.java
@@ -34,7 +34,7 @@ import org.springframework.xd.test.hadoop.HadoopFileSystemTestSupport;
 
 
 /**
- * 
+ *
  * @author Gary Russell
  */
 public class JobCommandWithHadoopTests extends AbstractJobIntegrationTest {
@@ -61,8 +61,8 @@ public class JobCommandWithHadoopTests extends AbstractJobIntegrationTest {
 
 		try {
 			int port = server.getPort();
-			executeJobCreate("myftphdfs", "ftphdfs --stepConcurrency=2 --port=" + port);
-			checkForJobInList("myftphdfs", "ftphdfs --stepConcurrency=2 --port=" + port, true);
+			executeJobCreate("myftphdfs", "ftphdfs --partitionResultsTimeout=120000 --port=" + port);
+			checkForJobInList("myftphdfs", "ftphdfs --partitionResultsTimeout=120000 --port=" + port, true);
 			executeJobLaunch("myftphdfs", "{\"-remoteDirectory\":\"ftpSource\",\"hdfsDirectory\":\"foo\"}");
 
 			Table jobExecutions = listJobExecutions();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-1389

Occasional NPE in ftphdfs job.

There was a fixed timeout of 60 seconds for the partition results
to be returned to master.

The spring-batch `MessageChannelPartitionHandler` croaks with
an NPE on timeout - this has now been corrected on master (batch).

In the config import file, Increase the default timeout to 1 hour
and make it configurable using the `partitionResultsTimeout` property.

In the ftphdfs job properties, make the default 5 minutes.

Also, remove `stepConcurrency`. Step concurrency will be handled
by the upcoming partitioning changes (in the message bus) XD-1338.
