### PR TITLE
XD-1824 Support RabbitMQ Cluster in source/sink

### DIFF
--- a/modules/sink/rabbit/config/rabbit.xml
+++ b/modules/sink/rabbit/config/rabbit.xml
@@ -23,9 +23,10 @@
 		connection-factory="rabbitConnectionFactory"
 		message-converter="messageConverter" />
 
-	<rabbit:connection-factory id="rabbitConnectionFactory" host="${host}"
-		port="${port}" virtual-host="${vhost}"
-		username="${username}" password="${password}"/>
+	<rabbit:connection-factory id="rabbitConnectionFactory"
+		addresses="${addresses}"
+		virtual-host="${vhost}"
+		username="${username}" password="${password}" />
 
 	<bean id="messageConverter" class="${converterClass}" />
 

--- a/modules/source/rabbit/config/rabbit.xml
+++ b/modules/source/rabbit/config/rabbit.xml
@@ -35,8 +35,9 @@
 
 	<int:channel id="output" />
 
-	<rabbit:connection-factory id="rabbitConnectionFactory" host="${host}"
-		port="${port}" virtual-host="${vhost}"
+	<rabbit:connection-factory id="rabbitConnectionFactory"
+		addresses="${addresses}"
+		virtual-host="${vhost}"
 		username="${username}" password="${password}" />
 
 	<beans profile="cloud" xmlns="http://www.springframework.org/schema/beans">

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitConnectionMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitConnectionMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * Factors out options for the typical connection setup to RabbitMQ.
  * 
  * @author Eric Bottard
+ * @author Gary Russell
  */
 public class RabbitConnectionMixin {
 
@@ -37,6 +38,8 @@ public class RabbitConnectionMixin {
 	private String username = "guest";
 
 	private String password = "guest";
+
+	private String addresses;
 
 	@NotBlank
 	public String getUsername() {
@@ -76,6 +79,20 @@ public class RabbitConnectionMixin {
 	@ModuleOption("the port to connect to")
 	public void setPort(int port) {
 		this.port = port;
+	}
+
+	public String getAddresses() {
+		if (this.addresses == null) {
+			return this.host + ":" + this.port;
+		}
+		else {
+			return this.addresses;
+		}
+	}
+
+	@ModuleOption("the list of 'host:port' addresses; comma separated - overrides host, port")
+	public void setAddresses(String addresses) {
+		this.addresses = addresses;
 	}
 
 	public String getVhost() {


### PR DESCRIPTION
The rabbit connection factory supports cluster failover
by providing a list of `host:port` in the `addresses`
property.

Tested with:

`xd:>stream create foo --definition "time | rabbit --addresses=localhost:5672,10.0.0.3:5672" --deploy`
`xd:>stream create bar --definition "rabbit --queues=foo --addresses=localhost:5672,10.0.0.3:5672 | log" --deploy`

And shutting down local rabbitmq - failed over to remote.
Restart local, shutdown remote; failed back.
