### PR TITLE
XD-1742 Support Binary in TCP and HTTP Sources

### DIFF
--- a/modules/source/tcp/config/tcp.xml
+++ b/modules/source/tcp/config/tcp.xml
@@ -20,11 +20,9 @@
 		using-direct-buffers="${useDirectBuffers}"
 		deserializer="${decoder}"/>
 
-	<int-ip:tcp-inbound-channel-adapter id="adapter" channel="toString"
+	<int-ip:tcp-inbound-channel-adapter id="adapter" channel="output"
 			auto-startup="false"
 			connection-factory="connectionFactory"/>
-
-	<int:transformer input-channel="toString" output-channel="output" expression="new String(payload, '${charset}')"/>
 
 	<int:channel id="output"/>
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-1742

Previously, the TCP and HTTP sources unconditionally
converted byte[] to String.

Remove the transformer from the tcp source; now, if people
want String conversion, they would use

```
tcp --outputType=text/plain
```

Tested with

```
stream create --name foo --definition "tcp --decoder=RAW | file --binary=true " --deploy
stream create --name foo --definition "tcp --decoder=RAW --outputType=text/plain;charset=UTF-8 | file --binary=true " --deploy
```

Update the inbound http channel adapter to detect a
content-type of `application/octet-stream` and emit
a byte[] instead of performing String conversion.

This allows POSTing binary data...

```
curl --data-binary @foo.zip -H'content-type: application/octet-stream' http://localhost:9000
```

Add test case to verify. Also tested with

```
stream create --name bar --definition "http | file --binary=true " --deploy
```
