### PR TITLE
XD-1416 Activate tap only when 1 or more consumers

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractPlugin.java
@@ -16,8 +16,8 @@
 
 package org.springframework.xd.dirt.plugins;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -36,7 +36,10 @@ import org.springframework.xd.module.core.Plugin;
  */
 public abstract class AbstractPlugin implements Plugin, Ordered, ApplicationContextAware {
 
-	protected final Log logger = LogFactory.getLog(getClass());
+	/**
+	 * Logger.
+	 */
+	protected final Logger logger = LoggerFactory.getLogger(getClass());
 
 	private ApplicationContext applicationContext;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
@@ -18,6 +18,7 @@ package org.springframework.xd.dirt.plugins;
 
 import org.springframework.util.Assert;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
+import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
 import org.springframework.xd.module.ModuleDescriptor;
 import org.springframework.xd.module.ModuleType;
 import org.springframework.xd.module.core.Module;
@@ -34,6 +35,10 @@ public abstract class AbstractStreamPlugin extends AbstractMessageBusBinderPlugi
 
 	public AbstractStreamPlugin(MessageBus messageBus) {
 		super(messageBus);
+	}
+
+	public AbstractStreamPlugin(MessageBus messageBus, ZooKeeperConnection zkConnection) {
+		super(messageBus, zkConnection);
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/StreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/StreamPlugin.java
@@ -20,11 +20,14 @@ import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_ST
 
 import java.util.Properties;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.context.ApplicationListener;
+import org.springframework.util.Assert;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.MessageBusAwareRouterBeanPostProcessor;
 import org.springframework.xd.dirt.plugins.AbstractStreamPlugin;
+import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
 import org.springframework.xd.module.ModuleType;
 import org.springframework.xd.module.core.Module;
 
@@ -38,8 +41,10 @@ import org.springframework.xd.module.core.Module;
  */
 public class StreamPlugin extends AbstractStreamPlugin {
 
-	public StreamPlugin(MessageBus messageBus) {
-		super(messageBus);
+	@Autowired
+	public StreamPlugin(MessageBus messageBus, ZooKeeperConnection zkConnection) {
+		super(messageBus, zkConnection);
+		Assert.notNull(zkConnection, "ZooKeeperConnection must not be null");
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/Paths.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/Paths.java
@@ -67,6 +67,11 @@ public class Paths {
 	public static final String JOBS = "jobs";
 
 	/**
+	 * Name of taps node. Channel names with active taps are written as children of this node.
+	 */
+	public static final String TAPS = "taps";
+
+	/**
 	 * Name of deployments node. Deployments are written as children of this node.
 	 */
 	public static final String DEPLOYMENTS = "deployments";

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/streams.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/streams.xml
@@ -5,10 +5,8 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
-<!-- TODO: This id required by TestMessageBusInjection -->
-	<bean id="streamPlugin" class="org.springframework.xd.dirt.plugins.stream.StreamPlugin">
-		<constructor-arg ref="messageBus"/>
-	</bean>
+	<!-- TODO: This id required by TestMessageBusInjection -->
+	<bean id="streamPlugin" class="org.springframework.xd.dirt.plugins.stream.StreamPlugin"/>
 
 	<bean class="org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionPlugin">
 		<constructor-arg name="converters" ref="xd.messageConverters"/>


### PR DESCRIPTION
When a module that begins with a tap channel (e.g. tap:stream:foo > log) is deployed,
a corresponding ZooKeeper node will be created under /xd/taps if not already present.

The AbstractMessageBusBinderPlugin has a TapListener that reacts to the addition of
such a node by "activating" the tap. Activation is simply the addition of the WireTap
interceptor on the output channel of the module being tapped along with the binding of
a pub/sub producer to that WireTap's channel. That logic remains the same, but has
simply been made lazy, triggered on-demand only when a tap has at least one consumer.

When the last consuming module for a given tap is undeployed, the ZooKeeper node for that
tap is deleted. The TapListener then reacts by removing the associated WireTap interceptor.
