### PR TITLE
XD-1585: Completions after a named channel

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionProvider.java
@@ -81,7 +81,7 @@ public class CompletionProvider {
 		}
 		catch (Exception recoverable) {
 			for (CompletionRecoveryStrategy<Exception> strategy : completionRecoveryStrategies) {
-				if (strategy.shouldTrigger(recoverable, kind)) {
+				if (strategy.shouldTrigger(start, recoverable, kind)) {
 					strategy.addProposals(start, recoverable, kind, results);
 				}
 			}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionRecoveryStrategy.java
@@ -32,7 +32,7 @@ public interface CompletionRecoveryStrategy<E extends Exception> {
 	/**
 	 * Whether this completion should be triggered.
 	 */
-	boolean shouldTrigger(Exception exception, CompletionKind kind);
+	boolean shouldTrigger(String dslStart, Exception exception, CompletionKind kind);
 
 	/**
 	 * Perform code completion by adding proposals to the {@code proposals} list.

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/StacktraceFingerprintingCompletionRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/StacktraceFingerprintingCompletionRecoveryStrategy.java
@@ -137,7 +137,7 @@ public abstract class StacktraceFingerprintingCompletionRecoveryStrategy<E exten
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public boolean shouldTrigger(Exception exception, CompletionKind kind) {
+	public boolean shouldTrigger(String dslStart, Exception exception, CompletionKind kind) {
 		if (!exceptionClass.isAssignableFrom(exception.getClass())) {
 			return false;
 		}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/UnfinishedModuleNameRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/UnfinishedModuleNameRecoveryStrategy.java
@@ -51,7 +51,7 @@ public class UnfinishedModuleNameRecoveryStrategy extends
 	 */
 	@Autowired
 	public UnfinishedModuleNameRecoveryStrategy(XDParser parser, ModuleDefinitionRepository moduleDefinitionRepository) {
-		super(parser, NoSuchModuleException.class, "ht", "file | brid", "file | bridge | jd");
+		super(parser, NoSuchModuleException.class, "ht", "file | brid", "file | bridge | jd", "queue:foo > bar");
 		this.moduleDefinitionRepository = moduleDefinitionRepository;
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/CheckpointedStreamDefinitionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/CheckpointedStreamDefinitionException.java
@@ -31,11 +31,22 @@ public class CheckpointedStreamDefinitionException extends StreamDefinitionExcep
 
 	private List<Token> tokens;
 
+	private int tokenPointer;
 
-	public CheckpointedStreamDefinitionException(String expressionString, int position, int checkpointPointer,
-			List<Token> tokens, XDDSLMessages message,
-			Object... inserts) {
-		super(expressionString, position, message, inserts);
+	/**
+	 * Construct a new exception
+	 * @param expressionString the raw, untokenized text that was being parsed
+	 * @param textPosition the text offset where the error occurs
+	 * @param checkpointPointer the token-index of the last known good token
+	 * @param tokenPointer the token-index of token where the error occured
+	 * @param tokens the list of tokens that make up expressionString
+	 * @param message the error message
+	 * @param inserts variables that may be inserted in the error message
+	 */
+	public CheckpointedStreamDefinitionException(String expressionString, int textPosition, int tokenPointer,
+			int checkpointPointer, List<Token> tokens, XDDSLMessages message, Object... inserts) {
+		super(expressionString, textPosition, message, inserts);
+		this.tokenPointer = tokenPointer;
 		this.checkpointPointer = checkpointPointer;
 		this.tokens = tokens;
 	}
@@ -95,6 +106,11 @@ public class CheckpointedStreamDefinitionException extends StreamDefinitionExcep
 
 	public List<Token> getTokens() {
 		return tokens;
+	}
+
+
+	public int getTokenPointer() {
+		return tokenPointer;
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
@@ -171,10 +171,10 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 
 	// return true if the specified tokenpointer appears to be pointing at a channel
 	private boolean looksLikeChannel(int tp) {
-		if (tokenStream.get(tp).getKind() == TokenKind.IDENTIFIER) {
+		if (moreTokens() && tokenStream.get(tp).getKind() == TokenKind.IDENTIFIER) {
 			String prefix = tokenStream.get(tp).data;
 			if (isLegalChannelPrefix(prefix)) {
-				if (tokenStream.get(tp + 1).getKind() == TokenKind.COLON) {
+				if (tokenStreamPointer + 1 < tokenStream.size() && tokenStream.get(tp + 1).getKind() == TokenKind.COLON) {
 					// if (isNextTokenAdjacent(tp) && isNextTokenAdjacent(tp + 1)) {
 					return true;
 					// }
@@ -606,8 +606,8 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 	}
 
 	private void raiseException(int pos, XDDSLMessages message, Object... inserts) {
-		throw new CheckpointedStreamDefinitionException(expressionString, pos, lastGoodPoint, tokenStream, message,
-				inserts);
+		throw new CheckpointedStreamDefinitionException(expressionString, pos, tokenStreamPointer, lastGoodPoint,
+				tokenStream, message, inserts);
 	}
 
 	private void checkpoint() {

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/completion/CompletionProviderTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/completion/CompletionProviderTests.java
@@ -273,6 +273,25 @@ public class CompletionProviderTests {
 		assertThat(completions, not(hasItem(startsWith("transform | syslog-tcp"))));
 	}
 
+	@Test
+	// queue:foo > <TAB>  ==> add module names
+	public void testXD1706() {
+		List<String> completions = completionProvider.complete(stream, "queue:foo > ");
+		assertThat(completions, hasItem(startsWith("queue:foo > http-client")));
+		assertThat(completions, hasItem(startsWith("queue:foo > splunk")));
+		assertThat(completions, not(hasItem(startsWith("queue:foo > twittersearch"))));
+	}
+
+	@Test
+	public void testCompleteAlreadyStartedNameAfterChannel() {
+		List<String> completions = completionProvider.complete(stream, "queue:foo > s");
+		// XD-1830: Currently does not support adding processors due do the way
+		// module type guessing works
+		//assertThat(completions, hasItem(startsWith("queue:foo > splitter")));
+		assertThat(completions, hasItem(startsWith("queue:foo > splunk")));
+		assertThat(completions, not(hasItem(startsWith("queue:foo > syslog"))));
+	}
+
 	private List<String> namesOfModulesWithType(ModuleType type) {
 		Page<ModuleDefinition> mods = moduleDefinitionRepository.findByType(new PageRequest(0, 1000), type);
 		List<String> result = new ArrayList<String>();


### PR DESCRIPTION
Adds completions for cases like

```
queue:foo > <TAB>
queue:foo > splu<TAB>
```

with one caveat: processors will not be part of proposals for the second case (XD-1830)
