### PR TITLE
XD-1630: Cut dep from xd-shell to xd-dirt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1464,17 +1464,17 @@ project('spring-xd-shell') {
 		}
 		compile "com.google.guava:guava:14.0.1"
 		testCompile project(":spring-xd-test-fixtures")
-		compile project(":spring-xd-dirt")
-		configurations.compile.exclude(group: "xerces")
-		compile project(":spring-xd-test")
+		testCompile project(":spring-xd-dirt")
+//		configurations.compile.exclude(group: "xerces")
+//		compile project(":spring-xd-test")
 
 		testCompile "uk.co.modular-it:hamcrest-date:$hamcrestDateVersion"
-		runtime "org.slf4j:jcl-over-slf4j:$slf4jVersion",
-				"org.slf4j:slf4j-log4j12:$slf4jVersion",
-				"log4j:log4j:$log4jVersion",
-				"org.codehaus.jackson:jackson-mapper-asl:$jackson1Version"
+		runtime "org.slf4j:jcl-over-slf4j:$slf4jVersion"
+		runtime	"org.slf4j:slf4j-log4j12:$slf4jVersion"
+		runtime	"log4j:log4j:$log4jVersion"
+		compile	"org.codehaus.jackson:jackson-mapper-asl:$jackson1Version"
 		compile "commons-io:commons-io:$commonsIoVersion"
-		compile "org.apache.ftpserver:ftpserver-core:$ftpServerVersion"
+		testCompile "org.apache.ftpserver:ftpserver-core:$ftpServerVersion"
 	}
 
 	// skip the startScripts task to avoid default start script generation

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RuntimeCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RuntimeCommands.java
@@ -16,6 +16,9 @@
 
 package org.springframework.xd.shell.command;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.shell.core.CommandMarker;
@@ -23,8 +26,6 @@ import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
-import org.springframework.xd.dirt.container.ContainerAttributes;
 import org.springframework.xd.rest.client.RuntimeOperations;
 import org.springframework.xd.rest.client.domain.ContainerAttributesResource;
 import org.springframework.xd.rest.client.domain.ModuleMetadataResource;
@@ -35,7 +36,7 @@ import org.springframework.xd.shell.util.TableRow;
 
 /**
  * Commands to interact with runtime containers/modules.
- *
+ * 
  * @author Ilayaperumal Gopinathan
  */
 @Component
@@ -58,30 +59,21 @@ public class RuntimeCommands implements CommandMarker {
 		final PagedResources<ContainerAttributesResource> containers = runtimeOperations().listRuntimeContainers();
 		final Table table = new Table();
 		table.addHeader(1, new TableHeader("Container Id"))
-		.addHeader(2, new TableHeader("Host"))
-		.addHeader(3, new TableHeader("IP Address"))
-		.addHeader(4, new TableHeader("PID"))
-		.addHeader(5, new TableHeader("Groups"))
-		.addHeader(6, new TableHeader("Custom Attributes"));
+				.addHeader(2, new TableHeader("Host"))
+				.addHeader(3, new TableHeader("IP Address"))
+				.addHeader(4, new TableHeader("PID"))
+				.addHeader(5, new TableHeader("Groups"))
+				.addHeader(6, new TableHeader("Custom Attributes"));
 		for (ContainerAttributesResource container : containers) {
-			ContainerAttributes attributes = new ContainerAttributes(container.getAttributes());
+			Map<String, String> copy = new HashMap<String, String>(container.getAttributes());
 			final TableRow row = table.newRow();
-			row.addValue(1, attributes.getId())
-			.addValue(2, attributes.getHost())
-			.addValue(3, attributes.getIp())
-			.addValue(4, String.valueOf(attributes.getPid()));
-			if (attributes.getGroups().size() > 0) {
-				row.addValue(5, StringUtils.collectionToCommaDelimitedString(attributes.getGroups()));
-			}
-			else {
-				row.addValue(5, "");
-			}
-			if (attributes.getCustomAttributes().size() > 0) {
-				row.addValue(6, attributes.getCustomAttributes().toString());
-			}
-			else {
-				row.addValue(6, "");
-			}
+			row.addValue(1, copy.remove("id"))
+					.addValue(2, copy.remove("host"))
+					.addValue(3, copy.remove("ip"))
+					.addValue(4, copy.remove("pid"));
+			String groups = copy.remove("groups");
+			row.addValue(5, groups == null ? "" : groups);
+			row.addValue(6, copy.isEmpty() ? "" : copy.toString());
 		}
 		return table;
 	}


### PR DESCRIPTION
XD shell should know about dirt only through the REST API.
lessen the dependency to test. As a side effect, changed handling of container attributes as a plain map.

@ilayaperumalg may want to have a look at the Xerces stuff which I left commented out, as it may have been a problem with the fact that shell depended on dirt in the first place.

Also, the dependency to spring-xd-test does not seem to be necessary!?

Lastly, but this may be the subject of another Jira, we may want to use jackson2 in the shell thoughout
