### PR TITLE
XD-1802: Add @XmlRootElement to all resources

### DIFF
--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/DetailedModuleDefinitionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/DetailedModuleDefinitionResource.java
@@ -19,6 +19,8 @@ package org.springframework.xd.rest.client.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
 import org.springframework.hateoas.PagedResources;
 
 
@@ -27,6 +29,7 @@ import org.springframework.hateoas.PagedResources;
  * 
  * @author Eric Bottard
  */
+@XmlRootElement
 public class DetailedModuleDefinitionResource extends ModuleDefinitionResource {
 
 	/**

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/JobDefinitionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/JobDefinitionResource.java
@@ -16,6 +16,8 @@
 
 package org.springframework.xd.rest.client.domain;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
 import org.springframework.hateoas.PagedResources;
 
 /**
@@ -24,6 +26,7 @@ import org.springframework.hateoas.PagedResources;
  * @author Glenn Renfro
  * @since 1.0
  */
+@XmlRootElement
 public class JobDefinitionResource extends DeployableResource {
 
 	/**

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/JobInstanceInfoResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/JobInstanceInfoResource.java
@@ -18,6 +18,8 @@ package org.springframework.xd.rest.client.domain;
 
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
 import org.springframework.batch.core.JobInstance;
 import org.springframework.hateoas.ResourceSupport;
 
@@ -27,6 +29,7 @@ import org.springframework.hateoas.ResourceSupport;
  * 
  * @author Ilayaperumal Gopinathan
  */
+@XmlRootElement
 public class JobInstanceInfoResource extends ResourceSupport {
 
 	private String jobName;

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/XDRuntime.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/XDRuntime.java
@@ -16,6 +16,8 @@
 
 package org.springframework.xd.rest.client.domain;
 
+import javax.xml.bind.annotation.XmlRootElement;
+
 import org.springframework.hateoas.ResourceSupport;
 
 /**
@@ -24,6 +26,7 @@ import org.springframework.hateoas.ResourceSupport;
  * @author Eric Bottard
  * 
  */
+@XmlRootElement
 public class XDRuntime extends ResourceSupport {
 
 }


### PR DESCRIPTION
Add @XmlRootElement to all REST resources, so that they don't throw marshalling errors when trying to marshal to xml (e.g. by default in a browser).

Note that this does not make our API xml friendly (by default, all fields are exposed to json by json, but jaxb does the inverse: fields/getters need to be explicitly declared as to-be-marshalled). Created https://jira.spring.io/browse/XD-1800 for that, if we ever want to invest time in it
