### PR TITLE
XD-1664 Remove singlenode prefix on a property

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -19,14 +19,14 @@
 #       enabled: false
 
 ---
-#Config for singlenode. Transport for single node may be overridden by --transport command line option 
+#Config for singlenode.
+#Transport for single node may be overridden by --transport command line option
+#If the singlenode needs to use external datasource for batch embeddedHsql can be set to false
 spring:
   profiles: singlenode
 xd:
   transport: local  
-
-#singlenode:
-#  embeddedHsql: true
+#embeddedHsql: true
 
 ---
 #Config for use with HSQLDB

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SingleNodeApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SingleNodeApplication.java
@@ -114,7 +114,7 @@ public class SingleNodeApplication {
 
 		private static final String SPRING_DATASOURCE_URL_OPTION = "${spring.datasource.url}";
 
-		private static final String SINGLENODE_EMBEDDED_HSQL = "${singlenode.embeddedHsql}";
+		private static final String SINGLENODE_EMBEDDED_HSQL = "${embeddedHsql}";
 
 		@Override
 		public void initialize(ConfigurableApplicationContext applicationContext) {

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -97,8 +97,8 @@ spring:
   profiles: singlenode
 transport: local
 analytics: memory
-singlenode:
-  embeddedHsql: ${XD_SINGLENODE_EMBEDHSQL:true}
+embeddedHsql: true
+
 ---
 
 # HSQL database configuration


### PR DESCRIPTION
- Remove singlenode prefix from `embeddedHsql` property key
  - Fix property usages in `application.yml`, `servers.yml`
