### PR TITLE
XD-1782: Exceptions thrown on module redeployment

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/NoContainerException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/NoContainerException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.cluster;
+
+
+/**
+ * Exception thrown when there are no containers available
+ * for module deployment.
+ *
+ * @see org.springframework.xd.dirt.server.ModuleDeploymentWriter
+ *
+ * @author Patrick Peralta
+ */
+@SuppressWarnings("serial")
+public class NoContainerException extends Exception {
+
+	/**
+	 * Construct a {@code NoContainerException}.
+	 */
+	public NoContainerException() {
+	}
+
+	/**
+	 * Construct a {@code NoContainerException} with a description.
+	 *
+	 * @param message description for exception
+	 */
+	public NoContainerException(String message) {
+		super(message);
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
 import org.springframework.xd.dirt.cluster.Container;
 import org.springframework.xd.dirt.cluster.ContainerMatcher;
 import org.springframework.xd.dirt.cluster.ContainerRepository;
+import org.springframework.xd.dirt.cluster.NoContainerException;
 import org.springframework.xd.dirt.core.Stream;
 import org.springframework.xd.dirt.core.StreamDeploymentsPath;
 import org.springframework.xd.dirt.stream.StreamFactory;
@@ -180,13 +181,18 @@ public class StreamDeploymentListener implements PathChildrenCacheListener {
 	 *
 	 * @param stream stream to be deployed
 	 *
-	 * @throws Exception
+	 * @throws InterruptedException
 	 */
-	private void deployStream(final Stream stream) throws Exception {
-		Collection<ModuleDeploymentWriter.Result> results =
-				moduleDeploymentWriter.writeDeployment(stream.getDeploymentOrderIterator(),
-						new StreamModuleDeploymentPropertiesProvider(stream));
-		moduleDeploymentWriter.validateResults(results);
+	private void deployStream(final Stream stream) throws InterruptedException {
+		try {
+			Collection<ModuleDeploymentWriter.Result> results =
+					moduleDeploymentWriter.writeDeployment(stream.getDeploymentOrderIterator(),
+							new StreamModuleDeploymentPropertiesProvider(stream));
+			moduleDeploymentWriter.validateResults(results);
+		}
+		catch (NoContainerException e) {
+			logger.warn("No containers available for deployment of stream {}", stream.getName());
+		}
 	}
 
 


### PR DESCRIPTION
As part of the ZK refactoring, the logging we used to do when there were no containers for deployment was lost. The exception `NoContainerException` was introduced to indicate that a deployment failed because there were no containers that met the criteria for deployment.

This is a checked exception since this condition needs to be handled whenever a module deployment is attempted.
