### PR TITLE
Add locator support to gemfire-cq source

### DIFF
--- a/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireCQSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireCQSourceOptionsMetadata.java
@@ -20,20 +20,25 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 
 import org.hibernate.validator.constraints.NotBlank;
+
 import org.springframework.xd.module.options.spi.ModuleOption;
+import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 
 /**
  * Describes options to the {@code gemfire-cq} source module.
  * 
  * @author Eric Bottard
+ * @author David Turanski
  */
-public class GemfireCQSourceOptionsMetadata {
+public class GemfireCQSourceOptionsMetadata implements ProfileNamesProvider {
 
 	private int port = 40404;
 
 	private String host = "localhost";
 
 	private String query;
+
+	private boolean useLocator = false;
 
 
 	@Min(0)
@@ -69,5 +74,23 @@ public class GemfireCQSourceOptionsMetadata {
 		this.query = query;
 	}
 
+	public boolean isUseLocator() {
+		return useLocator;
+	}
+
+	@ModuleOption("set to true if using a locator")
+	public void setUseLocator(boolean useLocator) {
+		this.useLocator = useLocator;
+	}
+
+	@Override
+	public String[] profilesToActivate() {
+		if (useLocator) {
+			return new String[] { "use-locator" };
+		}
+		else {
+			return new String[] { "use-server" };
+		}
+	}
 
 }

--- a/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireSourceOptionsMetadata.java
@@ -61,16 +61,6 @@ public class GemfireSourceOptionsMetadata implements ProfileNamesProvider {
 		this.port = port;
 	}
 
-	@Override
-	public String[] profilesToActivate() {
-		if (useLocator) {
-			return new String[] { "use-locator" };
-		}
-		else {
-			return new String[] { "use-server" };
-		}
-	}
-
 	@NotBlank
 	public String getCacheEventExpression() {
 		return cacheEventExpression;
@@ -91,5 +81,22 @@ public class GemfireSourceOptionsMetadata implements ProfileNamesProvider {
 		this.regionName = regionName;
 	}
 
+	public boolean isUseLocator() {
+		return useLocator;
+	}
 
+	@ModuleOption("set to true if using a locator")
+	public void setUseLocator(boolean useLocator) {
+		this.useLocator = useLocator;
+	}
+
+	@Override
+	public String[] profilesToActivate() {
+		if (useLocator) {
+			return new String[] { "use-locator" };
+		}
+		else {
+			return new String[] { "use-server" };
+		}
+	}
 }

--- a/modules/source/gemfire-cq/config/gemfire-cq.xml
+++ b/modules/source/gemfire-cq/config/gemfire-cq.xml
@@ -14,12 +14,10 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<gfe:client-cache id="client-cache" use-bean-factory-locator="false"/>
-	<gfe:pool id="cq-pool" subscription-enabled="true">
-		<gfe:server host="${host}" port="${port}" />
-	</gfe:pool>
+	 
 
 	<gfe:cq-listener-container id="cqContainer"
-		cache="client-cache" pool-name="cq-pool" />
+		cache="client-cache"/>
 
 	<int:channel id="output"/>
 
@@ -28,4 +26,15 @@
 	<int:transformer input-channel="to.transformer" output-channel="output" method="toString">
 		<bean class="org.springframework.integration.x.gemfire.JsonStringToObjectTransformer"/>
 	</int:transformer>
+	
+	<beans profile="use-server">
+		<gfe:pool subscription-enabled="true">
+			<gfe:server host="${host}" port="${port}" />
+		</gfe:pool>
+	</beans>
+	<beans profile="use-locator">
+		<gfe:pool subscription-enabled="true">
+			<gfe:locator host="${host}" port="${port}" />
+		</gfe:pool>
+	</beans>
 </beans>


### PR DESCRIPTION
This is something that I discovered updating the sources documents. Now all gemfire modules have locator support. Also, adds useLocator as a command line option.
