### PR TITLE
XD-1735 FileJdbc & JdbcHdfs test now use http src

### DIFF
--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FileJdbcTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FileJdbcTest.java
@@ -62,11 +62,15 @@ public class FileJdbcTest extends AbstractIntegrationTest {
 		jdbcSink.getJdbcTemplate().getDataSource();
 		FileJdbcJob job = jobs.fileJdbcJob();
 		// Create a stream that writes to a file. This file will be used by the job.
-		stream("dataSender", "trigger --payload='" + data + "'" + XD_DELIMETER
+		stream("dataSender", sources.http() + XD_DELIMETER
 				+ sinks.file(FileJdbcJob.DEFAULT_DIRECTORY, DEFAULT_FILE_NAME).toDSL("REPLACE", "true"), WAIT_TIME);
 		waitForXD();
+		sources.http().postData(data);
+
 		job(job.toDSL());
+		waitForXD();
 		jobLaunch();
+		waitForXD();
 		String query = String.format("SELECT data FROM %s", tableName);
 		assertEquals(
 				data,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JdbcHdfsTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JdbcHdfsTest.java
@@ -72,11 +72,15 @@ public class JdbcHdfsTest extends AbstractIntegrationTest {
 		jdbcSink.getJdbcTemplate().getDataSource();
 		JdbcHdfsJob job = jobs.jdbcHdfsJob();
 		// Use a trigger to send data to JDBC
-		stream("dataSender", "trigger --payload='" + data + "'" + XD_DELIMETER
+		stream("dataSender", sources.http() + XD_DELIMETER
 				+ jdbcSink, WAIT_TIME);
+		waitForXD();
+		sources.http().postData(data);
+
 		job(job.toDSL());
+		waitForXD();
 		jobLaunch();
-		waitForXD(5000);
+		waitForXD(2000);
 		// Evaluate the results of the test.
 		String path = JdbcHdfsJob.DEFAULT_DIRECTORY + "/" + JdbcHdfsJob.DEFAULT_FILE_NAME + "-0.csv";
 		assertTrue(JdbcHdfsJob.DEFAULT_FILE_NAME + "-0.csv is missing from hdfs",


### PR DESCRIPTION
When running tests in single & on EC2 these tests were successful.  However when running admin/container on the same machine these tests would fail because of the trigger.
With this update the tests work on all 3 types of deployments.
