### PR TITLE
Update Boot plugin to latest snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -690,9 +690,9 @@ project('spring-xd-extension-jdbc') {
 		runtime "org.postgresql:postgresql:$postgresqlVersion"
 		compile project(':spring-xd-module-spi')
 		compile "javax.validation:validation-api:$validationApiVersion"
-		testCompile("org.mockito:mockito-all:$mockitoVersion") {
-			exclude group: 'org.hamcrest'
-		}
+        testCompile("org.mockito:mockito-all:$mockitoVersion") {
+            exclude group: 'org.hamcrest'
+        }
 	}
 }
 
@@ -822,33 +822,33 @@ project('spring-xd-hadoop:cdh5') {
 }
 
 project('spring-xd-hadoop:hdp21') {
-	description = 'Hortonworks HDP 2.1 dependencies'
-	dependencies {
-		runtime ("org.springframework.data:spring-data-hadoop:${springDataHadoopBase}-hdp21") {
-			exclude group: 'org.apache.hadoop'
-		}
-		runtime ("org.springframework.data:spring-data-hadoop-store:${springDataHadoopBase}-hdp21") {
-			exclude group: 'org.apache.hadoop'
-		}
-		runtime ("org.apache.hadoop:hadoop-common:$hdp21Version")
-		runtime ("org.apache.hadoop:hadoop-distcp:$hdp21Version")
-		runtime ("org.apache.hadoop:hadoop-hdfs:$hdp21Version")
-		runtime ("org.apache.hadoop:hadoop-mapreduce-client-core:$hdp21Version")
-		runtime ("org.apache.hadoop:hadoop-mapreduce-client-jobclient:$hdp21Version")
-		runtime ("org.apache.hadoop:hadoop-streaming:$hdp21Version")
-		runtime ("org.apache.hadoop:hadoop-yarn-common:$hdp21Version")
-	}
-	task copyToLib(dependsOn: build, type: Copy) {
-		into "$buildDir/lib"
-		from configurations.default
-		include 'spring-data-hadoop-*'
-		include 'hadoop-*'
-		include 'avro-*'
-		include 'protobuf-java-*'
-		include 'jetty-util-*'
+    description = 'Hortonworks HDP 2.1 dependencies'
+    dependencies {
+        runtime ("org.springframework.data:spring-data-hadoop:${springDataHadoopBase}-hdp21") {
+            exclude group: 'org.apache.hadoop'
+        }
+        runtime ("org.springframework.data:spring-data-hadoop-store:${springDataHadoopBase}-hdp21") {
+            exclude group: 'org.apache.hadoop'
+        }
+        runtime ("org.apache.hadoop:hadoop-common:$hdp21Version")
+        runtime ("org.apache.hadoop:hadoop-distcp:$hdp21Version")
+        runtime ("org.apache.hadoop:hadoop-hdfs:$hdp21Version")
+        runtime ("org.apache.hadoop:hadoop-mapreduce-client-core:$hdp21Version")
+        runtime ("org.apache.hadoop:hadoop-mapreduce-client-jobclient:$hdp21Version")
+        runtime ("org.apache.hadoop:hadoop-streaming:$hdp21Version")
+        runtime ("org.apache.hadoop:hadoop-yarn-common:$hdp21Version")
+    }
+    task copyToLib(dependsOn: build, type: Copy) {
+        into "$buildDir/lib"
+        from configurations.default
+        include 'spring-data-hadoop-*'
+        include 'hadoop-*'
+        include 'avro-*'
+        include 'protobuf-java-*'
+        include 'jetty-util-*'
 		include 'jersey-core-*'
 		include 'jersey-server-*'
-	}
+    }
 }
 
 project('spring-xd-hadoop:phd1') {
@@ -913,73 +913,73 @@ project('spring-xd-hadoop:phd20') {
 	}
 }
 project('spring-xd-yarn:spring-xd-yarn-client') {
-	description = 'Spring XD YARN Client App'
-	apply plugin: 'spring-boot'
+    description = 'Spring XD YARN Client App'
+    apply plugin: 'spring-boot'
 
-	dependencies {
-		compile "org.springframework:spring-aop:$springVersion"
-		compile "org.springframework:spring-context:$springVersion"
-		compile "org.springframework:spring-context-support:$springVersion"
-		compile "org.springframework:spring-jdbc:$springVersion"
-		compile "org.springframework:spring-tx:$springVersion"
-		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-		compile ("org.springframework.data:spring-yarn-boot:$springDataHadoopVersion") {
-			exclude group: 'javax.servlet'
-			exclude group: 'javax.servlet.jsp'
-			exclude group: 'tomcat'
-			exclude group: 'org.mortbay.jetty'
-			exclude group: 'com.sun.jersey'
-			exclude group: 'org.codehaus.jackson'
-			exclude group: 'net.java.dev.jets3t'
-			exclude group: 'com.jcraft'
-			exclude group: 'junit'
-			exclude group: 'hsqldb'
-			exclude group: 'org.slf4j'
-			exclude group: 'log4j'
-		}
-		compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
-		runtime "log4j:log4j:$log4jVersion",
-				"org.slf4j:jcl-over-slf4j:$slf4jVersion",
-				"org.slf4j:slf4j-log4j12:$slf4jVersion"
-	}
+    dependencies {
+        compile "org.springframework:spring-aop:$springVersion"
+        compile "org.springframework:spring-context:$springVersion"
+        compile "org.springframework:spring-context-support:$springVersion"
+        compile "org.springframework:spring-jdbc:$springVersion"
+        compile "org.springframework:spring-tx:$springVersion"
+        compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
+        compile ("org.springframework.data:spring-yarn-boot:$springDataHadoopVersion") {
+            exclude group: 'javax.servlet'
+            exclude group: 'javax.servlet.jsp'
+            exclude group: 'tomcat'
+            exclude group: 'org.mortbay.jetty'
+            exclude group: 'com.sun.jersey'
+            exclude group: 'org.codehaus.jackson'
+            exclude group: 'net.java.dev.jets3t'
+            exclude group: 'com.jcraft'
+            exclude group: 'junit'
+            exclude group: 'hsqldb'
+            exclude group: 'org.slf4j'
+            exclude group: 'log4j'
+        }
+        compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
+        runtime "log4j:log4j:$log4jVersion",
+                "org.slf4j:jcl-over-slf4j:$slf4jVersion",
+                "org.slf4j:slf4j-log4j12:$slf4jVersion"
+    }
 
-	jar {
-		setExcludes([])
+    jar {
+    	setExcludes([])
 	}
 }
 
 project('spring-xd-yarn:spring-xd-yarn-appmaster') {
-	description = 'Spring XD YARN AppMaster'
-	apply plugin: 'spring-boot'
+    description = 'Spring XD YARN AppMaster'
+    apply plugin: 'spring-boot'
 
-	dependencies {
-		compile "org.springframework:spring-aop:$springVersion"
-		compile "org.springframework:spring-context:$springVersion"
-		compile "org.springframework:spring-context-support:$springVersion"
-		compile "org.springframework:spring-jdbc:$springVersion"
-		compile "org.springframework:spring-tx:$springVersion"
-		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-		compile ("org.springframework.data:spring-yarn-boot:$springDataHadoopVersion") {
-			exclude group: 'javax.servlet'
-			exclude group: 'javax.servlet.jsp'
-			exclude group: 'tomcat'
-			exclude group: 'org.mortbay.jetty'
-			exclude group: 'com.sun.jersey'
-			exclude group: 'org.codehaus.jackson'
-			exclude group: 'net.java.dev.jets3t'
-			exclude group: 'com.jcraft'
-			exclude group: 'junit'
-			exclude group: 'hsqldb'
-			exclude group: 'org.slf4j'
-			exclude group: 'log4j'
-			runtime "org.slf4j:jcl-over-slf4j:$slf4jVersion",
-					"org.slf4j:slf4j-log4j12:$slf4jVersion"
-		}
-		compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
-	}
+    dependencies {
+        compile "org.springframework:spring-aop:$springVersion"
+        compile "org.springframework:spring-context:$springVersion"
+        compile "org.springframework:spring-context-support:$springVersion"
+        compile "org.springframework:spring-jdbc:$springVersion"
+        compile "org.springframework:spring-tx:$springVersion"
+        compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
+        compile ("org.springframework.data:spring-yarn-boot:$springDataHadoopVersion") {
+            exclude group: 'javax.servlet'
+            exclude group: 'javax.servlet.jsp'
+            exclude group: 'tomcat'
+            exclude group: 'org.mortbay.jetty'
+            exclude group: 'com.sun.jersey'
+            exclude group: 'org.codehaus.jackson'
+            exclude group: 'net.java.dev.jets3t'
+            exclude group: 'com.jcraft'
+            exclude group: 'junit'
+            exclude group: 'hsqldb'
+            exclude group: 'org.slf4j'
+            exclude group: 'log4j'
+            runtime "org.slf4j:jcl-over-slf4j:$slf4jVersion",
+                    "org.slf4j:slf4j-log4j12:$slf4jVersion"
+        }
+        compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
+    }
 
-	jar {
-		setExcludes([])
+    jar {
+    	setExcludes([])
 	}
 }
 
@@ -1166,18 +1166,18 @@ project('modules.source.syslog-udp') {
 project('modules.source.reactor-ip') {
 	dependencies {
 		runtime(project(":spring-xd-extension-reactor")) {
-			exclude module: 'slf4j-api'
-			exclude module: 'spring-integration-core'
-		}
+            exclude module: 'slf4j-api'
+            exclude module: 'spring-integration-core'
+        }
 	}
 }
 
 project('modules.source.reactor-syslog') {
 	dependencies {
 		runtime(project(":spring-xd-extension-reactor")) {
-			exclude module: 'slf4j-api'
-			exclude module: 'spring-integration-core'
-		}
+            exclude module: 'slf4j-api'
+            exclude module: 'spring-integration-core'
+        }
 	}
 }
 
@@ -1496,12 +1496,12 @@ project('spring-xd-batch') {
 	}
 	apply plugin:'application'
 	// skip the startScripts task to avoid default start script generation
-		startScripts.setEnabled(false)
+        startScripts.setEnabled(false)
 
-		task scriptFiles {
-				def scripts = file("$rootDir/scripts/hsqldb")
-				outputs.dir scripts
-		}
+        task scriptFiles {
+                def scripts = file("$rootDir/scripts/hsqldb")
+                outputs.dir scripts
+        }
 
 	applicationDistribution.from(scriptFiles) { into "bin" }
 }
