### PR TITLE
XD-1663 Fix stream tap msg-bus's channel name

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractJobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractJobPlugin.java
@@ -44,6 +44,12 @@ public class AbstractJobPlugin extends AbstractMessageBusBinderPlugin {
 	}
 
 	@Override
+	protected String buildTapChannelName(Module module) {
+		throw new UnsupportedOperationException(
+				"Tap on job module is not valid as job module doesn't have an output channel.");
+	}
+
+	@Override
 	public boolean supports(Module module) {
 		return (module.getType() == ModuleType.job);
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -23,8 +23,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
-import org.springframework.xd.module.DeploymentMetadata;
-import org.springframework.xd.module.ModuleType;
 import org.springframework.xd.module.core.Module;
 import org.springframework.xd.module.core.Plugin;
 
@@ -80,6 +78,8 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 	protected abstract String getInputChannelName(Module module);
 
 	protected abstract String getOutputChannelName(Module module);
+
+	protected abstract String buildTapChannelName(Module module);
 
 	private void bindMessageConsumer(MessageChannel inputChannel, String inputChannelName) {
 		if (isChannelPubSub(inputChannelName)) {
@@ -147,13 +147,6 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 	private void unbindTapChannel(Module module) {
 		// Should this be unbindProducer() as there won't be multiple producers on the tap channel.
 		messageBus.unbindProducers(buildTapChannelName(module));
-	}
-
-	private String buildTapChannelName(Module module) {
-		Assert.isTrue(module.getType() != ModuleType.job, "Job module type not supported.");
-		DeploymentMetadata dm = module.getDeploymentMetadata();
-		// for Stream return channel name with indexed elements
-		return String.format("%s%s.%s.%s", TAP_CHANNEL_PREFIX, dm.getGroup(), module.getName(), dm.getIndex());
 	}
 
 	private boolean isChannelPubSub(String channelName) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
@@ -16,7 +16,9 @@
 
 package org.springframework.xd.dirt.plugins;
 
+import org.springframework.util.Assert;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
+import org.springframework.xd.module.DeploymentMetadata;
 import org.springframework.xd.module.ModuleType;
 import org.springframework.xd.module.core.Module;
 
@@ -41,6 +43,15 @@ public abstract class AbstractStreamPlugin extends AbstractMessageBusBinderPlugi
 	@Override
 	protected String getOutputChannelName(Module module) {
 		return module.getDeploymentMetadata().getOutputChannelName();
+	}
+
+	@Override
+	protected String buildTapChannelName(Module module) {
+		Assert.isTrue(module.getType() != ModuleType.job, "Job module type not supported.");
+		DeploymentMetadata dm = module.getDeploymentMetadata();
+		// for Stream return channel name with indexed elements
+		return String.format("%s%s%s.%s.%s", TAP_CHANNEL_PREFIX, "stream:", dm.getGroup(), module.getName(),
+				dm.getIndex());
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
@@ -137,7 +137,7 @@ public class ChannelNode extends AstNode {
 
 	public void resolve(StreamLookupEnvironment env) {
 		if (channelType == ChannelType.TAP_STREAM) {
-			String streamName = nameComponents.get(0);
+			String streamName = nameComponents.get(1);
 			StreamNode sn = env.lookupStream(streamName);
 			if (sn == null) {
 				throw new StreamDefinitionException("", -1, XDDSLMessages.UNRECOGNIZED_STREAM_REFERENCE, streamName);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
@@ -299,7 +299,6 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 			channelScopeComponents.remove(0); // remove 'tap'
 			if (tapping.equals("stream")) {
 				channelType = ChannelType.TAP_STREAM;
-				channelScopeComponents.remove(0);
 			}
 			else if (tapping.equals("job")) {
 				channelType = ChannelType.TAP_JOB;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
@@ -99,12 +99,12 @@ public class StreamPluginTests {
 		plugin.postProcessModule(module);
 		verify(bus).bindConsumer("foo.0", input);
 		verify(bus).bindProducer("foo.1", output);
-		verify(bus).bindPubSubProducer(eq("tap:foo.testing.1"), any(DirectChannel.class));
+		verify(bus).bindPubSubProducer(eq("tap:stream:foo.testing.1"), any(DirectChannel.class));
 		plugin.beforeShutdown(module);
 		plugin.removeModule(module);
 		verify(bus).unbindConsumer("foo.0", input);
 		verify(bus).unbindProducer("foo.1", output);
-		verify(bus).unbindProducers("tap:foo.testing.1");
+		verify(bus).unbindProducers("tap:stream:foo.testing.1");
 	}
 
 	@Test

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/XDStreamParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/XDStreamParserTests.java
@@ -181,7 +181,7 @@ public class XDStreamParserTests {
 		when(streamRepo.findOne("xxx")).thenReturn(new StreamDefinition("xxx", "http | file"));
 		List<ModuleDeploymentRequest> requests = parser.parse("test", "tap:stream:xxx.http > file", stream);
 		assertEquals(1, requests.size());
-		assertEquals("tap:xxx.http.0", requests.get(0).getSourceChannelName());
+		assertEquals("tap:stream:xxx.http.0", requests.get(0).getSourceChannelName());
 		assertEquals(ModuleType.sink, requests.get(0).getType());
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -405,7 +405,7 @@ public class StreamConfigParserTests {
 		parse("foo = http | bar | file");
 		StreamNode ast = parse("tap:stream:foo.bar > file");
 		assertEquals("[(tap:stream:foo.bar.1:0>18)>(ModuleNode:file:21>25)]", ast.stringify(true));
-		assertEquals("tap:foo.bar.1", ast.getSourceChannelNode().getChannelName());
+		assertEquals("tap:stream:foo.bar.1", ast.getSourceChannelNode().getChannelName());
 	}
 
 	@Test
@@ -432,7 +432,7 @@ public class StreamConfigParserTests {
 
 		ast = parse("tap:stream:mystream.http > file");
 		sourceChannelNode = ast.getSourceChannelNode();
-		assertEquals("tap:mystream.http.0", sourceChannelNode.getChannelName());
+		assertEquals("tap:stream:mystream.http.0", sourceChannelNode.getChannelName());
 	}
 
 	@Test
@@ -443,13 +443,13 @@ public class StreamConfigParserTests {
 
 		ast = parse("tap:stream:mystream.http > file");
 		sourceChannelNode = ast.getSourceChannelNode();
-		assertEquals("tap:mystream.http.0", sourceChannelNode.getChannelName());
+		assertEquals("tap:stream:mystream.http.0", sourceChannelNode.getChannelName());
 		assertEquals(ChannelType.TAP_STREAM, sourceChannelNode.getChannelType());
 
 		ast = parse("tap:stream:mystream > file");
 		sourceChannelNode = ast.getSourceChannelNode();
 		// After resolution the name has been properly setup
-		assertEquals("tap:mystream.http.0", sourceChannelNode.getChannelName());
+		assertEquals("tap:stream:mystream.http.0", sourceChannelNode.getChannelName());
 		assertEquals(ChannelType.TAP_STREAM, sourceChannelNode.getChannelType());
 	}
 
@@ -663,17 +663,17 @@ public class StreamConfigParserTests {
 	@Test
 	public void errorCases13() {
 		parse("mystream = http | transform | filter | transform | file");
-		checkForParseError("tap:stream:mystream.transform > file", XDDSLMessages.MODULE_REFERENCE_NOT_UNIQUE, 13,
+		checkForParseError("tap:stream:mystream.transform > file", XDDSLMessages.MODULE_REFERENCE_NOT_UNIQUE, 20,
 				"transform");
 		sn = parse("tap:stream:mystream.transform.1 > file");
-		assertEquals("tap:mystream.transform.1", sn.getSourceChannelNode().getChannelName());
+		assertEquals("tap:stream:mystream.transform.1", sn.getSourceChannelNode().getChannelName());
 	}
 
 	@Test
 	public void tapWithLabels() {
 		parse("mystream = http | flibble: transform | file");
 		sn = parse("tap:stream:mystream.flibble > file");
-		assertEquals("tap:mystream.transform.1", sn.getSourceChannelNode().getChannelName());
+		assertEquals("tap:stream:mystream.transform.1", sn.getSourceChannelNode().getChannelName());
 	}
 
 	@Test


### PR DESCRIPTION
- Allow `stream` string in tap's topic name
  - Fix StreamConfigParser not to remove the `stream` name component when parsing the `tap:stream:XXX`
- Move buildTapChannelName method
  - Move this method into Abstract Stream/Job Plugin
- Fix tests
