### PR TITLE
XD-1748 Spring Integration -> 4.0.1 + Spring IO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ ext {
 	commonsIoVersion = '2.4'
 	curatorVersion = '2.4.1'
 	ftpServerVersion = '1.0.6'
+	groovyVersion = '2.3.0'
 	h2Version = '1.3.172'
 	hamcrestDateVersion = '0.9.3'
 	hamcrestVersion = '1.3'
@@ -103,20 +104,20 @@ ext {
 	reactorSpringVersion = '1.1.0.RELEASE'
 	slf4jVersion = '1.7.6'
 	snakeYamlVersion = '1.12'
-	springAmqpVersion = '1.3.2.RELEASE'
+	springAmqpVersion = '1.3.3.RELEASE'
 	springBatchAdminMgrVersion = '1.3.0.M1'
 	springBatchVersion = '3.0.0.M3'
 	springBootVersion = '1.0.2.RELEASE'
 	springCloudVersion = '0.9.2'
-	springDataCommonsVersion = '1.6.2.RELEASE'
-	springDataGemfireVersion = '1.3.2.RELEASE'
+	springDataCommonsVersion = '1.8.0.RELEASE'
+	springDataGemfireVersion = '1.4.0.RELEASE'
 	springDataHadoopBase = '2.0.0.RC3'
 	springDataHadoopVersion = "${springDataHadoopBase}"
-	springDataMongoVersion = '1.3.2.RELEASE'
+	springDataMongoVersion = '1.5.0.RELEASE'
 	springDataRedisVersion = '1.1.1.RELEASE'
 	springHATEOASVersion = '0.9.0.RELEASE'
 	springIntegrationSplunkVersion = '1.1.0.M2'
-	springIntegrationVersion = '4.0.0.RELEASE'
+	springIntegrationVersion = '4.0.1.RELEASE'
 	springPluginVersion = '0.8.0.RELEASE'
 	springShellVersion = '1.1.0.RC3'
 	springVersion = '4.0.3.RELEASE'
@@ -151,6 +152,12 @@ def forceDependencyVersions(p) {
 				}
 				if (details.requested.group == 'org.slf4j') {
 					details.useVersion "$slf4jVersion"
+				}
+				if (details.requested.group == 'org.codehaus.groovy') {
+					details.useVersion "$groovyVersion"
+				}
+				if (details.requested.name == 'spring-data-redis') {
+					details.useVersion "$springDataRedisVersion"
 				}
 			}
 		}
@@ -235,7 +242,7 @@ configure(javaProjects) { subproject ->
 	// dependencies that are common across all java projects
 	dependencies {
 		testCompile "junit:junit:$junitVersion"
-		testCompile "org.codehaus.groovy:groovy-all:2.2.2"
+		testCompile "org.codehaus.groovy:groovy-all:$groovyVersion"
 		testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
 	}
 

--- a/modules/sink/hdfs-dataset.xml
+++ b/modules/sink/hdfs-dataset.xml
@@ -34,6 +34,8 @@
 
 	<bean id="messageStore" class="org.springframework.integration.store.SimpleMessageStore">
 		<property name="timeoutOnIdle" value="true"/>
+		<!-- TODO: The following property will default to "false" in Spring Integration 4.1 -->
+		<property name="copyOnGet" value="false"/>
 	</bean>
 
 	<int-hadoop:dataset-outbound-channel-adapter id="objects" dataset-operations="datasetOperations"/>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-1748

Spring Integration to 4.0.1 - performance improvement in
the aggregator for large groups (e.g. hdfs-dataset). Update
the sink to enable the improvement.

Also move other deps to Spring IO versions.

Hold back spring-data-redis, because 1.3.0 is not
compatible with boot 1.0.x.
