### PR TITLE
XD-1869: Expose mapped(Request|Response)Headers

### DIFF
--- a/extensions/spring-xd-extension-http/src/main/java/org/springframework/xd/http/HttpClientProcessorOptionsMetadata.java
+++ b/extensions/spring-xd-extension-http/src/main/java/org/springframework/xd/http/HttpClientProcessorOptionsMetadata.java
@@ -21,6 +21,9 @@ import static org.springframework.xd.http.HttpClientProcessorOptionsMetadata.Htt
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import org.springframework.xd.module.options.mixins.MappedRequestHeadersMixin;
+import org.springframework.xd.module.options.mixins.MappedResponseHeadersMixin;
+import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
 
 
@@ -29,6 +32,7 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * 
  * @author Eric Bottard
  */
+@Mixin({ MappedRequestHeadersMixin.Http.class, MappedResponseHeadersMixin.Http.class })
 public class HttpClientProcessorOptionsMetadata {
 
 	private String url;

--- a/modules/processor/http-client/config/http-client.xml
+++ b/modules/processor/http-client/config/http-client.xml
@@ -9,10 +9,12 @@
 		http://www.springframework.org/schema/integration/http
 			http://www.springframework.org/schema/integration/http/spring-integration-http.xsd">
 
-	<int-http:outbound-gateway id='http-client'
+	<int-http:outbound-gateway id='http-client' 
 		request-channel='input' url-expression="${url}" http-method="${httpMethod}"
 		expected-response-type='java.lang.String' charset='${charset}'
-		reply-timeout='${replyTimeout}' reply-channel='output'>
+		reply-timeout='${replyTimeout}' reply-channel='output'
+		mapped-request-headers="${mappedRequestHeaders}"
+		mapped-response-headers="${mappedResponseHeaders}">
 	</int-http:outbound-gateway>
 
 	<channel id="output" />

--- a/modules/sink/rabbit/config/rabbit.xml
+++ b/modules/sink/rabbit/config/rabbit.xml
@@ -15,7 +15,8 @@
 		default-delivery-mode="${deliveryMode}"
 		amqp-template="rabbitTemplate"
 		exchange-name="${exchange}"
-		routing-key-expression="${routingKey}" />
+		routing-key-expression="${routingKey}" 
+		mapped-request-headers="${mappedRequestHeaders}"/>
 
 	<rabbit:template id="rabbitTemplate"
 		connection-factory="rabbitConnectionFactory"

--- a/modules/source/rabbit/config/rabbit.xml
+++ b/modules/source/rabbit/config/rabbit.xml
@@ -14,7 +14,8 @@
 		auto-startup="false"
 		channel="output"
 		listener-container="listenerContainer"
-		message-converter="messageConverter" />
+		message-converter="messageConverter" 
+		mapped-request-headers="${mappedRequestHeaders}"/>
 
 	<bean id="listenerContainer" class="org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer">
 		<property name="connectionFactory" ref="rabbitConnectionFactory" />

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSinkOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSinkOptionsMetadata.java
@@ -16,6 +16,7 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
+import org.springframework.xd.module.options.mixins.MappedRequestHeadersMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
 import org.springframework.xd.module.options.spi.ModulePlaceholders;
@@ -27,7 +28,7 @@ import org.springframework.xd.module.options.spi.ModulePlaceholders;
  * @author Eric Bottard
  * @author Gary Russell
  */
-@Mixin(RabbitConnectionMixin.class)
+@Mixin({ RabbitConnectionMixin.class, MappedRequestHeadersMixin.Amqp.class })
 public class RabbitSinkOptionsMetadata {
 
 	private String exchange = "";

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSourceOptionsMetadata.java
@@ -18,6 +18,7 @@ package org.springframework.xd.dirt.modules.metadata;
 
 import org.hibernate.validator.constraints.NotBlank;
 
+import org.springframework.xd.module.options.mixins.MappedRequestHeadersMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
 import org.springframework.xd.module.options.spi.ModulePlaceholders;
@@ -28,7 +29,7 @@ import org.springframework.xd.module.options.spi.ModulePlaceholders;
  * @author Eric Bottard
  * @author Gary Russell
  */
-@Mixin(RabbitConnectionMixin.class)
+@Mixin({ RabbitConnectionMixin.class, MappedRequestHeadersMixin.Amqp.class })
 public class RabbitSourceOptionsMetadata {
 
 	private String queues = ModulePlaceholders.XD_STREAM_NAME;

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MappedRequestHeadersMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MappedRequestHeadersMixin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.module.options.mixins;
+
+import org.springframework.xd.module.options.spi.ModuleOption;
+
+
+/**
+ * Base class for mixins that add the {@code mappedRequestHeaders} option.
+ * Implemented as a base abstract class (with some concrete implementations as static inner classes)
+ * because the default value for the option varies by adapter.
+ * 
+ *  @author Eric Bottard
+ */
+public abstract class MappedRequestHeadersMixin {
+
+	private String mappedRequestHeaders;
+
+	protected MappedRequestHeadersMixin(String mappedRequestHeaders) {
+		this.mappedRequestHeaders = mappedRequestHeaders;
+	}
+
+	@ModuleOption("request message header names to be propagated to/from the adpater/gateway")
+	public void setMappedRequestHeaders(String mappedRequestHeaders) {
+		this.mappedRequestHeaders = mappedRequestHeaders;
+	}
+
+	public String getMappedRequestHeaders() {
+		return mappedRequestHeaders;
+	}
+
+	public static class Http extends MappedRequestHeadersMixin {
+
+		public Http() {
+			super("HTTP_REQUEST_HEADERS");
+		}
+
+	}
+
+	public static class Amqp extends MappedRequestHeadersMixin {
+
+		public Amqp() {
+			super("STANDARD_REQUEST_HEADERS");
+		}
+	}
+}

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MappedResponseHeadersMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MappedResponseHeadersMixin.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.module.options.mixins;
+
+import org.springframework.xd.module.options.spi.ModuleOption;
+
+
+/**
+ * Base class for mixins that add the {@code mappedResponseHeaders} option.
+ * Implemented as a base abstract class (with some concrete implementations as static inner classes)
+ * because the default value for the option varies by adapter.
+ * 
+ *  @author Eric Bottard
+ */
+public abstract class MappedResponseHeadersMixin {
+
+	private String mappedResponseHeaders;
+
+	protected MappedResponseHeadersMixin(String mappedResponseHeaders) {
+		this.mappedResponseHeaders = mappedResponseHeaders;
+	}
+
+	@ModuleOption("response message header names to be propagated from the adpater/gateway")
+	public void setMappedResponseHeaders(String mappedResponseHeaders) {
+		this.mappedResponseHeaders = mappedResponseHeaders;
+	}
+
+	public String getMappedResponseHeaders() {
+		return mappedResponseHeaders;
+	}
+
+	public static class Http extends MappedResponseHeadersMixin {
+
+		public Http() {
+			super("HTTP_RESPONSE_HEADERS");
+		}
+
+	}
+
+}


### PR DESCRIPTION
Not sure about the benefit of this especially if we don't provide the options for the http source module, but here is my take on it nevertheless :)
