### PR TITLE
XD-1819 Runtime executables share jars in xd\lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1572,19 +1572,44 @@ task launch {
 	dependsOn 'spring-xd-dirt:run'
 }
 
+def dirtJars = []
+def loadDirtJars = {
+		if (dirtJars.size == 0) {
+			File dirtLib = new File("$rootDir/spring-xd-dirt/build/install/spring-xd-dirt/lib")
+			dirtLib.traverse { jar -> dirtJars << jar.name }
+		}
+		dirtJars
+}
+
 task copyRedisInstall(type: Copy, dependsOn: ":redis:bundleRedis") {
 	from "$rootDir/redis/build"
 	into "$buildDir/dist/spring-xd/redis"
 }
 
-task copyGemfireInstall(type: Copy, dependsOn: ":spring-xd-gemfire-server:installApp") {
+task copyGemfireInstall(type: Copy, dependsOn: [
+	":spring-xd-gemfire-server:installApp",
+	"copyXDInstall"
+]) {
 	from "$rootDir/spring-xd-gemfire-server/build/install/spring-xd-gemfire-server"
 	into "$buildDir/dist/spring-xd/gemfire"
+	//exclude any jars already in xd/lib
+	exclude {jar ->
+		loadDirtJars()
+		dirtJars.contains(jar.name)
+	}
 }
 
-task copyBatchInstall(type: Copy, dependsOn: ":spring-xd-batch:installApp") {
+task copyBatchInstall(type: Copy, dependsOn: [
+":spring-xd-batch:installApp",
+"copyXDInstall"
+]) {
 	from "$rootDir/spring-xd-batch/build/install/spring-xd-batch"
 	into "$buildDir/dist/spring-xd/hsqldb"
+	//exclude any jars already in xd/lib
+	exclude {jar ->
+		loadDirtJars()
+		dirtJars.contains(jar.name)
+	}
 }
 
 task copyXDInstall(type: Copy, dependsOn: [
@@ -1600,6 +1625,7 @@ task copyXDInstall(type: Copy, dependsOn: [
 }
 
 task copyXDShellInstall(type: Copy, dependsOn: [
+	"copyXDInstall",
 	":spring-xd-shell:installApp"
 ]) {
 	from "$rootDir/spring-xd-shell/build/install/spring-xd-shell"
@@ -1607,6 +1633,11 @@ task copyXDShellInstall(type: Copy, dependsOn: [
 	exclude "**/lib/hadoop-*.jar"
 	exclude "**/lib/protobuf-java-*.jar"
 	exclude "**/lib/spring-data-hadoop-*.jar"
+	//exclude any jars already in xd/lib
+	exclude {jar ->
+		loadDirtJars()
+		dirtJars.contains(jar.name)
+	}
 }
 
 task copyHadoopLibs(dependsOn: [
@@ -1627,10 +1658,6 @@ task copyHadoopLibs(dependsOn: [
 			from "$rootDir/spring-xd-hadoop/$distro/build/lib"
 			into "$buildDir/dist/spring-xd/xd/lib/$distro"
 		}
-		copy {
-			from "$rootDir/spring-xd-hadoop/$distro/build/lib"
-			into "$buildDir/dist/spring-xd/shell/lib/$distro"
-		}
 	}
 }
 
@@ -1647,7 +1674,7 @@ task copyYarnInstall(type: Copy, dependsOn: [":spring-xd-dirt:build", ":spring-x
     exclude "**/lib/log4j-*.jar"
 }
 
-task copyInstall (type: Copy, dependsOn: ["copyRedisInstall", "copyGemfireInstall", "copyBatchInstall", "copyXDInstall", "copyHadoopLibs", "copyXDShellInstall", "copyYarnInstall"]) {
+task copyInstall (type: Copy, dependsOn: ["copyRedisInstall", "copyXDInstall", "copyGemfireInstall", "copyBatchInstall", "copyHadoopLibs", "copyXDShellInstall", "copyYarnInstall"]) {
 	group = 'Application'
 	description = "Copy all the required installs to build/dist directory"
 	from "$rootDir/scripts/README"

--- a/scripts/gemfire/gemfire-server
+++ b/scripts/gemfire/gemfire-server
@@ -65,7 +65,17 @@ cd "`dirname \"$PRG\"`/.." >&-
 APP_HOME="`pwd -P`"
 cd "$SAVED" >&-
 
-CLASSPATH=$CLASSPATH:$APP_HOME/lib/*
+addJarsToClassPath( ) {
+    if [ -d $1 ]; then
+        for jar in "$1"/*.jar; do
+            CLASSPATH="$CLASSPATH":"$jar"
+        done
+    fi
+}
+
+XD_LIB=$APP_HOME/../xd/lib
+CLASSPATH=addJarsToClassPath $XD_LIB
+CLASSPATH=addJarsToClassPath $APP_HOME/lib
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then
     if [ -x "$JAVA_HOME/jre/sh/java" ] ; then

--- a/scripts/gemfire/gemfire-server.bat
+++ b/scripts/gemfire/gemfire-server.bat
@@ -71,9 +71,15 @@ set CMD_LINE_ARGS=%$
 @rem Setup the command line
 
 set CLASSPATH=!CLASSPATH!;%APP_HOME%\lib\*
+@rem add xd/lib to CLASSPATH
+set XD_LIB=%APP_HOME%\..\xd\lib
+if exist "%XD_LIB%" (
+	setLocal EnableDelayedExpansion
+    set CLASSPATH=!CLASSPATH!;%XD_LIB%\*
+)
 
 @rem Execute gemfire-server
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% -Dlog4j.configuration=file:///%APP_HOME%/config/gemfire-cacheserver-logger.properties -classpath "%CLASSPATH%" org.springframework.xd.gemfire.CacheServer %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% -Dlog4j.configuration=file:///"%APP_HOME%"/config/gemfire-cacheserver-logger.properties -classpath "%CLASSPATH%" org.springframework.xd.gemfire.CacheServer %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/scripts/hsqldb/hsqldb-server
+++ b/scripts/hsqldb/hsqldb-server
@@ -65,12 +65,19 @@ cd "`dirname \"$PRG\"`/.." >&-
 APP_HOME="`pwd -P`"
 cd "$SAVED" >&-
 
-APP_HOME_LIB=$APP_HOME/lib
-if [ -d "$APP_HOME_LIB" ]; then
-    for i in "$APP_HOME_LIB"/*.jar; do
-        CLASSPATH="$CLASSPATH":"$i"
-    done
-fi
+addJarsToClassPath( ) {
+    if [ -d $1 ]; then
+        for jar in "$1"/*.jar; do
+            if [ $jar == spring-xd-batch* ] || [ $jar != spring-xd* ]; then
+                CLASSPATH="$CLASSPATH":"$jar"
+            fi
+        done
+    fi
+}
+
+XD_LIB=$APP_HOME/../xd/lib
+addJarsToClassPath $XD_LIB
+addJarsToClassPath $APP_HOME/lib
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then

--- a/scripts/hsqldb/hsqldb-server.bat
+++ b/scripts/hsqldb/hsqldb-server.bat
@@ -72,6 +72,12 @@ set CMD_LINE_ARGS=%$
 @echo off
 set APP_HOME_LIB=%APP_HOME%\lib
 set CLASSPATH=%APP_HOME_LIB%\*
+@rem add xd/lib to CLASSPATH
+set XD_LIB=%APP_HOME%\..\xd\lib
+if exist "%XD_LIB%" (
+    setLocal EnableDelayedExpansion
+    set CLASSPATH=!CLASSPATH!;%XD_LIB%\*
+)
 
 set SPRING_XD_OPTS=-Dxd.data.home=%APP_HOME%\..\xd\data
 

--- a/scripts/shell/xd-shell
+++ b/scripts/shell/xd-shell
@@ -81,19 +81,23 @@ for arg in "${args[@]}" ; do
     fi
     x=$((x+1))
 done
-APP_HOME_LIB=$APP_HOME/lib
-CLASSPATH="$APP_HOME/config"
-if [ -d "$APP_HOME_LIB" ]; then
-    for i in "$APP_HOME_LIB"/*.jar; do
-        CLASSPATH="$CLASSPATH":"$i"
-    done
-    HADOOP_LIB=$APP_HOME/lib/$HADOOP_DISTRO
-    if [ -d "$HADOOP_LIB" ]; then
-        for j in "$HADOOP_LIB"/*.jar; do
-            CLASSPATH="$CLASSPATH":"$j"
+
+addJarsToClassPath( ) {
+    if [ -d $1 ]; then
+        for jar in "$1"/*.jar; do
+            CLASSPATH="$CLASSPATH":"$jar"
         done
     fi
-fi
+}
+
+
+CLASSPATH="$APP_HOME/config"
+XD_LIB=$APP_HOME/../xd/lib
+APP_HOME_LIB=$APP_HOME/lib
+addJarsToClassPath $XD_LIB
+addJarsToClassPath $APP_HOME_LIB
+HADOOP_LIB=$XD_LIB/$HADOOP_DISTRO
+addJarsToClassPath $HADOOP_LIB
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then

--- a/scripts/shell/xd-shell.bat
+++ b/scripts/shell/xd-shell.bat
@@ -92,11 +92,18 @@ for %%a in (%CMD_LINE_ARGS%) do (
 )
 set CMD_LINE_ARGS=!NEW_CMD_LINE_ARGS!
 set APP_HOME_LIB=%APP_HOME%\lib
+
 if exist "%APP_HOME_LIB%" (
     setLocal EnableDelayedExpansion
     set CLASSPATH=%APP_HOME%\config
     set CLASSPATH=!CLASSPATH!;%APP_HOME_LIB%\*
-    set HADOOP_LIB=%APP_HOME%\lib\!HADOOP_DISTRO!
+)
+
+@rem add xd/lib to CLASSPATH
+set XD_LIB=%APP_HOME%\..\xd\lib
+if exist "%XD_LIB%" (
+    set CLASSPATH=!CLASSPATH!;%XD_LIB%\*
+    set HADOOP_LIB=%XD_LIB%\!HADOOP_DISTRO!
     if exist "!HADOOP_LIB!" (
         set CLASSPATH=!CLASSPATH!;!HADOOP_LIB!\*
     )

--- a/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HsqlServerApplication.java
+++ b/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HsqlServerApplication.java
@@ -19,6 +19,7 @@ package org.springframework.xd.batch.hsqldb.server;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchDatabaseInitializer;
+import org.springframework.boot.autoconfigure.integration.IntegrationAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,9 +30,10 @@ import org.springframework.xd.batch.XdBatchDatabaseInitializer;
  * Spring Application to operate life-cycle methods on {@link HSQLServerBean}.
  * 
  * @author Ilayaperumal Gopinathan
+ * @author David Turanski
  */
 @Configuration
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = { BatchAutoConfiguration.class, IntegrationAutoConfiguration.class })
 public class HsqlServerApplication {
 
 	public final static String HSQLDBSERVER_PROFILE = "hsqldbServer";


### PR DESCRIPTION
This reduces the size of XD dist zip from 390.4MB (M7)  to 252.3MB -- about 25MB due to discontinuing support for older Hadoop distros (XD-1854 applied after rebase).  This is accomplished by configuring xd-shell, hsqldb-server, and gemfire-server, to share jars already in xd/lib.  The build is modified to exclude such jars from the distribution and the runtime scripts are modified to add xd/lib  to the classpath.  I have started up and smoke tested these runtimes on Mac and Windows XD.   

Further space savings can be achieved by normalizing duplicate jars in the module lib directories. However there is some major work on the Module Registry proposed for 1.x, so this should be addressed then.  
