### PR TITLE
XD-1658 TwitterStream Source Acceptance Test

### DIFF
--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
@@ -25,6 +25,7 @@ import org.springframework.xd.test.fixtures.SimpleHttpSource;
 import org.springframework.xd.test.fixtures.SimpleTailSource;
 import org.springframework.xd.test.fixtures.TcpSource;
 import org.springframework.xd.test.fixtures.TwitterSearchSource;
+import org.springframework.xd.test.fixtures.TwitterStreamSource;
 
 
 /**
@@ -90,7 +91,7 @@ public class Sources {
 
 	/**
 	 * Construct a new SimpleTailSource with the the provided file name and delay
-	 * 
+	 *
 	 * @param delayInMillis on platforms that don't wait for a missing file to appear, how often (ms) to look for the
 	 *        file.
 	 * @param fileName the absolute path of the file to tail
@@ -131,7 +132,7 @@ public class Sources {
 
 	/**
 	 * Construct a TwitterSearchSource using that will search for the query string provided..
-	 * 
+	 *
 	 * @param query The string to search for on twitter.
 	 * @return An instance of the twitterSearchSource fixture.
 	 */
@@ -139,6 +140,17 @@ public class Sources {
 		Assert.hasText(query, "query must not be empty nor null");
 		return TwitterSearchSource.withDefaults(xdEnvironment.getTwitterConsumerKey(),
 				xdEnvironment.getTwitterConsumerSecretKey(), query);
+	}
+
+	/**
+	 * Construct a TwitterStreamSource fixture..
+	 *
+	 * @return An instance of the twitterStreamSource fixture.
+	 */
+	public TwitterStreamSource twitterStream() {
+		return new TwitterStreamSource(xdEnvironment.getTwitterConsumerKey(),
+				xdEnvironment.getTwitterConsumerSecretKey(), xdEnvironment.getTwitterAccessToken(),
+				xdEnvironment.getTwitterAccessTokenSecret());
 	}
 
 }

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
@@ -242,6 +242,7 @@ public class XdEc2Validation {
 		}
 	}
 
+
 	/**
 	 * generates the JMX query string for getting module data.
 	 * 

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEnvironment.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEnvironment.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Glenn Renfro
  */
+
 public class XdEnvironment implements BeanClassLoaderAware {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(XdEnvironment.class);
@@ -125,6 +126,12 @@ public class XdEnvironment implements BeanClassLoaderAware {
 
 	@Value("${twitterConsumerSecretKey}")
 	private String twitterConsumerSecretKey;
+
+	@Value("${twitterAccessToken}")
+	private String twitterAccessToken;
+
+	@Value("${twitterAccessTokenSecret}")
+	private String twitterAccessTokenSecret;
 
 	private SimpleDriverDataSource dataSource;
 
@@ -264,7 +271,6 @@ public class XdEnvironment implements BeanClassLoaderAware {
 		return twitterConsumerKey;
 	}
 
-
 	/**
 	 * The twitter consumer secret key
 	 *
@@ -274,6 +280,23 @@ public class XdEnvironment implements BeanClassLoaderAware {
 		return twitterConsumerSecretKey;
 	}
 
+	/**
+	 * The Twitter Access Token
+	 *
+	 * @return twitter access token
+	 */
+	public String getTwitterAccessToken() {
+		return twitterAccessToken;
+	}
+
+	/**
+	 * The Twitter Access Token Secret
+	 *
+	 * @return twitter access token secret
+	 */
+	public String getTwitterAccessTokenSecret() {
+		return twitterAccessTokenSecret;
+	}
 
 	/**
 	 * The hadoop name node that is available for this environment.

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TwitterStreamTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TwitterStreamTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.integration.test;
+
+import org.junit.Test;
+
+
+/**
+ * Test to verify that data is being received from twitter.
+ *
+ * @author Glenn Renfro
+ */
+
+public class TwitterStreamTest extends AbstractIntegrationTest {
+
+	@Test
+	public void twitterStream() throws Exception {
+
+		final String data = "screen_name";
+		stream(sources.twitterStream()
+				+ XD_DELIMETER
+				+ sinks.file());
+		this.waitForXD(2000);
+		assertContains(data);
+
+	}
+}

--- a/spring-xd-integration-test/src/test/resources/application-ec2.properties
+++ b/spring-xd-integration-test/src/test/resources/application-ec2.properties
@@ -29,8 +29,9 @@ jms_port=61616
 #Twitter Settings
 twitterConsumerKey=
 twitterConsumerSecretKey=
+twitterAccessToken=
+twitterAccessTokenSecret=
 
 #Hadoop Settings
 spring.hadoop.fsUri=hdfs://localhost:8020
 dfs.datanode.http.port=50075
-

--- a/spring-xd-integration-test/src/test/resources/application-singlenode.properties
+++ b/spring-xd-integration-test/src/test/resources/application-singlenode.properties
@@ -25,6 +25,8 @@ jms_port=61616
 #Twitter Settings
 twitterConsumerKey=
 twitterConsumerSecretKey=
+twitterAccessToken=
+twitterAccessTokenSecret=
 
 #Hadoop Settings
 spring.hadoop.fsUri=hdfs://localhost:8020

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TwitterStreamSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TwitterStreamSource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.test.fixtures;
+
+import org.springframework.util.Assert;
+
+
+/**
+ * A test fixture that allows testing of the 'TwitterStream' source module.
+ *
+ * @author Glenn Renfro
+ */
+public class TwitterStreamSource extends AbstractModuleFixture {
+
+
+	String consumerKey;
+
+	String consumerSecret;
+
+	String accessToken;
+
+	String accessTokenSecret;
+
+
+	/**
+	 * Initializes a TwitterStreamSource fixture.
+	 *
+	 * @param consumerKey
+	 * @param consumerSecret
+	 * @param accessToken
+	 * @param accessTokenSecret
+	 */
+	public TwitterStreamSource(String consumerKey, String consumerSecret, String accessToken, String accessTokenSecret) {
+		Assert.hasText(consumerKey, "the consumerKey must not be empty nor null");
+		Assert.hasText(consumerSecret, "the consumerSecret must not be empty nor null");
+		Assert.hasText(accessToken, "the accessToken must not be empty nor null");
+		Assert.hasText(accessTokenSecret, "the accessTokenSecret must not be empty nor null");
+
+		this.consumerKey = consumerKey;
+		this.consumerSecret = consumerSecret;
+		this.accessToken = accessToken;
+		this.accessTokenSecret = accessTokenSecret;
+	}
+
+	/**
+	 * Renders the DSL for this fixture.
+	 */
+	@Override
+	protected String toDSL() {
+		return "twitterstream --accessToken=" + accessToken + " --consumerKey=" + this.consumerKey
+				+ " --consumerSecret=" + consumerSecret + " --accessTokenSecret=" + accessTokenSecret + "  ";
+	}
+
+
+}


### PR DESCRIPTION
TwitterStreamSource Fixture was added to support this.
Verifies that data has been received by XD.
