### PR TITLE
XD-1651 Adding UUID as part of file name

### DIFF
--- a/modules/sink/hdfs.xml
+++ b/modules/sink/hdfs.xml
@@ -15,6 +15,12 @@
 	<task:executor id="taskExecutor" pool-size="1"/>
 	<task:scheduler id="taskScheduler" pool-size="1"/>
 
+	<!-- to generate something unique for each instance's file name -->
+	<!-- TODO: remove the use of '_' once we fix https://jira.spring.io/browse/SHDP-345 -->
+	<bean id="uuid" class="java.lang.String">
+		<constructor-arg value="#{T(java.util.UUID).randomUUID().toString().replaceAll('-', '_') }"/>
+	</bean>
+
 	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
 		fs.default.name=${spring.hadoop.fsUri}
 	</hdp:configuration>
@@ -31,7 +37,7 @@
 	Default value for fileName set here due to use of xd.stream.name variable.
 	-->
 	<int-hadoop:naming-strategy>
-		<int-hadoop:static order="1" name="${fileName:${xd.stream.name}}" />
+		<int-hadoop:static order="1" name="${fileName:${xd.stream.name}}_#{uuid}" />
 		<int-hadoop:rolling order="2" />
 		<int-hadoop:static order="3" prefix="." name="${fileExtension}" />
 		<int-hadoop:codec />


### PR DESCRIPTION
- Due to a file numbering bug in SHDP (https://jira.spring.io/browse/SHDP-345) we need to use _ as separator
  until that is fixed in next release
