### PR TITLE
Fixed compile warnings

### DIFF
--- a/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/syslog/SyslogInboundChannelAdapter.java
+++ b/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/syslog/SyslogInboundChannelAdapter.java
@@ -47,14 +47,14 @@ import reactor.net.udp.spec.DatagramServerSpec;
 /**
  * {@code InboundChannelAdapter} implementation that uses the Reactor TCP support to read in syslog messages and
  * transform them to a {@code Map} for use in downstream modules.
- * 
+ *
  * @author Jon Brisbin
  */
 public class SyslogInboundChannelAdapter extends MessageProducerSupport {
 
 	private final Environment env;
 
-	private volatile NetServer server;
+	private volatile NetServer<Buffer, Buffer> server;
 
 	private volatile String transport = "tcp";
 
@@ -105,7 +105,7 @@ public class SyslogInboundChannelAdapter extends MessageProducerSupport {
 	protected void onInit() {
 		super.onInit();
 
-		NetServerSpec<Buffer, Buffer, ? extends NetServerSpec<Buffer, Buffer, ?, ?>, ? extends NetServer> spec;
+		NetServerSpec<Buffer, Buffer, ? extends NetServerSpec<Buffer, Buffer, ?, ?>, ? extends NetServer<Buffer, Buffer>> spec;
 		if("udp".equals(transport)) {
 			spec = new DatagramServerSpec<Buffer, Buffer>(NettyDatagramServer.class);
 		} else {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdConfigLoggingInitializer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdConfigLoggingInitializer.java
@@ -35,7 +35,7 @@ import org.springframework.xd.dirt.server.SharedServerContextConfiguration;
 
 /**
  * Initializer that can print useful stuff about an XD context on startup.
- * 
+ *
  * @author Dave Syer
  * @author David Turanski
  * @author Ilayaperumal Gopinathan
@@ -98,7 +98,7 @@ public class XdConfigLoggingInitializer implements ApplicationListener<ContextRe
 		ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
 		for (PropertySource<?> ps : env.getPropertySources()) {
 			if (ps instanceof EnumerablePropertySource) {
-				EnumerablePropertySource eps = (EnumerablePropertySource) ps;
+				EnumerablePropertySource<?> eps = (EnumerablePropertySource<?>) ps;
 				propertyNames.addAll(Arrays.asList(eps.getPropertyNames()));
 			}
 		}


### PR DESCRIPTION
```
/Users/pperalta/src/github/spring-xd/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdConfigLoggingInitializer.java:101: warning: [rawtypes] found raw type: EnumerablePropertySource
                EnumerablePropertySource eps = (EnumerablePropertySource) ps;
                ^
  missing type arguments for generic class EnumerablePropertySource<T>
  where T is a type-variable:
    T extends Object declared in class EnumerablePropertySource
3 warnings
```

```
/Users/pperalta/src/github/spring-xd/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/syslog/SyslogInboundChannelAdapter.java:57: warning: [rawtypes] found raw type: NetServer
    private volatile NetServer server;
                     ^
  missing type arguments for generic class NetServer<IN,OUT>
  where IN,OUT are type-variables:
    IN extends Object declared in interface NetServer
    OUT extends Object declared in interface NetServer
/Users/pperalta/src/github/spring-xd/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/syslog/SyslogInboundChannelAdapter.java:108: warning: [rawtypes] found raw type: NetServer
        NetServerSpec<Buffer, Buffer, ? extends NetServerSpec<Buffer, Buffer, ?, ?>, ? extends NetServer> spec;
                                                                                               ^
  missing type arguments for generic class NetServer<IN,OUT>
  where IN,OUT are type-variables:
    IN extends Object declared in interface NetServer
    OUT extends Object declared in interface NetServer
3 warnings
```
