### PR TITLE
Misc changes (see below for details)

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
@@ -718,7 +718,7 @@ public class ContainerRegistrar implements ApplicationListener<ContextRefreshedE
 		 */
 		@Override
 		public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
-			ZooKeeperConnection.logCacheEvent(logger, event);
+			ZooKeeperUtils.logCacheEvent(logger, event);
 			switch (event.getType()) {
 				case INITIALIZED:
 					break;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
@@ -34,6 +34,7 @@ import org.springframework.xd.dirt.job.JobFactory;
 import org.springframework.xd.dirt.util.DeploymentPropertiesUtility;
 import org.springframework.xd.dirt.zookeeper.Paths;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
+import org.springframework.xd.dirt.zookeeper.ZooKeeperUtils;
 import org.springframework.xd.module.ModuleDeploymentProperties;
 import org.springframework.xd.module.ModuleDescriptor;
 
@@ -89,7 +90,7 @@ public class JobDeploymentListener implements PathChildrenCacheListener {
 	 */
 	@Override
 	public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
-		ZooKeeperConnection.logCacheEvent(logger, event);
+		ZooKeeperUtils.logCacheEvent(logger, event);
 		switch (event.getType()) {
 			case CHILD_ADDED:
 				onChildAdded(client, event.getData());

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
@@ -76,7 +76,7 @@ public class ModuleDeploymentWriter {
 	/**
 	 * Default timeout in milliseconds.
 	 *
-	 * @see #configuredTimeout
+	 * @see #timeout
 	 */
 	private final static long DEFAULT_TIMEOUT = 30000;
 
@@ -116,7 +116,7 @@ public class ModuleDeploymentWriter {
 	 * Amount of time to wait for a status to be written to all module
 	 * deployment request paths.
 	 */
-	private final long configuredTimeout;
+	private final long timeout;
 
 	/**
 	 * Key used in status map to indicate the module deployment status.
@@ -175,14 +175,14 @@ public class ModuleDeploymentWriter {
 	 * @param zkConnection         ZooKeeper connection
 	 * @param containerRepository  repository for containers in the cluster
 	 * @param containerMatcher     matcher for modules to containers
-	 * @param configuredTimeout    amount of time to wait for module deployments
+	 * @param timeout    amount of time to wait for module deployments
 	 */
 	public ModuleDeploymentWriter(ZooKeeperConnection zkConnection,
 			ContainerRepository containerRepository, ContainerMatcher containerMatcher,
-			long configuredTimeout) {
+			long timeout) {
 		this.zkConnection = zkConnection;
 		this.containerRepository = containerRepository;
-		this.configuredTimeout = configuredTimeout;
+		this.timeout = timeout;
 		this.containerMatcher = containerMatcher;
 	}
 
@@ -597,9 +597,9 @@ public class ModuleDeploymentWriter {
 		 */
 		public synchronized Collection<Result> getResults() throws InterruptedException {
 			long now = System.currentTimeMillis();
-			long timeout = now + configuredTimeout;
-			while (pending.size() > 0 && now < timeout) {
-				wait(timeout - now);
+			long expiryTime = now + timeout;
+			while (pending.size() > 0 && now < expiryTime) {
+				wait(expiryTime - now);
 				now = System.currentTimeMillis();
 			}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
@@ -39,6 +39,7 @@ import org.springframework.xd.dirt.stream.StreamFactory;
 import org.springframework.xd.dirt.util.DeploymentPropertiesUtility;
 import org.springframework.xd.dirt.zookeeper.Paths;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
+import org.springframework.xd.dirt.zookeeper.ZooKeeperUtils;
 import org.springframework.xd.module.ModuleDeploymentProperties;
 import org.springframework.xd.module.ModuleDescriptor;
 
@@ -112,7 +113,7 @@ public class StreamDeploymentListener implements PathChildrenCacheListener {
 	 */
 	@Override
 	public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
-		ZooKeeperConnection.logCacheEvent(logger, event);
+		ZooKeeperUtils.logCacheEvent(logger, event);
 		executorService.submit(new EventHandler(client, event));
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnection.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnection.java
@@ -16,7 +16,6 @@
 
 package org.springframework.xd.dirt.zookeeper;
 
-import java.io.UnsupportedEncodingException;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.apache.commons.logging.Log;
@@ -24,12 +23,9 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.slf4j.Logger;
 
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.Assert;
@@ -240,34 +236,6 @@ public class ZooKeeperConnection implements SmartLifecycle {
 	public void stop(Runnable callback) {
 		this.stop();
 		callback.run();
-	}
-
-	/**
-	 * Utility method to log {@link org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent events}.
-	 *
-	 * @param logger logger to write to
-	 * @param event  event to log
-	 */
-	public static void logCacheEvent(Logger logger, PathChildrenCacheEvent event) {
-		ChildData data = event.getData();
-		String path = (data == null) ? "null" : data.getPath();
-		logger.info("Path cache event: {}, type: {}", path, event.getType());
-		if (data != null && logger.isTraceEnabled()) {
-			String content;
-			byte[] bytes = data.getData();
-			if (bytes == null || bytes.length == 0) {
-				content = "empty";
-			}
-			else {
-				try {
-					content = new String(data.getData(), "UTF-8");
-				}
-				catch (UnsupportedEncodingException e) {
-					content = "Could not convert content to UTF-8: " + e.toString();
-				}
-			}
-			logger.trace("Data for path {}: {}", path, content);
-		}
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -17,6 +17,12 @@
 package org.springframework.xd.dirt.zookeeper;
 
 
+import java.io.UnsupportedEncodingException;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.slf4j.Logger;
+
 /**
  * Utility methods for ZooKeeper.
  * @author David Turanski
@@ -63,5 +69,33 @@ public abstract class ZooKeeperUtils {
 			}
 		}
 		throw wrapThrowable(t);
+	}
+
+	/**
+	 * Utility method to log {@link org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent events}.
+	 *
+	 * @param logger logger to write to
+	 * @param event  event to log
+	 */
+	public static void logCacheEvent(Logger logger, PathChildrenCacheEvent event) {
+		ChildData data = event.getData();
+		String path = (data == null) ? "null" : data.getPath();
+		logger.info("Path cache event: {}, type: {}", path, event.getType());
+		if (data != null && logger.isTraceEnabled()) {
+			String content;
+			byte[] bytes = data.getData();
+			if (bytes == null || bytes.length == 0) {
+				content = "empty";
+			}
+			else {
+				try {
+					content = new String(data.getData(), "UTF-8");
+				}
+				catch (UnsupportedEncodingException e) {
+					content = "Could not convert content to UTF-8: " + e.toString();
+				}
+			}
+			logger.trace("Data for path {}: {}", path, content);
+		}
 	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
@@ -57,7 +57,7 @@ import org.springframework.xd.dirt.test.sink.SingleNodeNamedChannelSinkFactory;
 import org.springframework.xd.dirt.test.source.NamedChannelSource;
 import org.springframework.xd.dirt.test.source.SingleNodeNamedChannelSourceFactory;
 import org.springframework.xd.dirt.zookeeper.Paths;
-import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
+import org.springframework.xd.dirt.zookeeper.ZooKeeperUtils;
 
 /**
  * Base class for testing stream deployments across different transport types.
@@ -542,7 +542,7 @@ public abstract class AbstractSingleNodeStreamDeploymentIntegrationTests {
 		 */
 		@Override
 		public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
-			ZooKeeperConnection.logCacheEvent(logger, event);
+			ZooKeeperUtils.logCacheEvent(logger, event);
 			ModuleDeploymentsPath path = new ModuleDeploymentsPath(event.getData().getPath());
 			if (event.getType().equals(Type.CHILD_ADDED)) {
 				deployQueues.putIfAbsent(path.getStreamName(), new LinkedBlockingQueue<PathChildrenCacheEvent>());


### PR DESCRIPTION
Follow ups to review (by Mark F) of XD-1548 including:
- Renamed methods in `ContainerListener`
- Renamed configuredTimeout to timeout in `ModuleDeploymentWriter`

Also moved `logCacheEvent` from `ZooKeeperConnection` to `ZooKeeperUtils`.
