### PR TITLE
XD-777: Prevent tapping on an inexistant module

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
@@ -163,6 +163,10 @@ public class ChannelNode extends AstNode {
 						indexingElements.clear();
 						indexingElements.add(0, sn.getModuleNodes().get(index).getName() + "." + index);
 					}
+					else {
+						throw new StreamDefinitionException("", -1, XDDSLMessages.UNRECOGNIZED_MODULE_REFERENCE,
+								indexString);
+					}
 				}
 			}
 		}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -277,6 +277,12 @@ public class StreamConfigParserTests {
 		parse("tap:stream:mystream.foobar.1 > file");
 	}
 
+	@Test(expected = StreamDefinitionException.class)
+	public void tapOnNonExistentStreamModuleFails() throws Exception {
+		parse("mystream = http | file");
+		parse("tap:stream:mystream.foobar > log");
+	}
+
 	@Test
 	public void expressions_xd159() {
 		StreamNode ast = parse("foo | transform --expression=--payload | bar");


### PR DESCRIPTION
Would be nice if we had access to the error location. Created https://jira.spring.io/browse/XD-1858
