### PR TITLE
XD-1848 more fine grained states via REST API

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
@@ -108,7 +108,7 @@ public class JobsController extends
 			JobDefinitionResource maskedJobDefinitionResource =
 					new JobDefinitionResource(jobDefinitionResource.getName(),
 							PasswordUtils.maskPasswordsInDefinition(jobDefinitionResource.getDefinition()));
-			maskedJobDefinitionResource.setDeployed(jobDefinitionResource.isDeployed());
+			maskedJobDefinitionResource.setStatus(jobDefinitionResource.getStatus());
 			maskedContents.add(maskedJobDefinitionResource);
 		}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/BaseInstance.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/BaseInstance.java
@@ -20,6 +20,7 @@ import java.util.Date;
 
 import org.springframework.util.Assert;
 import org.springframework.xd.dirt.core.BaseDefinition;
+import org.springframework.xd.dirt.core.DeploymentUnitStatus;
 
 /**
  * A runtime representation of a Definition.
@@ -40,6 +41,11 @@ public class BaseInstance<D extends BaseDefinition> {
 	 * When was this instance started.
 	 */
 	private Date startedAt = new Date();
+
+	/**
+	 * Status for this deployment unit.
+	 */
+	private DeploymentUnitStatus status;
 
 	/**
 	 * Create a new instance out of the given definition.
@@ -64,7 +70,7 @@ public class BaseInstance<D extends BaseDefinition> {
 	}
 
 	/**
-	 * Returns the date when this instance was started.
+	 * Set the date when this instance was started.
 	 * 
 	 * @param startedAt Must not be null
 	 */
@@ -72,4 +78,21 @@ public class BaseInstance<D extends BaseDefinition> {
 		Assert.notNull(startedAt, "The passed in date must not be null.");
 		this.startedAt = startedAt;
 	}
+
+	/**
+	 * @return the {@link DeploymentUnitStatus} for this instance.
+	 */
+	public DeploymentUnitStatus getStatus() {
+		return status;
+	}
+
+	/**
+	 * Set the {@link DeploymentUnitStatus} for this instance.
+	 * 
+	 * @param status the status for this instance
+	 */
+	public void setStatus(DeploymentUnitStatus status) {
+		this.status = status;
+	}
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperJobRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperJobRepository.java
@@ -115,6 +115,7 @@ public class ZooKeeperJobRepository implements JobRepository, InitializingBean {
 				Stat deployStat = client.checkExists().forPath(Paths.build(Paths.JOB_DEPLOYMENTS, id));
 				if (deployStat != null) {
 					job.setStartedAt(new Date(deployStat.getCtime()));
+					job.setStatus(getDeploymentStatus(id));
 					return job;
 				}
 			}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamRepository.java
@@ -120,6 +120,7 @@ public class ZooKeeperStreamRepository implements StreamRepository, Initializing
 				Stat deployStat = client.checkExists().forPath(Paths.build(Paths.STREAM_DEPLOYMENTS, id));
 				if (deployStat != null) {
 					stream.setStartedAt(new Date(deployStat.getCtime()));
+					stream.setStatus(getDeploymentStatus(id));
 					return stream;
 				}
 			}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
@@ -45,6 +45,7 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.xd.dirt.core.DeploymentUnitStatus;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.module.ModuleRegistry;
 import org.springframework.xd.dirt.plugins.job.DistributedJobLocator;
@@ -246,7 +247,7 @@ public class JobsControllerIntegrationTests extends AbstractControllerIntegratio
 		mockMvc.perform(get("/jobs/definitions/job1")
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.deployed", equalTo(false)));
+				.andExpect(jsonPath("$.status", equalTo(DeploymentUnitStatus.State.undeployed.toString())));
 
 	}
 
