### PR TITLE
XD-1766 Fixing failing tcptofile test

### DIFF
--- a/src/test/scripts/basic_stream_tests
+++ b/src/test/scripts/basic_stream_tests
@@ -67,7 +67,7 @@ destroy_stream 'httpfilter1'
 
 echo -e '*** Test 5. tcp | file stream\n'
 
-create_stream 'tcptofile' "tcp --port=21234 --socketTimeout=2000 | file --dir=$TEST_DIR" 'true'
+create_stream 'tcptofile' "tcp --outputType=text/plain --port=21234 --socketTimeout=2000 | file --dir=$TEST_DIR" 'true'
 
 sleep 5
 echo -en 'blahblah\r\n' | netcat localhost 21234


### PR DESCRIPTION
- Added --outputType=text/plain option to tcp source as
  that is now required.

More info can be found from here: https://github.com/spring-projects/spring-xd/commit/9928025ae64b0aa01fdef0783a8a6ac4cebf4f3d

This is already mentioned in tcp source docs that text/plain is needed in a case like this.
