### PR TITLE
XD-1900 Fix JobDeploymentModulesPath

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
@@ -207,7 +207,7 @@ public class JobDeploymentListener implements PathChildrenCacheListener {
 			String jobName = iterator.next();
 			Job job = deploymentLoader.loadJob(client, jobName, jobFactory);
 			if (job != null) {
-				String jobModulesPath = Paths.build(Paths.JOB_DEPLOYMENTS, jobName);
+				String jobModulesPath = Paths.build(Paths.JOB_DEPLOYMENTS, jobName, Paths.MODULES);
 				List<ModuleDeploymentStatus> statusList = new ArrayList<ModuleDeploymentStatus>();
 				List<String> moduleDeployments = client.getChildren().forPath(jobModulesPath);
 				for (String moduleDeployment : moduleDeployments) {


### PR DESCRIPTION
- Fix the JobDeploymentsPath when the `DeploymentSupervisor` recalculates the states of deployed jobs
