### PR TITLE
XD-1730: Zookeeper NoNode exception when deploying stream

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
@@ -80,7 +80,7 @@ public class ModuleDeploymentWriter {
 	 *
 	 * @see #configuredTimeout
 	 */
-	private final static long DEFAULT_TIMEOUT = 10000;
+	private final static long DEFAULT_TIMEOUT = 30000;
 
 	/**
 	 * ZooKeeper connection.


### PR DESCRIPTION
If the admin supervisor does not receive a response for a module deployment request in the allotted time, it will consider the deployment timed out and it will remove the ZK path for the module deployment. In the meantime, if the module is successfully deployed on the container side, it will attempt to write the module metadata to the node that was already deleted by the supervisor, thus causing a `NoNodeException`.

This fix splits out the module deployment and the updating of the module deployment ZooKeeper node into two separate try blocks. If a `NoNodeException` is thrown the container logs the fact that the supervisor decided to undeploy the module while it was being deployed.

Instead of undeploying the module right away, we will leave it alone and let the upcoming `CHILD_REMOVED` event handler perform the undeployment.

Additionally, the default timeout for module deployment was increased to 30 seconds.
