### PR TITLE
XD-1701: Remove need of Hadoop on admin classpath

### DIFF
--- a/modules/sink/hdfs/config/hdfs.properties
+++ b/modules/sink/hdfs/config/hdfs.properties
@@ -26,8 +26,8 @@ options.rollover.description = threshold in bytes when file will be automaticall
 options.rollover.type = String
 options.rollover.default = 1G
 
-options.codec.description = compression codec alias name
-options.codec.type = org.springframework.data.hadoop.store.codec.Codecs
+options.codec.description = compression codec alias name (gzip, snappy, bzip2, lzo, or slzo)
+options.codec.type = String
 options.codec.default =
 
 options.idleTimeout.description = inactivity timeout after file will be automatically closed
@@ -42,10 +42,10 @@ options.inUsePrefix.description = prefix for files currently being written
 options.inUsePrefix.type = String
 options.inUsePrefix.default =
 
-options.partitionPath.description = spel expression defining a partition path
+options.partitionPath.description = SPeL expression defining a partition path
 options.partitionPath.type = String
 options.partitionPath.default =
 
 options.fileOpenAttempts.description = maximum number of file open attempts to find a path
-options.fileOpenAttempts.type = Integer
+options.fileOpenAttempts.type = int
 options.fileOpenAttempts.default = 10


### PR DESCRIPTION
Note that I created https://jira.spring.io/browse/XD-1868 to **actually** remove hadoop (and others) from the admin classpath (which should be post 1.0 IMHO)
