### PR TITLE
XD-1839: Named channels only allowed in full streams

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/ParsingContext.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/ParsingContext.java
@@ -32,38 +32,38 @@ public enum ParsingContext {
 	/**
 	 * A full stream definition, which ought to start with a source (or channel) and end with a sink (or channel).
 	 */
-	stream(true, source, processor, sink),
+	stream(true, true, source, processor, sink),
 
 	/**
 	 * A composed module, which starts or ends on a processor.
 	 */
 	// Read these vertically: either [source, processor, processor] or [processor, processor, sink]
-	module(true, new ModuleType[] { source, processor },
+	module(true, false, new ModuleType[] { source, processor },
 			new ModuleType[] { processor /* ,processsor */},
 			new ModuleType[] { processor, sink }),
 
 	/**
 	 * A job definition.
 	 */
-	job(true, ModuleType.job, null, null),
+	job(true, false, ModuleType.job, null, null),
 
 	/**
 	 * For the purpose of DSL completion only, a (maybe unfinished) stream definition.
 	 */
-	partial_stream(false, new ModuleType[] { source },
+	partial_stream(false, true, new ModuleType[] { source },
 			new ModuleType[] { processor },
 			new ModuleType[] { processor, sink }),
 	/**
 	 * For the purpose of DSL completion only, a (maybe unfinished) composed module definition.
 	 */
-	partial_module(false, new ModuleType[] { source, processor },
+	partial_module(false, false, new ModuleType[] { source, processor },
 			new ModuleType[] { processor },
 			new ModuleType[] { processor, sink }),
 
 	/**
 	 * For the purpose of DSL completion only, a (maybe unfinished) job definition.
 	 */
-	partial_job(false, ModuleType.job, null, null);
+	partial_job(false, false, ModuleType.job, null, null);
 
 	/**
 	 * Represents the position of a module in an XD DSL declaration.
@@ -114,15 +114,22 @@ public enum ParsingContext {
 		return bindAndValidate;
 	}
 
-	private ParsingContext(boolean bindAndValidate, ModuleType atStart, ModuleType atMiddle, ModuleType atEnd) {
-		this(bindAndValidate,
+	public boolean supportsNamedChannels() {
+		return supportsNamedChannels;
+	}
+
+	private ParsingContext(boolean bindAndValidate, boolean supportsNamedChannels, ModuleType atStart,
+			ModuleType atMiddle, ModuleType atEnd) {
+		this(bindAndValidate, supportsNamedChannels,
 				new ModuleType[] { atStart },
 				new ModuleType[] { atMiddle },
 				new ModuleType[] { atEnd });
 	}
 
-	private ParsingContext(boolean bindAndValidate, ModuleType[] atStart, ModuleType[] atMiddle, ModuleType[] atEnd) {
+	private ParsingContext(boolean bindAndValidate, boolean supportsNamedChannels, ModuleType[] atStart,
+			ModuleType[] atMiddle, ModuleType[] atEnd) {
 		this.bindAndValidate = bindAndValidate;
+		this.supportsNamedChannels = supportsNamedChannels;
 		allowed[0] = atStart;
 		allowed[1] = atMiddle;
 		allowed[2] = atEnd;
@@ -138,6 +145,8 @@ public enum ParsingContext {
 	 * want to fail with a validation exception.
 	 */
 	private final boolean bindAndValidate;
+
+	private final boolean supportsNamedChannels;
 
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
@@ -17,6 +17,8 @@
 package org.springframework.xd.dirt.stream;
 
 
+import static org.springframework.xd.dirt.stream.dsl.XDDSLMessages.NAMED_CHANNELS_UNSUPPORTED_HERE;
+
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
@@ -37,6 +39,7 @@ import org.springframework.xd.dirt.stream.dsl.ModuleNode;
 import org.springframework.xd.dirt.stream.dsl.SinkChannelNode;
 import org.springframework.xd.dirt.stream.dsl.SourceChannelNode;
 import org.springframework.xd.dirt.stream.dsl.StreamConfigParser;
+import org.springframework.xd.dirt.stream.dsl.StreamDefinitionException;
 import org.springframework.xd.dirt.stream.dsl.StreamNode;
 import org.springframework.xd.module.ModuleDefinition;
 import org.springframework.xd.module.ModuleDescriptor;
@@ -136,12 +139,24 @@ public class XDStreamParser implements XDParser {
 
 		SourceChannelNode sourceChannel = stream.getSourceChannelNode();
 		if (sourceChannel != null) {
-			builders.getLast().setSourceChannelName(sourceChannel.getChannelName());
+			if (parsingContext.supportsNamedChannels()) {
+				builders.getLast().setSourceChannelName(sourceChannel.getChannelName());
+			}
+			else {
+				throw new StreamDefinitionException(config, sourceChannel.getStartPos(),
+						NAMED_CHANNELS_UNSUPPORTED_HERE);
+			}
 		}
 
 		SinkChannelNode sinkChannel = stream.getSinkChannelNode();
 		if (sinkChannel != null) {
-			builders.getFirst().setSinkChannelName(sinkChannel.getChannelName());
+			if (parsingContext.supportsNamedChannels()) {
+				builders.getFirst().setSinkChannelName(sinkChannel.getChannelName());
+			}
+			else {
+				throw new StreamDefinitionException(config, sinkChannel.getChannelNode().getStartPos(),
+						NAMED_CHANNELS_UNSUPPORTED_HERE);
+			}
 		}
 
 		// Now that we know about source and sink channel names,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/XDDSLMessages.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/XDDSLMessages.java
@@ -100,8 +100,8 @@ public enum XDDSLMessages {
 			"Reference to ''{0}'' is not unique in the target stream ''{1}'', please label the relevant module and use the label, or use a suffix index to indicate which occurrence of the module, e.g. ''{0}.0''"), //
 	NO_WHITESPACE_IN_DOTTED_NAME(ERROR,
 			145,
-			"No whitespace is allowed between dot and components of a name"), //
-	;
+			"No whitespace is allowed between dot and components of a name"),
+	NAMED_CHANNELS_UNSUPPORTED_HERE(ERROR, 146, "A named channel is not supported in this kind of definition"), ;
 
 	private Kind kind;
 


### PR DESCRIPTION
Not sure about where exactly to report the error location. I chose the channel name itself (as opposed to the ">" symbol) 
I think it should be consistent between the source and sink case, but the current behavior seems to imply that in

```
http > queue:bar
       ^
```

if you change "queue:bar" to something else, it may succeed eventually, which is not the case.

Thoughts welcome
