### PR TITLE
Suppress shutdown error message

### DIFF
--- a/spring-xd-dirt/src/main/resources/log4j.properties
+++ b/spring-xd-dirt/src/main/resources/log4j.properties
@@ -30,3 +30,6 @@ log4j.logger.org.apache.zookeeper.server.PrepRequestProcessor=WARN
 # This prevents warning message during shutdown of the EmbeddedZookeeper
 #javax.management.InstanceNotFoundException: org.apache.ZooKeeperService:name0=StandaloneServer_port-1,name1=InMemoryDataTree
 log4j.logger.org.apache.zookeeper.jmx.MBeanRegistry=ERROR
+# This prevents error message during shutdown of the EmbeddedZookeeper
+# java.lang.IllegalStateException: instance must be started before calling this method at com.google.common.base.Preconditions.checkState(Preconditions.java:149)
+log4j.logger.org.apache.curator.framework.recipes.cache.PathChildrenCache=FATAL


### PR DESCRIPTION
I investigated the possibility of preventing the IllegalStateException during shutdown of the SingleNodeApplication, but this happens before we get into SmartLifecycle.stop() in EmbeddedZooKeeper, so not obvious what can be done. Of course this suppresses all log messages from PathChildrenCache, which currently is only done in one place. 

```
protected void handleException(Throwable e)
{
    log.error("", e);
}
```