@@ -1652,7 +1652,7 @@ task copyHadoopLibs(dependsOn: [
 }
 
 task copyYarnInstall(type: Copy, dependsOn: [":spring-xd-dirt:build", ":spring-xd-dirt:installApp", ":spring-xd-yarn:spring-xd-yarn-client:build", ":spring-xd-yarn:spring-xd-yarn-appmaster:build"]) {
-	group = 'Application'
+    group = 'Application'
 	from "$rootDir/spring-xd-dirt/build/install/spring-xd-dirt"
 	into "$buildDir/dist/spring-xd-yarn/xd-yarn"
 	exclude "**/bin/*"
@@ -1660,8 +1660,8 @@ task copyYarnInstall(type: Copy, dependsOn: [":spring-xd-dirt:build", ":spring-x
 	exclude "**/config/modules"
 	exclude "**/lib/hadoop-*.jar"
 	exclude "**/lib/spring-data-hadoop-*.jar"
-	exclude "**/lib/slf4j-log4j12-*.jar"
-	exclude "**/lib/log4j-*.jar"
+    exclude "**/lib/slf4j-log4j12-*.jar"
+    exclude "**/lib/log4j-*.jar"
 }
 
 task copyInstall (type: Copy, dependsOn: ["copyRedisInstall", "copyGemfireInstall", "copyBatchInstall", "copyXDInstall", "copyHadoopLibs", "copyXDShellInstall", "copyYarnInstall"]) {
@@ -1836,13 +1836,13 @@ task api(type: Javadoc) {
 		project.sourceSets.main.compileClasspath
 	})
 
-		if (JavaVersion.current().isJava8Compatible()) {
-			allprojects {
-				tasks.withType(Javadoc) {
-					options.addStringOption('Xdoclint:none', '-quiet')
-				}
-			}
-		}
+        if (JavaVersion.current().isJava8Compatible()) {
+            allprojects {
+                tasks.withType(Javadoc) {
+                    options.addStringOption('Xdoclint:none', '-quiet')
+                }
+            }
+        }
 }
 
 task docsZip(type: Zip) {
@@ -1892,22 +1892,22 @@ task yarnZip(type: Zip, dependsOn: [copyInstall], overwrite: true) {
 
 	destinationDir = new File("$buildDir/tmp")
 
-	from("$buildDir/dist/spring-xd-yarn/xd-yarn/lib") {
+    from("$buildDir/dist/spring-xd-yarn/xd-yarn/lib") {
 		into "/lib"
 	}
-	from("$buildDir/dist/spring-xd/xd/lib/hadoop22") {
-		include "spring-data-hadoop-*.jar"
-		into "/lib"
-	}
-	from("$buildDir/dist/spring-xd-yarn/xd-yarn/config") {
-		into "/config"
-	}
-	from("$buildDir/dist/spring-xd-yarn/xd-yarn/modules") {
-		into "/modules"
-	}
-	from("$buildDir/dist/spring-xd-yarn/xd-yarn/spring-xd-ui") {
-		into "/spring-xd-ui"
-	}
+    from("$buildDir/dist/spring-xd/xd/lib/hadoop22") {
+        include "spring-data-hadoop-*.jar"
+        into "/lib"
+    }
+    from("$buildDir/dist/spring-xd-yarn/xd-yarn/config") {
+        into "/config"
+    }
+    from("$buildDir/dist/spring-xd-yarn/xd-yarn/modules") {
+        into "/modules"
+    }
+    from("$buildDir/dist/spring-xd-yarn/xd-yarn/spring-xd-ui") {
+        into "/spring-xd-ui"
+    }
 }
 
 task distYarnZip(type: Zip, dependsOn: [copyInstall, yarnZip], overwrite: true) {
@@ -1917,12 +1917,12 @@ task distYarnZip(type: Zip, dependsOn: [copyInstall, yarnZip], overwrite: true) 
 
 	ext.baseDir = "${project.name}-${project.version}-yarn";
 
-	from("$rootDir/scripts/README") {
-		into "${baseDir}"
-	}
-	from("$rootDir/scripts/LICENSE") {
-		into "${baseDir}"
-	}
+    from("$rootDir/scripts/README") {
+        into "${baseDir}"
+    }
+    from("$rootDir/scripts/LICENSE") {
+        into "${baseDir}"
+    }
 	from("$rootDir/spring-xd-yarn/site/scripts") {
 		into "${baseDir}/bin"
 	}
@@ -1939,10 +1939,10 @@ task distYarnZip(type: Zip, dependsOn: [copyInstall, yarnZip], overwrite: true) 
 		include "spring-xd-yarn-appmaster-${project.version}.jar"
 		into "${baseDir}/lib"
 	}
-	from("$buildDir/tmp") {
-		include "spring-xd-yarn-${project.version}.zip"
-		into "${baseDir}"
-	}
+    from("$buildDir/tmp") {
+    	include "spring-xd-yarn-${project.version}.zip"
+    	into "${baseDir}"
+    }
 }
 
 artifacts {
@@ -1965,14 +1965,14 @@ task wrapper(type: Wrapper) {
 apply plugin: 'jacoco'
 
 jacoco {
-	toolVersion = '0.7.0.201403182114'
+    toolVersion = '0.7.0.201403182114'
 }
 
 configure (coverageProjects) {
-	project -> apply plugin: 'jacoco'
-	jacoco {
-		toolVersion = '0.7.0.201403182114'
-	}
+    project -> apply plugin: 'jacoco'
+    jacoco {
+        toolVersion = '0.7.0.201403182114'
+    }
 }
 
 task coverageReport(type: JacocoReport) {

--- a/spring-xd-exec/README.md
+++ b/spring-xd-exec/README.md
@@ -1,1 +1,0 @@
-Directory is used by the *Spring XD Exec* Gradle module.


### PR DESCRIPTION
The latest Boot plugin has a number of useful features including the ability to create the executable dirt jar in place (instead of using the spring-xd-exec pseudo-project).

TODO: there's no reason spring-xd-dirt.jar (the non-executable version) needs to have application.yml in it, but the shell tests don't have an application.yml of their own so they will fail if we take it out of the DIRT jar now.
