### PR TITLE
XD-1686: Pluralize admins group node

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
@@ -227,7 +227,7 @@ public class DeploymentSupervisor implements ContainerRepository, ApplicationLis
 			Paths.ensurePath(client, Paths.JOBS);
 
 			if (leaderSelector == null) {
-				leaderSelector = new LeaderSelector(client, Paths.build(Paths.ADMIN), leaderListener);
+				leaderSelector = new LeaderSelector(client, Paths.build(Paths.ADMINS), leaderListener);
 				leaderSelector.setId(getId());
 				leaderSelector.start();
 			}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/Paths.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/Paths.java
@@ -40,9 +40,10 @@ public class Paths {
 	public static final String XD_NAMESPACE = "xd";
 
 	/**
-	 * Name of admin leader node.
+	 * Name of admins (that could participate to become leader) node.
+	 * Admin lock nodes are written as children of this node.
 	 */
-	public static final String ADMIN = "admin";
+	public static final String ADMINS = "admins";
 
 	/**
 	 * Name of containers node. Containers are written as children of this node.


### PR DESCRIPTION
- Since we support multiple admin servers and all of them participate in leadership election,
  it might be good pluralizing the leadership group path's node name

/xd/admin -> /xd/admins
