### PR TITLE
XD-1861 Fix XD config logger

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SharedServerContextConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SharedServerContextConfiguration.java
@@ -60,6 +60,8 @@ public class SharedServerContextConfiguration {
 
 	public static final String EMBEDDED_ZK_CONNECT = "zk.embedded.client.connect";
 
+	public static final String ZK_PROPERTIES_SOURCE = "zk-properties";
+
 	@Configuration
 	@Profile(XdProfiles.SINGLENODE_PROFILE)
 	static class SingleNodeZooKeeperConfig extends ZookeeperConnectionConfig {
@@ -136,7 +138,8 @@ public class SharedServerContextConfiguration {
 			else {
 				zkProperties.put(ZK_CONNECT, zkClientConnect);
 			}
-			this.environment.getPropertySources().addFirst(new PropertiesPropertySource("zk-properties", zkProperties));
+			this.environment.getPropertySources().addFirst(
+					new PropertiesPropertySource(ZK_PROPERTIES_SOURCE, zkProperties));
 			ZooKeeperConnection zooKeeperConnection = new ZooKeeperConnection(zkClientConnect);
 
 			zooKeeperConnection.setAutoStartup(!zkConnectionConfigured);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdConfigLoggingInitializer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdConfigLoggingInitializer.java
@@ -44,16 +44,11 @@ public class XdConfigLoggingInitializer implements ApplicationListener<ContextRe
 
 	private static Log logger = LogFactory.getLog(XdConfigLoggingInitializer.class);
 
-	protected Environment environment;
+	protected ConfigurableEnvironment environment;
 
 	private final boolean isContainer;
 
 	private static final String HADOOP_DISTRO_OPTION = "${HADOOP_DISTRO}";
-
-	private static final String ZK_CONNECT_OPTION = "${" + SharedServerContextConfiguration.ZK_CONNECT + "}";
-
-	private static final String EMBEDDED_ZK_CONNECT_OPTION = "${"
-			+ SharedServerContextConfiguration.EMBEDDED_ZK_CONNECT + "}";
 
 	public XdConfigLoggingInitializer(boolean isContainer) {
 		this.isContainer = isContainer;
@@ -61,18 +56,21 @@ public class XdConfigLoggingInitializer implements ApplicationListener<ContextRe
 
 	@Override
 	public void setEnvironment(Environment environment) {
-		this.environment = environment;
+		this.environment = (ConfigurableEnvironment) environment;
 	}
 
 	@Override
 	public void onApplicationEvent(ContextRefreshedEvent event) {
 		logger.info("XD Home: " + environment.resolvePlaceholders("${XD_HOME}"));
+		logger.info("Transport: " + environment.resolvePlaceholders("${XD_TRANSPORT}"));
 		if (isContainer) {
-			logger.info("Transport: " + environment.resolvePlaceholders("${XD_TRANSPORT}"));
 			logHadoopDistro();
 		}
 		logZkConnectString();
 		logger.info("Analytics: " + environment.resolvePlaceholders("${XD_ANALYTICS}"));
+		if ("true".equals(environment.getProperty("verbose"))) {
+			logAllProperties();
+		}
 	}
 
 	private void logHadoopDistro() {
@@ -82,21 +80,21 @@ public class XdConfigLoggingInitializer implements ApplicationListener<ContextRe
 	}
 
 	private void logZkConnectString() {
-		String zkConnectString = environment.resolvePlaceholders(ZK_CONNECT_OPTION);
-		String embeddedZkConnectString = environment.resolvePlaceholders(EMBEDDED_ZK_CONNECT_OPTION);
-		String connectString = (!StringUtils.hasText(zkConnectString) && StringUtils.hasText(embeddedZkConnectString)) ? embeddedZkConnectString
-				: zkConnectString;
-		logger.info("Zookeeper at: " + connectString);
-		if ("true".equals(environment.getProperty("verbose"))) {
-			logAllProperties();
+		PropertySource zkPropertySource = environment.getPropertySources().get(
+				SharedServerContextConfiguration.ZK_PROPERTIES_SOURCE);
+		if (zkPropertySource != null) {
+			String zkConnectString = (String) zkPropertySource.getProperty(SharedServerContextConfiguration.ZK_CONNECT);
+			String embeddedZkConnectString = (String) zkPropertySource.getProperty(SharedServerContextConfiguration.EMBEDDED_ZK_CONNECT);
+			String connectString = (!StringUtils.hasText(zkConnectString) && StringUtils.hasText(embeddedZkConnectString)) ? embeddedZkConnectString
+					: zkConnectString;
+			logger.info("Zookeeper at: " + connectString);
 		}
 	}
 
 	private void logAllProperties() {
 		Set<String> propertyNames = new TreeSet<String>();
 
-		ConfigurableEnvironment env = (ConfigurableEnvironment) environment;
-		for (PropertySource<?> ps : env.getPropertySources()) {
+		for (PropertySource<?> ps : this.environment.getPropertySources()) {
 			if (ps instanceof EnumerablePropertySource) {
 				EnumerablePropertySource<?> eps = (EnumerablePropertySource<?>) ps;
 				propertyNames.addAll(Arrays.asList(eps.getPropertyNames()));


### PR DESCRIPTION
- Spring Boot 1.1.1 has the following change:
  https://github.com/spring-projects/spring-boot/commit/b75578d99c8d435e1f8bf18d0dbb3a2ddf56fdc4
  where, an external property source precedence would get re-ordered after the application configuration properties.
  This change affects Spring XD config initializer which expects an external "zk-properties" property source
  always preceding over the application configuration properties.
  - Fix XdConfigLoggingInitializer to explicitly check for `zk-properties` property source and obtain the
    zk connection properties (for standalone/embedded case) before logging the appropriate value.
  - Log transport option for admin server
