### PR TITLE
Minor fixes on DeploymentSupervisor

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/DefaultContainerMatcher.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/DefaultContainerMatcher.java
@@ -142,7 +142,9 @@ public class DefaultContainerMatcher implements ContainerMatcher {
 	 * @return the list of containers matching the criteria
 	 */
 	private List<Container> findAllContainersMatchingCriteria(Iterable<Container> containers, String criteria) {
-		logger.debug("Matching containers for criteria '{}'", criteria);
+		if (StringUtils.hasText(criteria)) {
+			logger.debug("Matching containers for criteria '{}'", criteria);
+		}
 
 		List<Container> candidates = new ArrayList<Container>();
 
@@ -154,7 +156,7 @@ public class DefaultContainerMatcher implements ContainerMatcher {
 			}
 		}
 
-		if (candidates.isEmpty()) {
+		if (candidates.isEmpty() && StringUtils.hasText(criteria)) {
 			logger.warn("No currently available containers match criteria '{}'", criteria);
 		}
 		return candidates;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
@@ -348,7 +347,7 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 
 				containers = instantiatePathChildrenCache(client, Paths.CONTAINERS);
 				containers.getListenable().addListener(containerListener);
-				containers.start();
+				containers.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
 
 				Thread.sleep(Long.MAX_VALUE);
 			}


### PR DESCRIPTION
- Avoid logging 'null' criteria
  - If the `deploymentProperties` doesn't have the container matching
    criteria, then the `DefaultContainerMatcher` logs saying:
    "No currently available containers match criteria 'null'"
- Add `POST_INITIALIZED_EVENT` StartMode for containers path cache
  start()
