### PR TITLE
XD-1846 Simplify DeploymentVerifier

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/DeploymentPathProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/DeploymentPathProvider.java
@@ -16,16 +16,18 @@
 
 package org.springframework.xd.dirt.test;
 
-import java.util.List;
+import org.springframework.xd.dirt.core.DeploymentUnitStatus;
+
 
 /**
  * For a given deployment name, provide the expected ZooKeeper
- * paths for definitions, deployments, and individual module
- * deployments.
+ * paths for definitions, deployments.
  *
  * @author Patrick Peralta
+ * @author Ilayaperumal Gopinathan
  */
 public interface DeploymentPathProvider {
+
 	/**
 	 * Return the expected path for a definition with the provided name.
 	 *
@@ -35,22 +37,10 @@ public interface DeploymentPathProvider {
 	String getDefinitionPath(String name);
 
 	/**
-	 * Return the expected path for a deployment with the provided name.
+	 * Return the deployment status for the deployment name.
 	 *
-	 * @param name definition name
-	 * @return path of deployment
+	 * @param name deployment name
+	 * @return the deployment status
 	 */
-	String getDeploymentPath(String name);
-
-	/**
-	 * Return the number of children expected under the deployment path
-	 * for this deployment. When the expected number of children exist,
-	 * it is assumed that all modules were deployed.
-	 *
-	 * @param name definition name
-	 *
-	 * @return number of children expected under the deployment path
-	 *         for this deployment
-	 */
-	int getDeploymentPathChildrenCount(String name);
+	DeploymentUnitStatus getDeploymentStatus(String name);
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/JobPathProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/JobPathProvider.java
@@ -17,22 +17,32 @@
 package org.springframework.xd.dirt.test;
 
 
+import org.springframework.xd.dirt.core.DeploymentUnitStatus;
+import org.springframework.xd.dirt.stream.JobRepository;
 import org.springframework.xd.dirt.zookeeper.Paths;
 
 /**
- * Provides path information for job definitions, deployments, and
- * job module deployments.
+ * Provides path information for job definitions, deployments.
  *
  * @author David Turanski
  * @author Mark Fisher
  * @author Patrick Peralta
+ * @author Ilayaperumal Gopinathan
  */
 public class JobPathProvider implements DeploymentPathProvider {
 
 	/**
-	 * Construct a JobPathProvider.
+	 * Job instance repository
 	 */
-	public JobPathProvider() {
+	private final JobRepository jobRepository;
+
+	/**
+	 * Construct a JobPathProvider.
+	 *
+	 * @param jobRepository the job instance repository
+	 */
+	public JobPathProvider(JobRepository jobRepository) {
+		this.jobRepository = jobRepository;
 	}
 
 	/**
@@ -47,17 +57,7 @@ public class JobPathProvider implements DeploymentPathProvider {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public String getDeploymentPath(String jobName) {
-		return Paths.build(Paths.JOB_DEPLOYMENTS, jobName, Paths.MODULES);
+	public DeploymentUnitStatus getDeploymentStatus(String jobName) {
+		return this.jobRepository.getDeploymentStatus(jobName);
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public int getDeploymentPathChildrenCount(String jobName) {
-		// jobs always have one module
-		return 1;
-	}
-
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/SingleNodeIntegrationTestSupport.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/SingleNodeIntegrationTestSupport.java
@@ -24,11 +24,11 @@ import org.springframework.xd.dirt.core.RuntimeTimeoutException;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
 import org.springframework.xd.dirt.module.DelegatingModuleRegistry;
-import org.springframework.xd.dirt.module.ModuleDefinitionRepository;
 import org.springframework.xd.dirt.module.ModuleDeployer;
 import org.springframework.xd.dirt.module.ModuleRegistry;
 import org.springframework.xd.dirt.module.ResourceModuleRegistry;
 import org.springframework.xd.dirt.server.SingleNodeApplication;
+import org.springframework.xd.dirt.stream.JobRepository;
 import org.springframework.xd.dirt.stream.StreamDefinition;
 import org.springframework.xd.dirt.stream.StreamDefinitionRepository;
 import org.springframework.xd.dirt.stream.StreamDeployer;
@@ -36,7 +36,6 @@ import org.springframework.xd.dirt.stream.StreamRepository;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperUtils;
 import org.springframework.xd.module.core.Module;
-import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
 
 
 /**
@@ -53,6 +52,8 @@ public class SingleNodeIntegrationTestSupport {
 	private StreamDefinitionRepository streamDefinitionRepository;
 
 	private StreamRepository streamRepository;
+
+	private JobRepository jobRepository;
 
 	private StreamDeployer streamDeployer;
 
@@ -83,15 +84,13 @@ public class SingleNodeIntegrationTestSupport {
 		Assert.notNull(application, "SingleNodeApplication must not be null");
 		streamDefinitionRepository = application.pluginContext().getBean(StreamDefinitionRepository.class);
 		streamRepository = application.pluginContext().getBean(StreamRepository.class);
+		jobRepository = application.pluginContext().getBean(JobRepository.class);
 		streamDeployer = application.adminContext().getBean(StreamDeployer.class);
 		messageBus = application.pluginContext().getBean(MessageBusSupport.class);
 		zooKeeperConnection = application.adminContext().getBean(ZooKeeperConnection.class);
 		moduleDeployer = application.containerContext().getBean(ModuleDeployer.class);
-		streamDeploymentVerifier = new DeploymentVerifier(zooKeeperConnection,
-				new StreamPathProvider(zooKeeperConnection, streamDefinitionRepository,
-						application.containerContext().getBean(ModuleDefinitionRepository.class),
-						application.containerContext().getBean(ModuleOptionsMetadataResolver.class)));
-		jobDeploymentVerifier = new DeploymentVerifier(zooKeeperConnection, new JobPathProvider());
+		streamDeploymentVerifier = new DeploymentVerifier(zooKeeperConnection, new StreamPathProvider(streamRepository));
+		jobDeploymentVerifier = new DeploymentVerifier(zooKeeperConnection, new JobPathProvider(jobRepository));
 		ResourceModuleRegistry cp = new ResourceModuleRegistry(moduleResourceLocation);
 		DelegatingModuleRegistry cmr1 = application.pluginContext().getBean(DelegatingModuleRegistry.class);
 		cmr1.addDelegate(cp);


### PR DESCRIPTION
- With the Stream/Job Deployment State changes, the `DeploymentVerifier`
  has been simplified to use the DeploymentUnitStatus.State to verify if
  the Stream/Job is successfully deployed/undeployed.
  - Add `getDeploymentStatus` in DeploymentPathProvider and remove other
    deployment path specific method contracts.
  - Have `Stream/JobPathProvider`s implement this method and use Stream/JobRepository's
    `getDeploymentStatus` (via DeploymentStatusRepository) to return DeploymentUnitStatus
  - Since the StateCalcualtor already determines the number of modules that need to be
    deployed for a given deployment unit, the verification of `DeploymentUnitStatus.State`
    can be sufficient to assert if the deployment unit is successfully deployed/undeployed
    with the expected number of modules count etc.,
  - Update `DeploymentVerifier`'s deployment verifier methods waitForDeploy/waitForUndeploy
