### PR TITLE
XD-1771 TwitterSearchTest now tests in append mode

### DIFF
--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TwitterSearchTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TwitterSearchTest.java
@@ -34,9 +34,8 @@ public class TwitterSearchTest extends AbstractIntegrationTest {
 
 		final String data = "#springio";
 		TwitterSearchSource twitterSearchSource = sources.twitterSearch(data);
-		stream(twitterSearchSource + XD_DELIMETER + sinks.file());
+		stream(twitterSearchSource + XD_DELIMETER + " file");
 		this.waitForXD();
-		assertReceived("file.1", "input", 1);
 		assertFileContainsIgnoreCase(data);
 
 	}


### PR DESCRIPTION
Since the updates to TwitterSearch it returns multiple messages during the duration of the test.
Before we expected only one result/message now we get an indeterminate amount.  Thus the
assertReceived was removed and the file sink that captures the results is now in append mode.
