### PR TITLE
Fix RemoteFileToHadoopTests

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests.java
@@ -79,7 +79,7 @@ public class RemoteFileToHadoopTests {
 
 	@BeforeClass
 	public static void init() {
-		System.setProperty("spring.hadoop.fsUri", "hdfs://localhost:8020");
+		System.setProperty("fsUri", "hdfs://localhost:8020");
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/hadoop/HadoopFileSystemTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/hadoop/HadoopFileSystemTestSupport.java
@@ -20,8 +20,8 @@ import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
-
 import org.apache.hadoop.fs.Path;
+
 import org.springframework.data.hadoop.configuration.ConfigurationFactoryBean;
 import org.springframework.xd.test.AbstractExternalResourceTestSupport;
 
@@ -42,7 +42,7 @@ public class HadoopFileSystemTestSupport extends AbstractExternalResourceTestSup
 	protected void obtainResource() throws Exception {
 		ConfigurationFactoryBean cfb = new ConfigurationFactoryBean();
 		Properties props = new Properties();
-		props.setProperty("fs.defaultFS", System.getProperty("spring.hadoop.fsUri"));
+		props.setProperty("fs.defaultFS", System.getProperty("fsUri"));
 		cfb.setProperties(props);
 		cfb.setRegisterUrlHandler(false);
 		cfb.afterPropertiesSet();


### PR DESCRIPTION
- Use `fsUri` instead of `spring.hadoop.fsUri`
