### PR TITLE
SyslogTest Compile Error Fixed.

### DIFF
--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
@@ -168,22 +168,24 @@ public class Sources {
 	}
 
 	/**
-	* Constructs a SyslogTcpSource that receives syslog events via tcp.
-	*
-	* @return an instance of SyslogTcpSource.
-	*/
-	public SyslogTcpSource syslogTcpSource() {
-		return SyslogTcpSource.withDefaults();
+	 * Constructs a SyslogTcpSource that receives syslog events via tcp.
+	 *
+	 * @param host the ip of the machine where simulated syslog traffic will be sent.
+	 * @return an instance of SyslogTcpSource.
+	 */
+	public SyslogTcpSource syslogTcpSource(String host) {
+		return SyslogTcpSource.withDefaults(host);
 	}
 
 
 	/**
-	* Constructs a SyslogUdpSource that receives syslog events via udp.
-	*
-	* @return an instance of SyslogUdpSource.
-	*/
-	public SyslogUdpSource syslogUdpSource() {
-		return SyslogUdpSource.withDefaults();
+	 * Constructs a SyslogUdpSource that receives syslog events via udp.
+	 * 
+	 * @param host the ip of the machine where simulated syslog traffic will be sent.
+	 * @return an instance of SyslogUdpSource.
+	 */
+	public SyslogUdpSource syslogUdpSource(String host) {
+		return SyslogUdpSource.withDefaults(host);
 	}
 
 }

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SyslogTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SyslogTest.java
@@ -39,7 +39,7 @@ public class SyslogTest extends AbstractIntegrationTest {
 	@Test
 	public void testSyslogTcp() {
 		String data = UUID.randomUUID().toString();
-		SyslogTcpSource syslogTcp = sources.syslogTcpSource().host(getContainerForStream().getHost());
+		SyslogTcpSource syslogTcp = sources.syslogTcpSource(getContainerForStream().getHost());
 		stream(syslogTcp + XD_DELIMETER
 				+ "file");
 		waitForXD();
@@ -55,7 +55,7 @@ public class SyslogTest extends AbstractIntegrationTest {
 	@Test
 	public void testSyslogUdp() {
 		String data = UUID.randomUUID().toString();
-		SyslogUdpSource syslogUdp = sources.syslogUdpSource().host(getContainerForStream().getHost());
+		SyslogUdpSource syslogUdp = sources.syslogUdpSource(getContainerForStream().getHost());
 		stream(syslogUdp + XD_DELIMETER
 				+ "file");
 		waitForXD();


### PR DESCRIPTION
Using fixtures' withDefaults(String host), to set the host for the test.
