### PR TITLE
XD-1708 (slight improvements)

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ExcludingContainerMatcher.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ExcludingContainerMatcher.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.cluster;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+
+import org.springframework.util.Assert;
+import org.springframework.xd.module.ModuleDeploymentProperties;
+import org.springframework.xd.module.ModuleDescriptor;
+
+/**
+ * Wrapper for {@link org.springframework.xd.dirt.cluster.ContainerMatcher}
+ * that excludes containers whose names are present in the provided
+ * {@code exclusions} collection.
+ *
+ * @author Patrick Peralta
+ */
+public class ExcludingContainerMatcher implements ContainerMatcher {
+
+	/**
+	 * Wrapped {@link org.springframework.xd.dirt.cluster.ContainerMatcher}.
+	 */
+	private final ContainerMatcher containerMatcher;
+
+	/**
+	 * Set of container names that should <b>not</b> be returned by {@link #match}.
+	 */
+	private final Set<String> exclusions;
+
+	/**
+	 * Predicate used to determine if a container should be returned by {@link #match}.
+	 */
+	private final MatchingPredicate matchingPredicate;
+
+	/**
+	 * Construct an {@code ExcludingContainerMatcher}.
+	 *
+	 * @param containerMatcher  container matcher to wrap
+	 * @param exclusions        collection of container names to exclude
+	 */
+	public ExcludingContainerMatcher(ContainerMatcher containerMatcher, Collection<String> exclusions) {
+		Assert.notNull(containerMatcher);
+		Assert.notNull(exclusions);
+		this.containerMatcher = containerMatcher;
+		this.exclusions = Collections.unmodifiableSet(new HashSet<String>(exclusions));
+		this.matchingPredicate = new MatchingPredicate();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Collection<Container> match(ModuleDescriptor moduleDescriptor,
+			ModuleDeploymentProperties deploymentProperties, Iterable<Container> containers) {
+
+		return containerMatcher.match(moduleDescriptor, deploymentProperties,
+				Iterables.filter(containers, matchingPredicate));
+	}
+
+	/**
+	 * Predicate used to determine if a container should be returned by {@link #match}.
+	 */
+	private class MatchingPredicate implements Predicate<Container> {
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public boolean apply(Container input) {
+			return input != null && (!exclusions.contains(input.getName()));
+		}
+	}
+
+}


### PR DESCRIPTION
Proposed changes for XD-1708:

I was confused by the method signature in `ModuleDeploymentWriter.writeDeployment`:

```
Collection<Result> writeDeployment(
        Iterator<ModuleDescriptor> descriptors,
        ModuleDeploymentPropertiesProvider provider,
        ContainerMatcher containerMatcher,
        Iterator<Container> containersToMatch)
```

The third parameter is called `containerMatcher` and the fourth parameter is `containersToMatch`. It seems
to me that an object called `containerMatcher` should be able to match containers on its own.

Therefore I introduced a new `ContainerMatcher` implementation that wraps another `ContainerMatcher` and also accepts container ids that should be excluded from matches. This puts the logic in `ContainerMatcher` (which is where it should go since it's one job is to match containers) and allows for easier reuse down the line if we need it.

Note that this uses the Google Collections library.
