### PR TITLE
Fixed ModuleDescriptor.Key.compareTo

### DIFF
--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
@@ -656,6 +656,9 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
 			if (c == 0) {
 				c = label.compareTo(other.getLabel());
 			}
+			if (c == 0) {
+				c = group.compareTo(other.getGroup());
+			}
 			return c;
 		}
 


### PR DESCRIPTION
Modified `ModuleDescriptor.Key.compareTo` to take group into account if necessary.