@@ -260,7 +261,7 @@ public class JobsControllerIntegrationTests extends AbstractControllerIntegratio
 		mockMvc.perform(get("/jobs/definitions/job1")
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.deployed", equalTo(true)));
+				.andExpect(jsonPath("$.status", equalTo(DeploymentUnitStatus.State.deploying.toString())));
 
 	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationWithRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationWithRepositoryTests.java
@@ -39,6 +39,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.xd.dirt.core.DeploymentUnitStatus;
 import org.springframework.xd.dirt.module.ModuleRegistry;
 import org.springframework.xd.dirt.stream.StreamDefinition;
 import org.springframework.xd.dirt.stream.StreamDeployer;
@@ -156,7 +157,7 @@ public class StreamsControllerIntegrationWithRepositoryTests extends AbstractCon
 		mockMvc.perform(get("/streams/definitions/mystream")
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.deployed", Matchers.equalTo(false)));
+				.andExpect(jsonPath("$.status", Matchers.equalTo(DeploymentUnitStatus.State.undeployed.toString())));
 
 		mockMvc.perform(delete("/streams/definitions/mystream").accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isOk());
@@ -179,7 +180,7 @@ public class StreamsControllerIntegrationWithRepositoryTests extends AbstractCon
 		mockMvc.perform(get("/streams/definitions/mystream")
 				.accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.deployed", Matchers.equalTo(true)));
+				.andExpect(jsonPath("$.status", Matchers.equalTo(DeploymentUnitStatus.State.deploying.toString())));
 
 		mockMvc.perform(delete("/streams/definitions/mystream").accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isOk());

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/JobUtils.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/JobUtils.java
@@ -127,7 +127,7 @@ public class JobUtils {
 		while (resourceIter.hasNext()) {
 			JobDefinitionResource resource = resourceIter.next();
 			if (jobName.equals(resource.getName())) {
-				if (resource.isDeployed()) {
+				if ("deployed".equals(resource.getStatus())) {
 					result = true;
 					break;
 				}

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/StreamUtils.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/StreamUtils.java
@@ -203,7 +203,7 @@ public class StreamUtils {
 		while (resourceIter.hasNext()) {
 			StreamDefinitionResource resource = resourceIter.next();
 			if (streamName.equals(resource.getName())) {
-				if (resource.isDeployed()) {
+				if ("deployed".equals(resource.getStatus())) {
 					result = true;
 					break;
 				}

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/DeployableResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/DeployableResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 
 package org.springframework.xd.rest.client.domain;
 
-
 /**
- * Abstract base class for resources that represent deployable things.
+ * Abstract base class for resources that represent deployable units.
  * 
  * @author Eric Bottard
+ * @author Mark Fisher
  */
 public abstract class DeployableResource extends NamedResource {
 
@@ -35,17 +35,17 @@ public abstract class DeployableResource extends NamedResource {
 	}
 
 	// @XmlAttribute
-	private Boolean deployed;
+	private String status;
 
 	/**
-	 * Return deployment status of the underlying thing, or {@code null} if unknown.
+	 * Return status of the underlying deployment unit, or {@code null} if unknown.
 	 */
-	public Boolean isDeployed() {
-		return deployed;
+	public String getStatus() {
+		return status;
 	}
 
-	public void setDeployed(Boolean deployed) {
-		this.deployed = deployed;
+	public void setStatus(String status) {
+		this.status = status;
 	}
 
 }

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
@@ -113,21 +113,16 @@ public class JobCommands implements CommandMarker {
 	public Table listJobs() {
 
 		final PagedResources<JobDefinitionResource> jobs = jobOperations().list();
-		final Table table = new Table();
-		table.addHeader(1, new TableHeader("Job Name")).
-				addHeader(2, new TableHeader("Job Definition")).
-				addHeader(3, new TableHeader("Status"));
+		final Table table = new Table()
+				.addHeader(1, new TableHeader("Job Name"))
+				.addHeader(2, new TableHeader("Job Definition"))
+				.addHeader(3, new TableHeader("Status"));
 
 		for (JobDefinitionResource jobDefinitionResource : jobs) {
-			final TableRow row = new TableRow();
-			row.addValue(1, jobDefinitionResource.getName()).addValue(2, jobDefinitionResource.getDefinition());
-			if (Boolean.TRUE.equals(jobDefinitionResource.isDeployed())) {
-				row.addValue(3, "deployed");
-			}
-			else {
-				row.addValue(3, "undeployed");
-			}
-			table.getRows().add(row);
+			table.newRow()
+					.addValue(1, jobDefinitionResource.getName())
+					.addValue(2, jobDefinitionResource.getDefinition())
+					.addValue(3, jobDefinitionResource.getStatus());
 		}
 		return table;
 	}

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/StreamCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/StreamCommands.java
@@ -28,7 +28,6 @@ import org.springframework.xd.rest.client.domain.StreamDefinitionResource;
 import org.springframework.xd.shell.XDShell;
 import org.springframework.xd.shell.util.Table;
 import org.springframework.xd.shell.util.TableHeader;
-import org.springframework.xd.shell.util.TableRow;
 
 @Component
 public class StreamCommands implements CommandMarker {
@@ -122,23 +121,18 @@ public class StreamCommands implements CommandMarker {
 
 		final PagedResources<StreamDefinitionResource> streams = streamOperations().list();
 
-		final Table table = new Table();
-		table.addHeader(1, new TableHeader("Stream Name")).addHeader(2, new TableHeader("Stream Definition")).addHeader(
-				3, new TableHeader("Status"));
+		final Table table = new Table()
+				.addHeader(1, new TableHeader("Stream Name"))
+				.addHeader(2, new TableHeader("Stream Definition"))
+				.addHeader(3, new TableHeader("Status"));
 
 		for (StreamDefinitionResource stream : streams) {
-			final TableRow row = table.newRow();
-			row.addValue(1, stream.getName()).addValue(2, stream.getDefinition());
-			if (Boolean.TRUE.equals(stream.isDeployed())) {
-				row.addValue(3, "deployed");
-			}
-			else {
-				row.addValue(3, "undeployed");
-			}
+			table.newRow()
+					.addValue(1, stream.getName())
+					.addValue(2, stream.getDefinition())
+					.addValue(3, stream.getStatus());
 		}
-
 		return table;
-
 	}
 
 	private StreamOperations streamOperations() {

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/ExistingXDEntityConverter.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/ExistingXDEntityConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ public class ExistingXDEntityConverter implements Converter<String> {
 			@Override
 			boolean matches(NamedResource resource) {
 				DeployableResource deployable = (DeployableResource) resource;
-				return Boolean.TRUE.equals(deployable.isDeployed());
+				return deployed.toString().equals(deployable.getStatus());
 			}
 
 			@Override
@@ -134,7 +134,7 @@ public class ExistingXDEntityConverter implements Converter<String> {
 			@Override
 			boolean matches(NamedResource resource) {
 				DeployableResource deployable = (DeployableResource) resource;
-				return Boolean.FALSE.equals(deployable.isDeployed());
+				return undeployed.toString().equals(deployable.getStatus());
 			}
 
 			@Override
@@ -158,12 +158,10 @@ public class ExistingXDEntityConverter implements Converter<String> {
 			String heading(NamedResource resource, String kind) {
 				if (resource instanceof DeployableResource) {
 					DeployableResource deployable = (DeployableResource) resource;
-					if (Boolean.TRUE.equals(deployable.isDeployed())) {
-						return String.format("Deployed %s", kind);
-					}
-					if (Boolean.FALSE.equals(deployable.isDeployed())) {
+					if (undeployed.toString().equals(deployable.getStatus())) {
 						return String.format("Undeployed %s", kind);
 					}
+					return String.format("Deployed %s", kind);
 				}
 				return null;
 			}


### PR DESCRIPTION
The status of a stream, as returned by the REST API (and thus the shell also),
may now contain any of the following states:
- deploying (deployment has been initiated)
- deployed (fully deployed based on each of the stream's modules' count properties)
- incomplete (at least 1 of each module, but 1 or more of them not at requested capacity)
- failed (1 or more of the modules does not have even a single instance deployed)
- undeployed (intentionally undeployed, or created but not yet deployed)
