### PR TITLE
XD-1872 Close Taps pathcache upon ZK disconnect

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -348,7 +348,12 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 		@Override
 		public void onDisconnect(CuratorFramework client) {
 			taps.getListenable().removeListener(tapListener);
-			taps.clear();
+			try {
+				taps.close();
+			}
+			catch (Exception e) {
+				throw ZooKeeperUtils.wrapThrowable(e);
+			}
 		}
 
 		@Override


### PR DESCRIPTION
- In AbstractMessageBusBinderPlugin, close the `taps` PathChildrenCache
  upon ZK disconnect. This will avoid existence of multiple `TapsPathChildrenCache`
  over period of time (during multiple ZK connect/disconnect)
