### PR TITLE
Fix some generics warnings

### DIFF
--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/HttpSource.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/HttpSource.java
@@ -31,7 +31,7 @@ import org.springframework.xd.test.fixtures.AvailableSocketPorts;
  * 
  * @author Eric Bottard
  */
-public class HttpSource extends AbstractModuleFixture {
+public class HttpSource extends AbstractModuleFixture<HttpSource> {
 
 	private int port;
 

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsJdbcJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsJdbcJob.java
@@ -24,7 +24,7 @@ import org.springframework.util.Assert;
  *
  * @author Glenn Renfro
  */
-public class HdfsJdbcJob extends AbstractModuleFixture {
+public class HdfsJdbcJob extends AbstractModuleFixture<HdfsJdbcJob> {
 
 	public final static String DEFAULT_DIRECTORY = "/xd/hdfsjdbctest";
 

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsMongoDbJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsMongoDbJob.java
@@ -31,7 +31,7 @@ import com.mongodb.DBObject;
  *
  * @author Glenn Renfro
  */
-public class HdfsMongoDbJob extends AbstractModuleFixture {
+public class HdfsMongoDbJob extends AbstractModuleFixture<HdfsMongoDbJob> {
 
 	public final static String DEFAULT_DIRECTORY = "/xd/hdfsmongodbtest";
 
@@ -200,11 +200,11 @@ public class HdfsMongoDbJob extends AbstractModuleFixture {
 	}
 
 	/**
-	 * Returns a single object from the collection
-	 * @param collectionName The name of the collection to query
+	 * Returns a single object from the collection.
 	 * 
+	 * @param collectionName the name of the collection to query
 	 * @return A Map with the content of the result
-	 * @throws IllegalStateException if the number of objects in the collection is not 
+	 * @throws IllegalStateException if the number of objects in the collection is not one
 	 */
 	@SuppressWarnings("unchecked")
 	public Map<String, String> getSingleObject(String collectionName) {
@@ -213,7 +213,7 @@ public class HdfsMongoDbJob extends AbstractModuleFixture {
 			throw new IllegalStateException("Expected only one result but received " + cursor.count() + " entries");
 		}
 		DBObject dbObject = mongoTemplate.getCollection(collectionName).findOne();
-		Map result = null;
+		Map<String, String> result = null;
 		if (dbObject != null) {
 			result = dbObject.toMap();
 		}

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/Transform.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/Transform.java
@@ -23,7 +23,7 @@ import org.springframework.util.Assert;
  * Test fixture that creates a Transform.
  * @author Glenn Renfro
  */
-public class Transform extends AbstractModuleFixture {
+public class Transform extends AbstractModuleFixture<Transform> {
 
 	private String expression;
 
@@ -31,19 +31,13 @@ public class Transform extends AbstractModuleFixture {
 
 	private String properties;
 
-	private String label;
-
 	/**
 	 * Renders the default DSL for this fixture.
 	 */
 	@Override
 	protected String toDSL() {
 		StringBuilder dsl = new StringBuilder();
-		if (label != null) {
-			dsl.append(" ");
-			dsl.append(label);
-			dsl.append(": ");
-		}
+		dsl.append(getDslLabel());
 
 		dsl.append("transform");
 
@@ -74,7 +68,7 @@ public class Transform extends AbstractModuleFixture {
 	}
 
 	/**
-	 Sets the groovy script the user wants to transform the input.
+	 * Sets the groovy script the user wants to transform the input.
 	 * @param The file where the groovy script is located.
 	 * @return current instance of the transform fixture.
 	 */
@@ -92,17 +86,6 @@ public class Transform extends AbstractModuleFixture {
 	public Transform properties(String properties) {
 		Assert.hasText(properties, "properties can not be empty nor null");
 		this.properties = properties;
-		return this;
-	}
-
-	/**
-	 * Sets the label for this instance of transform
-	 * @param label The label to be used by this transform.
-	 * @return current instance of the transform fixture
-	 */
-	public Transform label(String label) {
-		Assert.hasText(label, "label can not be empty nor null");
-		this.label = label;
 		return this;
 	}
 


### PR DESCRIPTION
I was going to push this directly to master, but stumbled upon some issues with Tap IMHO:

Why is it a subclass of AbstractModuleFixture? (It's not a module, and as such does not have a label). Moreover, the `label()` method of Tap now shadows the one of the same name from the base class, which has a totally different meaning. Finally, tapping can now only be done through one single concept, the "label" (which is either explicit or implicit). So label from tap should be removed, moduleName() should be renamed to something like moduleToTap() and that class should not inherit from AbstractModuleFixture.
