### PR TITLE
XD-1895 - Upgrade to Boot 1.1.3 and use the Platform to provide versions (take 2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.1.2.BUILD-SNAPSHOT")
+		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.1.3.RELEASE")
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.3")
 		classpath("org.springframework.build.gradle:docbook-reference-plugin:0.2.8")
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:0.7.0'
@@ -76,70 +76,31 @@ allprojects {
 }
 
 ext {
-	activemqVersion = '5.6.0'
+	// Not in IO
 	args4jVersion = '2.0.16'
-	commonsBeanUtilsVersion = '1.6'
-	commonsPool2Version = '2.0'
-	commonsCollectionsVersion = '3.2'
-	commonsIoVersion = '2.4'
 	curatorVersion = '2.5.0'
 	equalsverifierVersion = '1.1.3'
 	ftpServerVersion = '1.0.6'
 	greenmailVersion = '1.3.1b'
-	groovyVersion = '2.3.2'
-	guavaVersion = '14.0.1'
-	h2Version = '1.3.172'
 	hamcrestDateVersion = '0.9.3'
-	hamcrestVersion = '1.3'
-	hibernateValidatorVersion = '4.3.1.Final'
-	hsqldbVersion = '2.3.0'
 	httpClientVersion = '4.2.5'
-	jackson1Version = '1.9.13'
-	jacksonVersion = '2.3.1'
-	javaxMailVersion = '1.5.0'
 	jcloudsVersion = '1.7.0'
-	jedisVersion = '2.4.1'
-	jodaTimeVersion = '2.1'
-	jolokiaVersion = '1.1.5'
-	jsonPathVersion = '0.8.1'
-	junitVersion = '4.11'
-	kryoVersion = '2.22'
-	log4jVersion = '1.2.17'
-	mockitoVersion = '1.9.5'
-	mysqlVersion = '5.1.23'
-	nettyVersion = '3.6.6.Final'
 	oracleToolsVersion = '1.2.2'
+	platformVersion = '1.0.1.BUILD-SNAPSHOT'
 	postgresqlVersion = '9.2-1002-jdbc4'
-	reactorVersion = '1.1.0.RELEASE'
-	reactorSpringVersion = '1.1.0.RELEASE'
-	slf4jVersion = '1.7.6'
-	snakeYamlVersion = '1.12'
-	snappyVersion = '1.1.0'
 	splunkVersion = '1.2.0'
-	springAmqpVersion = '1.3.4.RELEASE'
 	springBatchAdminMgrVersion = '1.3.0.M1'
-	springBatchVersion = '3.0.1.BUILD-SNAPSHOT'
-	springBootVersion = '1.1.2.BUILD-SNAPSHOT'
-	springDataCommonsVersion = '1.8.0.RELEASE'
-	springDataGemfireVersion = '1.4.0.RELEASE'
-	springDataHadoopBase = '2.0.0.RELEASE'
-	springDataHadoopVersion = "${springDataHadoopBase}"
-	springDataMongoVersion = '1.5.0.RELEASE'
-	springDataRedisVersion = '1.2.1.RELEASE'
-	springHATEOASVersion = '0.9.0.RELEASE'
 	springIntegrationSplunkVersion = '1.1.0.M2'
-	springIntegrationVersion = '4.0.2.RELEASE'
-	springPluginVersion = '0.8.0.RELEASE'
 	springShellVersion = '1.1.0.BUILD-SNAPSHOT'
-	springSocialTwitterVersion = '1.1.0.RELEASE'
-	springVersion = '4.0.3.RELEASE'
-	tomcatJdbcPoolVersion = '7.0.42'
-	tomcatVersion = '7.0.35'
 	uuidVersion = '3.2'
-	validationApiVersion = '1.0.0.GA'
 	zookeeperVersion = '3.4.6'
 
+	// Also in IO
+	nettyVersion = '3.6.6.Final' // N.B. Reactor depends on Netty 4
+	springBatchVersion = '3.0.1.BUILD-SNAPSHOT'
+
 	// Hadoop Versions
+	springDataHadoopBase = '2.0.0.RELEASE'
 	hadoop22Version = '2.2.0'
 	cdh5Version = '2.3.0-cdh5.0.0'
 	hdp21Version = '2.4.0'
@@ -149,31 +110,6 @@ ext {
 	singleNodeServerProcess = new SingleNodeServerProcess()
 }
 
-def forceDependencyVersions(p) {
-	p.configurations.all {
-		resolutionStrategy {
-			eachDependency { DependencyResolveDetails details ->
-				//Force same version of Spring across the board
-				if (details.requested.group == 'org.springframework') {
-					details.useVersion "$springVersion"
-				}
-				if (details.requested.group == 'org.springframework.amqp') {
-					details.useVersion "$springAmqpVersion"
-				}
-				if (details.requested.group == 'org.slf4j') {
-					details.useVersion "$slf4jVersion"
-				}
-				if (details.requested.group == 'org.codehaus.groovy') {
-					details.useVersion "$groovyVersion"
-				}
-				if (details.requested.name == 'spring-data-redis') {
-					details.useVersion "$springDataRedisVersion"
-				}
-			}
-		}
-	}
-}
-
 configure(javaProjects) { subproject ->
 
 	apply plugin: 'groovy'
@@ -181,8 +117,11 @@ configure(javaProjects) { subproject ->
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
 	apply plugin: 'javadocHotfix'
+	apply plugin: 'spring-boot'
 
-	forceDependencyVersions(subproject)
+    bootRepackage {
+      enabled = false
+    }
 
 	compileJava {
 		sourceCompatibility=1.6
@@ -251,9 +190,9 @@ configure(javaProjects) { subproject ->
 	configurations.all { resolutionStrategy.cacheChangingModulesFor 60, 'minutes' }
 	// dependencies that are common across all java projects
 	dependencies {
-		testCompile "junit:junit:$junitVersion"
-		testCompile "org.codehaus.groovy:groovy-all:$groovyVersion"
-		testCompile "org.hamcrest:hamcrest-library:$hamcrestVersion"
+		versionManagement "io.spring.platform:platform-versions:$platformVersion@properties"
+		testCompile "org.springframework.boot:spring-boot-starter-test"
+		testCompile "org.codehaus.groovy:groovy-all"
 	}
 
 	// enable all compiler warnings; individual projects may customize further
@@ -328,7 +267,12 @@ configure(moduleProjects) { moduleProject ->
 	// require it to emit e.g. a .classpath file. Those projects don't actually
 	// contain java code, so reset everything (prevents creation of
 	// the 'build' directory, etc)
-	apply plugin: 'java'
+	apply plugin: 'spring-boot'
+
+    bootRepackage {
+      enabled = false
+    }
+
 	task build(overwrite: true) {}
 	task clean(overwrite: true) {}
 	compileJava {
@@ -336,11 +280,8 @@ configure(moduleProjects) { moduleProject ->
 		targetCompatibility=1.6
 	}
 
-
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
-
-	forceDependencyVersions(moduleProject)
 
 	eclipse {
 		project { natures += 'org.springframework.ide.eclipse.core.springnature' }
@@ -381,30 +322,27 @@ project('spring-xd-analytics') {
 	description = 'Spring XD Anayltics'
 	dependencies {
 		compile project(":spring-xd-tuple")
-		compile "org.springframework:spring-core:$springVersion"
-		compile "org.springframework.data:spring-data-redis:$springDataRedisVersion"
-		compile "org.springframework.data:spring-data-commons:$springDataCommonsVersion"
-		compile "redis.clients:jedis:$jedisVersion"
-		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
-		compile "joda-time:joda-time:$jodaTimeVersion"
+		compile "org.springframework:spring-core"
+		compile "org.springframework.data:spring-data-redis"
+		compile "org.springframework.data:spring-data-commons"
+		compile "redis.clients:jedis"
+		compile "org.springframework.integration:spring-integration-core"
+		compile "joda-time:joda-time"
 		compile project(':spring-xd-module-spi')
 		testCompile project(":spring-xd-test")
 		testCompile "nl.jqno.equalsverifier:equalsverifier:$equalsverifierVersion"
-		testCompile "org.springframework:spring-test:$springVersion"
-		testCompile ("org.mockito:mockito-core:$mockitoVersion") { exclude group:'org.hamcrest' }
-		testCompile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		runtime "log4j:log4j:$log4jVersion",
-				"org.slf4j:jcl-over-slf4j:$slf4jVersion",
-				"org.slf4j:slf4j-log4j12:$slf4jVersion","org.apache.commons:commons-pool2:$commonsPool2Version"
+		testCompile "com.fasterxml.jackson.core:jackson-databind"
+		runtime "log4j:log4j",
+				"org.slf4j:jcl-over-slf4j",
+				"org.slf4j:slf4j-log4j12","org.apache.commons:commons-pool2"
 	}
 }
 
 project('spring-xd-analytics-ml') {
 	description = 'Spring XD Analytics ML'
 	dependencies {
-		compile "org.springframework:spring-core:$springVersion"
+		compile "org.springframework:spring-core"
 		testCompile project(":spring-xd-tuple")
-		testCompile ("org.mockito:mockito-core:$mockitoVersion") { exclude group:'org.hamcrest' }
 	}
 }
 
@@ -414,26 +352,27 @@ project('spring-xd-dirt') {
 
 		// See XD-903 for breakdown
 		// ************* Common to both Server and Container
-		compile "org.springframework:spring-aop:$springVersion"
+		compile "org.springframework:spring-aop"
 		compile project(":spring-xd-analytics")
-		compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
-		compile "org.springframework.boot:spring-boot-actuator:$springBootVersion"
-		compile "org.springframework.data:spring-data-redis:$springDataRedisVersion"
-		compile "org.springframework.integration:spring-integration-amqp:$springIntegrationVersion"
-		compile "org.springframework.integration:spring-integration-event:$springIntegrationVersion"
-		compile "org.springframework.integration:spring-integration-file:$springIntegrationVersion"
-		compile "org.springframework.integration:spring-integration-ftp:$springIntegrationVersion"
-		compile "org.springframework.integration:spring-integration-groovy:$springIntegrationVersion"
-		compile "org.springframework.integration:spring-integration-http:$springIntegrationVersion"
+		compile "org.springframework.cloud:spring-cloud-spring-service-connector"
+		compile "org.springframework.cloud:spring-cloud-cloudfoundry-connector"
+		compile "org.springframework.boot:spring-boot-autoconfigure"
+		compile "org.springframework.boot:spring-boot-actuator"
+		compile "org.springframework.data:spring-data-redis"
+		compile "org.springframework.integration:spring-integration-amqp"
+		compile "org.springframework.integration:spring-integration-event"
+		compile "org.springframework.integration:spring-integration-file"
+		compile "org.springframework.integration:spring-integration-ftp"
+		compile "org.springframework.integration:spring-integration-groovy"
+		compile "org.springframework.integration:spring-integration-http"
 		// TODO: Investigate why spring-integration-http's optional dependency xerces becomes transitive dependency
 		configurations.compile.exclude(group: "xerces")
-		compile "org.springframework.integration:spring-integration-jmx:$springIntegrationVersion"
-		compile "org.springframework.integration:spring-integration-redis:$springIntegrationVersion"
-		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		compile "log4j:log4j:$log4jVersion"
-		compile "org.jolokia:jolokia-spring:$jolokiaVersion"
-		compile "com.esotericsoftware.kryo:kryo:$kryoVersion"
-		compile "redis.clients:jedis:$jedisVersion"
+		compile "org.springframework.integration:spring-integration-jmx"
+		compile "org.springframework.integration:spring-integration-redis"
+		compile "com.fasterxml.jackson.core:jackson-databind"
+		compile "log4j:log4j"
+		compile "com.esotericsoftware.kryo:kryo"
+		compile "redis.clients:jedis"
 		compile ("org.apache.zookeeper:zookeeper:$zookeeperVersion") {
 			exclude group: 'jline'
 		}
@@ -445,7 +384,7 @@ project('spring-xd-dirt') {
 		compile "args4j:args4j:$args4jVersion"
 
 		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-		compile "org.apache.tomcat:tomcat-jdbc:$tomcatJdbcPoolVersion"
+		compile "org.apache.tomcat:tomcat-jdbc"
 		compile ("org.springframework.batch:spring-batch-admin-manager:$springBatchAdminMgrVersion") {
 			exclude group: 'org.freemarker'
 			exclude group: 'hsqldb'
@@ -455,56 +394,51 @@ project('spring-xd-dirt') {
 			exclude group: 'org.springframework.integration'
 			exclude group: 'org.springframework'
 		}
-		compile "org.hibernate:hibernate-validator:$hibernateValidatorVersion"
+		compile "org.hibernate:hibernate-validator"
 
-		runtime "org.slf4j:jcl-over-slf4j:$slf4jVersion"
-		runtime "org.slf4j:slf4j-log4j12:$slf4jVersion"
-		runtime "org.yaml:snakeyaml:$snakeYamlVersion"
+		runtime "org.slf4j:jcl-over-slf4j"
+		runtime "org.slf4j:slf4j-log4j12"
+		runtime "org.yaml:snakeyaml"
 		runtime "org.postgresql:postgresql:$postgresqlVersion"
-		runtime "mysql:mysql-connector-java:$mysqlVersion"
+		runtime "mysql:mysql-connector-java"
 
 		compile project(':spring-xd-batch')
 
 		// ************* Dirt-Server only
 		compile project(':spring-xd-rest-domain')
-		compile "org.springframework:spring-webmvc:$springVersion"
-		compile "org.springframework.plugin:spring-plugin-core:$springPluginVersion"
-		compile "org.springframework.data:spring-data-commons:$springDataCommonsVersion"
-		compile "org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion"
-		compile "org.apache.tomcat.embed:tomcat-embed-logging-juli:$tomcatVersion"
-		compile "org.apache.tomcat:tomcat-jsp-api:$tomcatVersion"
+		compile "org.springframework:spring-webmvc"
+		compile "org.springframework.data:spring-data-commons"
+		compile "org.apache.tomcat.embed:tomcat-embed-core"
+		compile "org.apache.tomcat.embed:tomcat-embed-logging-juli"
 
 		// ************* Dirt-Container only (per se)
 		compile project(":spring-xd-module")
-		compile "com.jayway.jsonpath:json-path:$jsonPathVersion"
+		compile "com.jayway.jsonpath:json-path"
 		compile "com.eaio.uuid:uuid:$uuidVersion"
 
 		// ************* Container: Modules (should move on their own: XD-915)
 		compile project(":spring-xd-hadoop")
 
 		// ************* Container: Imposed by some Module (can't move)
-		compile "com.sun.mail:javax.mail:$javaxMailVersion"
+		compile "com.sun.mail:javax.mail"
 
 		// The following is needed eg by twitter module b/c jackson classes
 		// are loaded by RestTemplate and RestTemplate is in Dirt
-		runtime "org.codehaus.jackson:jackson-mapper-asl:$jackson1Version"
+		runtime "org.codehaus.jackson:jackson-mapper-asl"
 
 		// ************* Test
 		testCompile project(":spring-xd-test")
-		testCompile "org.springframework.integration:spring-integration-test:$springIntegrationVersion"
-		testCompile "com.jayway.jsonpath:json-path:$jsonPathVersion"
-		testCompile ("org.mockito:mockito-core:$mockitoVersion") { exclude group:'org.hamcrest' }
+		testCompile "org.springframework.integration:spring-integration-test"
+		testCompile "com.jayway.jsonpath:json-path"
 
 		// The following two because of AmqBrokerAndTest
-		testCompile ("org.apache.activemq:activemq-core:$activemqVersion") {
+		testCompile ("org.apache.activemq:activemq-broker") {
 			exclude group: 'org.mortbay.jetty'
 			exclude group: 'org.fusesource.fuse-extra'
 		}
-		testCompile "org.springframework:spring-jms:$springVersion"
+		testCompile "org.springframework:spring-jms"
 	}
 
-	apply plugin:'application'
-	apply plugin:'spring-boot'
 	// skip the startScripts task to avoid default start script generation
 	startScripts.setEnabled(false)
 	mainClassName = "org.springframework.xd.dirt.server.SingleNodeApplication"
@@ -522,6 +456,8 @@ project('spring-xd-dirt') {
 
 	bootRepackage  {
 		withJarTask = tasks['execJar']
+        classifier = 'exec'
+        enabled = true
 	}
 
 	test {
@@ -608,7 +544,7 @@ project('spring-xd-exec') {
 project('spring-xd-extension-mail') {
 	description = 'Spring XD Mail'
 	dependencies {
-		compile "org.springframework.integration:spring-integration-mail:$springIntegrationVersion"
+		compile "org.springframework.integration:spring-integration-mail"
 		compile project(":spring-xd-module-spi")
 	}
 }
@@ -616,9 +552,9 @@ project('spring-xd-extension-mail') {
 project('spring-xd-extension-http') {
 	description = 'Spring XD HTTP'
 	dependencies {
-		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
-		compile "io.netty:netty:$nettyVersion"
-		compile "org.springframework:spring-web:$springVersion"
+		compile "org.springframework.integration:spring-integration-core"
+		compile "io.netty:netty:${nettyVersion}"
+		compile "org.springframework:spring-web"
 		compile project(":spring-xd-module-spi")
 		testCompile project(":spring-xd-test")
 	}
@@ -627,18 +563,18 @@ project('spring-xd-extension-http') {
 project('spring-xd-extension-gemfire') {
 	description = 'Spring XD Gemfire'
 	dependencies {
-		compile "org.springframework.integration:spring-integration-gemfire:$springIntegrationVersion"
+		compile "org.springframework.integration:spring-integration-gemfire"
 		compile project(':spring-xd-module-spi')
-		compile "javax.validation:validation-api:$validationApiVersion"
+		compile "javax.validation:validation-api"
 	}
 }
 
 project('spring-xd-extension-tcp') {
 	description = 'Spring XD TCP'
 	dependencies {
-		compile "org.springframework.integration:spring-integration-ip:$springIntegrationVersion"
+		compile "org.springframework.integration:spring-integration-ip"
 		compile project(':spring-xd-module-spi')
-		compile "javax.validation:validation-api:$validationApiVersion"
+		compile "javax.validation:validation-api"
 	}
 }
 
@@ -646,12 +582,11 @@ project('spring-xd-extension-twitter') {
 	description = 'Spring XD Twitter'
 	dependencies {
 		compile project(':spring-xd-module-spi')
-		compile "javax.validation:validation-api:$validationApiVersion"
-		// Override the version which social-twitter brings in
-		runtime "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		compile "org.springframework.social:spring-social-twitter:$springSocialTwitterVersion"
-		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
-		compile "org.codehaus.groovy:groovy-all:$groovyVersion"
+		compile "javax.validation:validation-api"
+		runtime "com.fasterxml.jackson.core:jackson-databind"
+		compile "org.springframework.social:spring-social-twitter"
+		compile "org.springframework.integration:spring-integration-core"
+		compile "org.codehaus.groovy:groovy-all"
 	}
 }
 
@@ -659,7 +594,7 @@ project('spring-xd-extension-splunk') {
 	description = 'Spring XD Splunk'
 	dependencies {
 		compile "org.springframework.integration:spring-integration-splunk:$springIntegrationSplunkVersion"
-		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
+		compile "org.springframework.integration:spring-integration-core"
 		runtime "com.splunk:splunk:$splunkVersion"
 		compile project(':spring-xd-module-spi')
 	}
@@ -670,7 +605,7 @@ project('spring-xd-extension-mongodb') {
 	dependencies {
 		compile project(':spring-xd-tuple')
 		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-		compile ("org.springframework.data:spring-data-mongodb:$springDataMongoVersion") { exclude group: 'org.slf4j' }
+		compile ("org.springframework.data:spring-data-mongodb") { exclude group: 'org.slf4j' }
 	}
 }
 
@@ -678,20 +613,17 @@ project('spring-xd-extension-jdbc') {
 	description = 'Spring XD JDBC'
 	dependencies {
 		compile project(':spring-xd-tuple')
-		compile "org.springframework:spring-jdbc:$springVersion"
-		compile "org.springframework:spring-tx:$springVersion"
+		compile "org.springframework:spring-jdbc"
+		compile "org.springframework:spring-tx"
 		compile "org.springframework.batch:spring-batch-infrastructure:$springBatchVersion"
-		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
-		runtime "org.springframework.integration:spring-integration-jdbc:$springIntegrationVersion"
-		runtime "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		compile "org.hsqldb:hsqldb:$hsqldbVersion"
-		runtime "mysql:mysql-connector-java:$mysqlVersion"
+		compile "org.springframework.integration:spring-integration-core"
+		runtime "org.springframework.integration:spring-integration-jdbc"
+		runtime "com.fasterxml.jackson.core:jackson-databind"
+		compile "org.hsqldb:hsqldb"
+		runtime "mysql:mysql-connector-java"
 		runtime "org.postgresql:postgresql:$postgresqlVersion"
 		compile project(':spring-xd-module-spi')
-		compile "javax.validation:validation-api:$validationApiVersion"
-        testCompile("org.mockito:mockito-all:$mockitoVersion") {
-            exclude group: 'org.hamcrest'
-        }
+		compile "javax.validation:validation-api"
 	}
 }
 
@@ -699,20 +631,17 @@ project('spring-xd-extension-reactor') {
 	description = 'Spring XD Reactor'
 	dependencies {
 		compile project(':spring-xd-module-spi'),
-				"org.projectreactor.spring:reactor-spring-messaging:$reactorSpringVersion",
-				"org.springframework.integration:spring-integration-core:$springIntegrationVersion",
-				"javax.validation:validation-api:$validationApiVersion"
+				"org.projectreactor.spring:reactor-spring-messaging",
+				"org.springframework.integration:spring-integration-core",
+				"javax.validation:validation-api"
 
 		testCompile project(":spring-xd-test"),
 				project(':spring-xd-module'),
-				"com.jayway.jsonpath:json-path:$jsonPathVersion",
-				"com.esotericsoftware.kryo:kryo:$kryoVersion"
-		testCompile("org.mockito:mockito-core:$mockitoVersion") {
-			exclude group: 'org.hamcrest'
-		}
-		testRuntime "org.slf4j:jcl-over-slf4j:$slf4jVersion",
-				"org.slf4j:slf4j-log4j12:$slf4jVersion",
-				"log4j:log4j:$log4jVersion"
+				"com.jayway.jsonpath:json-path"
+				"com.esotericsoftware.kryo:kryo"
+		testRuntime "org.slf4j:jcl-over-slf4j",
+				"org.slf4j:slf4j-log4j12",
+				"log4j:log4j"
 	}
 }
 
@@ -720,28 +649,28 @@ project('spring-xd-extension-throughput') {
 	description = 'Spring XD Throughput testing'
 	dependencies {
 		compile project(':spring-xd-module-spi'),
-				"org.slf4j:slf4j-api:$slf4jVersion",
-				"org.springframework.integration:spring-integration-core:$springIntegrationVersion"
+				"org.slf4j:slf4j-api",
+				"org.springframework.integration:spring-integration-core"
 
 		testCompile project(":spring-xd-test"),
 				project(':spring-xd-module')
-		testRuntime "org.slf4j:jcl-over-slf4j:$slf4jVersion",
-				"org.slf4j:slf4j-log4j12:$slf4jVersion",
-				"log4j:log4j:$log4jVersion"
+		testRuntime "org.slf4j:jcl-over-slf4j",
+				"org.slf4j:slf4j-log4j12",
+				"log4j:log4j"
 	}
 }
 
 project('spring-xd-hadoop') {
 	description = 'Spring XD Hadoop'
 	dependencies {
-		compile "org.springframework:spring-aop:$springVersion"
-		compile "org.springframework:spring-context:$springVersion"
-		compile "org.springframework:spring-context-support:$springVersion"
-		compile "org.springframework:spring-jdbc:$springVersion"
-		compile "org.springframework:spring-tx:$springVersion"
-		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
+		compile "org.springframework:spring-aop"
+		compile "org.springframework:spring-context"
+		compile "org.springframework:spring-context-support"
+		compile "org.springframework:spring-jdbc"
+		compile "org.springframework:spring-tx"
+		compile "org.springframework.integration:spring-integration-core"
 		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-		compile ("org.springframework.data:spring-data-hadoop:$springDataHadoopVersion") {
+		compile ("org.springframework.data:spring-data-hadoop") {
 			exclude group: 'org.springframework.batch'
 			exclude group: 'javax.servlet'
 			exclude group: 'javax.servlet.jsp'
@@ -755,18 +684,18 @@ project('spring-xd-hadoop') {
 			exclude group: 'hsqldb'
 			exclude group: 'jline'
 		}
-		compile ("org.springframework.data:spring-data-hadoop-store:$springDataHadoopVersion") { exclude group: 'org.apache.hadoop' }
-		testRuntime "org.xerial.snappy:snappy-java:$snappyVersion"
+		compile ("org.springframework.data:spring-data-hadoop-store") { exclude group: 'org.apache.hadoop' }
+		testRuntime "org.xerial.snappy:snappy-java"
 	}
 }
 
 project('spring-xd-hadoop:hadoop22') {
 	description = 'Hadoop 2.2.x dependencies'
 	dependencies {
-		runtime ("org.springframework.data:spring-data-hadoop:${springDataHadoopBase}") {
+		runtime ("org.springframework.data:spring-data-hadoop") {
 			exclude group: 'org.apache.hadoop'
 		}
-		runtime ("org.springframework.data:spring-data-hadoop-store:${springDataHadoopBase}") {
+		runtime ("org.springframework.data:spring-data-hadoop-store") {
 			exclude group: 'org.apache.hadoop'
 		}
 		runtime ("org.apache.hadoop:hadoop-common:$hadoop22Version")
@@ -913,16 +842,15 @@ project('spring-xd-hadoop:phd20') {
 }
 project('spring-xd-yarn:spring-xd-yarn-client') {
     description = 'Spring XD YARN Client App'
-    apply plugin: 'spring-boot'
 
     dependencies {
-        compile "org.springframework:spring-aop:$springVersion"
-        compile "org.springframework:spring-context:$springVersion"
-        compile "org.springframework:spring-context-support:$springVersion"
-        compile "org.springframework:spring-jdbc:$springVersion"
-        compile "org.springframework:spring-tx:$springVersion"
+        compile "org.springframework:spring-aop"
+        compile "org.springframework:spring-context"
+        compile "org.springframework:spring-context-support"
+        compile "org.springframework:spring-jdbc"
+        compile "org.springframework:spring-tx"
         compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-        compile ("org.springframework.data:spring-yarn-boot:$springDataHadoopVersion") {
+        compile ("org.springframework.data:spring-yarn-boot") {
             exclude group: 'javax.servlet'
             exclude group: 'javax.servlet.jsp'
             exclude group: 'tomcat'
@@ -936,10 +864,10 @@ project('spring-xd-yarn:spring-xd-yarn-client') {
             exclude group: 'org.slf4j'
             exclude group: 'log4j'
         }
-        compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
-        runtime "log4j:log4j:$log4jVersion",
-                "org.slf4j:jcl-over-slf4j:$slf4jVersion",
-                "org.slf4j:slf4j-log4j12:$slf4jVersion"
+        compile "org.springframework.boot:spring-boot-autoconfigure"
+        runtime "log4j:log4j",
+                "org.slf4j:jcl-over-slf4j",
+                "org.slf4j:slf4j-log4j12"
     }
 
     jar {
@@ -949,16 +877,15 @@ project('spring-xd-yarn:spring-xd-yarn-client') {
 
 project('spring-xd-yarn:spring-xd-yarn-appmaster') {
     description = 'Spring XD YARN AppMaster'
-    apply plugin: 'spring-boot'
 
     dependencies {
-        compile "org.springframework:spring-aop:$springVersion"
-        compile "org.springframework:spring-context:$springVersion"
-        compile "org.springframework:spring-context-support:$springVersion"
-        compile "org.springframework:spring-jdbc:$springVersion"
-        compile "org.springframework:spring-tx:$springVersion"
+        compile "org.springframework:spring-aop"
+        compile "org.springframework:spring-context"
+        compile "org.springframework:spring-context-support"
+        compile "org.springframework:spring-jdbc"
+        compile "org.springframework:spring-tx"
         compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-        compile ("org.springframework.data:spring-yarn-boot:$springDataHadoopVersion") {
+        compile ("org.springframework.data:spring-yarn-boot") {
             exclude group: 'javax.servlet'
             exclude group: 'javax.servlet.jsp'
             exclude group: 'tomcat'
@@ -971,10 +898,10 @@ project('spring-xd-yarn:spring-xd-yarn-appmaster') {
             exclude group: 'hsqldb'
             exclude group: 'org.slf4j'
             exclude group: 'log4j'
-            runtime "org.slf4j:jcl-over-slf4j:$slf4jVersion",
-                    "org.slf4j:slf4j-log4j12:$slf4jVersion"
+            runtime "org.slf4j:jcl-over-slf4j",
+                    "org.slf4j:slf4j-log4j12"
         }
-        compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
+        compile "org.springframework.boot:spring-boot-autoconfigure"
     }
 
     jar {
@@ -987,12 +914,12 @@ project('spring-xd-yarn:spring-xd-yarn-appmaster') {
 project ('spring-xd-gemfire-server') {
 	description = 'Gemfire Server to support XD Development and Demos'
 	dependencies {
-		compile "commons-beanutils:commons-beanutils:$commonsBeanUtilsVersion"
-		compile "org.springframework.data:spring-data-gemfire:$springDataGemfireVersion"
+		compile "commons-beanutils:commons-beanutils"
+		compile "org.springframework.data:spring-data-gemfire"
 		compile project(':spring-xd-tuple')
-		runtime "log4j:log4j:$log4jVersion",
-				"org.slf4j:jcl-over-slf4j:$slf4jVersion",
-				"org.slf4j:slf4j-log4j12:$slf4jVersion"
+		runtime "log4j:log4j",
+				"org.slf4j:jcl-over-slf4j",
+				"org.slf4j:slf4j-log4j12"
 	}
 	apply plugin:'application'
 	// skip the startScripts task to avoid default start script generation
@@ -1059,8 +986,8 @@ project('redis') {
 project('spring-xd-module') {
 	description = 'Spring XD Module'
 	dependencies {
-		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
-		compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
+		compile "org.springframework.integration:spring-integration-core"
+		compile "org.springframework.boot:spring-boot-autoconfigure"
 		compile project(':spring-xd-module-spi')
 	}
 }
@@ -1068,41 +995,41 @@ project('spring-xd-module') {
 project('spring-xd-module-spi') {
 	description = 'Spring XD Module Options API'
 	dependencies {
-		compile "javax.validation:validation-api:$validationApiVersion"
-		compile "org.hibernate:hibernate-validator:$hibernateValidatorVersion"
-		compile "org.springframework:spring-web:$springVersion"
-		testCompile "junit:junit:$junitVersion"
+		compile "org.hibernate:hibernate-validator"
+		compile "org.apache.tomcat.embed:tomcat-embed-el"
+		compile "org.springframework:spring-web"
 	}
 }
 
 project('spring-xd-tuple') {
 	description = 'Spring XD Tuple'
 	dependencies {
-		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		compile "org.springframework:spring-context:$springVersion"
-		compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
+		compile "com.fasterxml.jackson.core:jackson-databind"
+		compile "org.springframework:spring-context"
+		compile "org.springframework.integration:spring-integration-core"
 		compile "org.springframework.batch:spring-batch-infrastructure:$springBatchVersion"
-		compile "org.springframework:spring-jdbc:$springVersion"
+		compile "org.springframework:spring-jdbc"
 		compile "com.eaio.uuid:uuid:$uuidVersion"
-		testCompile ("org.mockito:mockito-core:$mockitoVersion") { exclude group:'org.hamcrest' }
 	}
 }
 
 project('spring-xd-rest-client') {
 	description = 'Spring XD REST Client'
 	dependencies {
-		compile "org.springframework:spring-web:$springVersion"
+		compile "org.springframework:spring-web"
 		compile project(':spring-xd-rest-domain')
-		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		compile "org.codehaus.jackson:jackson-core-asl:$jackson1Version"
-		compile "joda-time:joda-time:$jodaTimeVersion"
+		compile "com.fasterxml.jackson.core:jackson-databind"
+		compile "org.codehaus.jackson:jackson-core-asl"
+		compile "joda-time:joda-time"
 	}
 }
 
 project('spring-xd-rest-domain') {
 	description = 'Spring XD REST Domain'
 	dependencies {
-		compile ("org.springframework.hateoas:spring-hateoas:$springHATEOASVersion") { exclude module: "spring-asm" }
+		compile "org.springframework:spring-webmvc"
+		compile ("org.springframework.hateoas:spring-hateoas") { exclude module: "spring-asm" }
+		compile "org.springframework.plugin:spring-plugin-core"
 		compile ("org.springframework.batch:spring-batch-admin-manager:$springBatchAdminMgrVersion") {
 			exclude module: 'spring-batch-integration'
 			exclude group: 'org.springframework.integration'
@@ -1110,8 +1037,8 @@ project('spring-xd-rest-domain') {
 			exclude group: 'org.freemarker'
 		}
 		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
-		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		compile "org.codehaus.jackson:jackson-core-asl:$jackson1Version"
+		compile "com.fasterxml.jackson.core:jackson-databind"
+		compile "org.codehaus.jackson:jackson-core-asl"
 	}
 }
 
@@ -1132,11 +1059,11 @@ project('modules.source.mail') {
 }
 
 project('modules.source.file') {
-	dependencies { runtime	"org.springframework.integration:spring-integration-file:$springIntegrationVersion" }
+	dependencies { runtime	"org.springframework.integration:spring-integration-file" }
 }
 
 project('modules.source.tail') {
-	dependencies { runtime	"org.springframework.integration:spring-integration-file:$springIntegrationVersion" }
+	dependencies { runtime	"org.springframework.integration:spring-integration-file" }
 }
 
 project('modules.source.http') {
@@ -1152,15 +1079,15 @@ project('modules.source.tcp-client') {
 }
 
 project('modules.source.mqtt') {
-	dependencies { runtime "org.springframework.integration:spring-integration-mqtt:$springIntegrationVersion" }
+	dependencies { runtime "org.springframework.integration:spring-integration-mqtt" }
 }
 
 project('modules.source.syslog-tcp') {
-	dependencies { runtime "org.springframework.integration:spring-integration-syslog:$springIntegrationVersion" }
+	dependencies { runtime "org.springframework.integration:spring-integration-syslog" }
 }
 
 project('modules.source.syslog-udp') {
-	dependencies { runtime "org.springframework.integration:spring-integration-syslog:$springIntegrationVersion" }
+	dependencies { runtime "org.springframework.integration:spring-integration-syslog" }
 }
 
 project('modules.source.reactor-ip') {
@@ -1183,13 +1110,8 @@ project('modules.source.reactor-syslog') {
 
 project('modules.source.jms') {
 	dependencies {
-		runtime "org.springframework.integration:spring-integration-jms:$springIntegrationVersion"
-		runtime ("org.apache.activemq:activemq-core:$activemqVersion") {
-			exclude group: 'org.mortbay.jetty'
-			exclude group: 'org.fusesource.fuse-extra'
-			exclude group: 'org.slf4j'
-		}
-
+		runtime "org.springframework.integration:spring-integration-jms"
+		runtime "org.apache.activemq:activemq-client"
 	}
 }
 
@@ -1229,15 +1151,15 @@ project('modules.source.twittersearch') {
 project('modules.processor.http-client') {
 	dependencies {
 		runtime(project(":spring-xd-extension-http"))
-		runtime	"org.springframework.integration:spring-integration-http:$springIntegrationVersion"
+		runtime	"org.springframework.integration:spring-integration-http"
 	}
 }
 
 project('modules.processor.aggregator') {
 	dependencies {
 		// Adding redis for the message store, as it may become optional in DIRT itself
-		runtime	("org.springframework.integration:spring-integration-redis:$springIntegrationVersion") { exclude group: 'org.slf4j' }
-		runtime	("org.springframework.integration:spring-integration-jdbc:$springIntegrationVersion")
+		runtime	("org.springframework.integration:spring-integration-redis") { exclude group: 'org.slf4j' }
+		runtime	("org.springframework.integration:spring-integration-jdbc")
 	}
 }
 
@@ -1248,12 +1170,12 @@ project('modules.sink.tcp') {
 }
 
 project('modules.sink.mqtt') {
-	dependencies { runtime "org.springframework.integration:spring-integration-mqtt:$springIntegrationVersion" }
+	dependencies { runtime "org.springframework.integration:spring-integration-mqtt" }
 }
 
 
 project('modules.sink.file') {
-	dependencies { runtime	"org.springframework.integration:spring-integration-file:$springIntegrationVersion" }
+	dependencies { runtime	"org.springframework.integration:spring-integration-file" }
 }
 
 project('modules.sink.jdbc') {
@@ -1298,7 +1220,7 @@ project('modules.sink.throughput-sampler') {
 
 project('modules.sink.mongodb') {
 	dependencies {
-		runtime ("org.springframework.integration:spring-integration-mongodb:$springIntegrationVersion")
+		runtime ("org.springframework.integration:spring-integration-mongodb")
 	}
 }
 
@@ -1331,7 +1253,7 @@ project('modules.job.jdbchdfs') {
 }
 
 project('modules.job.ftphdfs') {
-	dependencies { runtime "org.springframework.integration:spring-integration-ftp:$springIntegrationVersion" }
+	dependencies { runtime "org.springframework.integration:spring-integration-ftp" }
 }
 
 project('spring-xd-ui') {
@@ -1400,11 +1322,11 @@ project('spring-xd-ui') {
 project('spring-xd-test') {
 	description = 'Spring XD Test'
 	dependencies {
-		compile "org.springframework.integration:spring-integration-test:$springIntegrationVersion"
-		compile "org.springframework.integration:spring-integration-amqp:$springIntegrationVersion"
-		compile "org.springframework.integration:spring-integration-redis:$springIntegrationVersion"
-		compile "org.springframework.integration:spring-integration-mqtt:$springIntegrationVersion"
-		compile ("org.springframework.data:spring-data-hadoop:$springDataHadoopVersion") {
+		compile "org.springframework.integration:spring-integration-test"
+		compile "org.springframework.integration:spring-integration-amqp"
+		compile "org.springframework.integration:spring-integration-redis"
+		compile "org.springframework.integration:spring-integration-mqtt"
+		compile ("org.springframework.data:spring-data-hadoop") {
 			exclude group: 'javax.servlet'
 			exclude group: 'javax.servlet.jsp'
 			exclude group: 'tomcat'
@@ -1418,17 +1340,17 @@ project('spring-xd-test') {
 			exclude group: 'org.springframework.batch'
 			exclude group: 'jline'
 		}
-		compile "com.google.guava:guava:$guavaVersion"
-		compile "org.springframework.data:spring-data-redis:$springDataRedisVersion"
-		compile "org.springframework:spring-context:$springVersion"
-		compile "org.springframework:spring-context-support:$springVersion"
-		compile "org.springframework:spring-tx:$springVersion"
-		compile "org.springframework:spring-test:$springVersion"
-		compile "redis.clients:jedis:$jedisVersion"
-		compile "org.hsqldb:hsqldb:$hsqldbVersion"
-		compile "org.apache.tomcat:tomcat-jdbc:$tomcatJdbcPoolVersion"
-		compile "junit:junit:$junitVersion"
-		compile "commons-io:commons-io:$commonsIoVersion"
+		compile "com.google.guava:guava"
+		compile "org.springframework.data:spring-data-redis"
+		compile "org.springframework:spring-context"
+		compile "org.springframework:spring-context-support"
+		compile "org.springframework:spring-tx"
+		compile "org.springframework:spring-test"
+		compile "redis.clients:jedis"
+		compile "org.hsqldb:hsqldb"
+		compile "org.apache.tomcat:tomcat-jdbc"
+		compile "junit:junit"
+		compile "commons-io:commons-io"
 	}
 }
 
@@ -1446,22 +1368,22 @@ project('spring-xd-shell') {
 	dependencies {
 		compile "org.springframework.shell:spring-shell:$springShellVersion"
 		compile project(":spring-xd-rest-client")
-		compile ("org.springframework.data:spring-data-hadoop:$springDataHadoopVersion") {
+		compile ("org.springframework.data:spring-data-hadoop") {
 			exclude group: 'javax.servlet'
 			exclude group: 'org.mortbay.jetty'
 			exclude group: 'hsqldb'
 		}
-		compile "com.google.guava:guava:$guavaVersion"
-		compile	"org.codehaus.jackson:jackson-mapper-asl:$jackson1Version"
-		compile "commons-io:commons-io:$commonsIoVersion"
+		compile "com.google.guava:guava"
+		compile	"org.codehaus.jackson:jackson-mapper-asl"
+		compile "commons-io:commons-io"
 		configurations.compile.exclude(group: "xerces")
 
-		runtime "org.slf4j:jcl-over-slf4j:$slf4jVersion"
-		runtime	"org.slf4j:slf4j-log4j12:$slf4jVersion"
-		runtime	"log4j:log4j:$log4jVersion"
+		runtime "org.slf4j:jcl-over-slf4j"
+		runtime	"org.slf4j:slf4j-log4j12"
+		runtime	"log4j:log4j"
 		testCompile project(":spring-xd-test-fixtures")
 		testCompile project(":spring-xd-dirt")
-		testCompile "uk.co.modular-it:hamcrest-date:$hamcrestDateVersion"
+		testCompile "uk.co.modular-it:hamcrest-date:${hamcrestDateVersion}"
 		testCompile "org.apache.ftpserver:ftpserver-core:$ftpServerVersion"
 	}
 
@@ -1487,11 +1409,11 @@ project('spring-xd-batch') {
 	description = 'Sub project for XD batch support '
 
 	dependencies {
-		runtime "org.yaml:snakeyaml:$snakeYamlVersion"
-		compile "org.hsqldb:hsqldb:$hsqldbVersion"
-		compile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
-		compile "org.springframework.boot:spring-boot-actuator:$springBootVersion"
-		compile "org.springframework:spring-jdbc:$springVersion"
+		runtime "org.yaml:snakeyaml"
+		compile "org.hsqldb:hsqldb"
+		compile "org.springframework.boot:spring-boot-autoconfigure"
+		compile "org.springframework.boot:spring-boot-actuator"
+		compile "org.springframework:spring-jdbc"
 		compile "org.springframework.batch:spring-batch-core:$springBatchVersion"
 	}
 	apply plugin:'application'
@@ -1515,19 +1437,17 @@ project('spring-xd-test-fixtures') {
 	dependencies {
 		compile project(":spring-xd-test")
 		compile "org.springframework.shell:spring-shell:$springShellVersion"
-		compile "commons-collections:commons-collections:$commonsCollectionsVersion"
+		compile "commons-collections:commons-collections"
 		compile "com.icegreen:greenmail:$greenmailVersion"
-		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-		compile "org.springframework:spring-jms:$springVersion"
-		compile ("org.apache.activemq:activemq-core:$activemqVersion") {
-			exclude group: 'org.mortbay.jetty'
-		}
-		compile "org.springframework:spring-web:$springVersion"
-		compile ("org.springframework.data:spring-data-mongodb:$springDataMongoVersion") { exclude group: 'org.slf4j' }
+		compile "com.fasterxml.jackson.core:jackson-databind"
+		compile "org.springframework:spring-jms"
+		compile "org.apache.activemq:activemq-client"
+		compile "org.springframework:spring-web"
+		compile ("org.springframework.data:spring-data-mongodb") { exclude group: 'org.slf4j' }
 
-		runtime "log4j:log4j:$log4jVersion",
-				"org.slf4j:jcl-over-slf4j:$slf4jVersion",
-				"org.slf4j:slf4j-log4j12:$slf4jVersion"
+		runtime "log4j:log4j",
+				"org.slf4j:jcl-over-slf4j",
+				"org.slf4j:slf4j-log4j12"
 	}
 }
 
@@ -1547,23 +1467,22 @@ project('spring-xd-integration-test') {
 		compile project(":spring-xd-rest-client")
 		compile "org.apache.jclouds.provider:aws-sts:$jcloudsVersion"
 		compile "org.apache.jclouds.driver:jclouds-sshj:$jcloudsVersion"
-		compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+		compile "com.fasterxml.jackson.core:jackson-databind"
 		compile ("org.apache.hadoop:hadoop-common:$hadoop22Version")
 		compile ("org.apache.hadoop:hadoop-client:$hadoop22Version")
-		compile ("org.springframework.data:spring-data-mongodb:$springDataMongoVersion") { exclude group: 'org.slf4j' }
-		testCompile "mysql:mysql-connector-java:$mysqlVersion"
-		testCompile "commons-collections:commons-collections:$commonsCollectionsVersion"
+		compile ("org.springframework.data:spring-data-mongodb") { exclude group: 'org.slf4j' }
+		testCompile "mysql:mysql-connector-java"
+		testCompile "commons-collections:commons-collections"
 		testCompile "org.springframework.shell:spring-shell:$springShellVersion"
-		testCompile "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion"
-		testCompile "org.springframework:spring-web:$springVersion"
-		testCompile "org.springframework:spring-jms:$springVersion"
-		testCompile ("org.springframework.data:spring-data-hadoop:${springDataHadoopBase}") {
+		testCompile "org.springframework.boot:spring-boot-autoconfigure"
+		testCompile "org.springframework:spring-web"
+		testCompile "org.springframework:spring-jms"
+		testCompile ("org.springframework.data:spring-data-hadoop") {
 							exclude group: 'org.apache.hadoop'
 						}
-		testCompile group: 'junit', name: 'junit', version: '4.+'
-		runtime "log4j:log4j:$log4jVersion",
-				"org.slf4j:jcl-over-slf4j:$slf4jVersion",
-				"org.slf4j:slf4j-log4j12:$slf4jVersion"
+		runtime "log4j:log4j",
+				"org.slf4j:jcl-over-slf4j",
+				"org.slf4j:slf4j-log4j12"
 	}
 
 }
@@ -1594,10 +1513,10 @@ project('spring-xd-distributed-test') {
 		compile "com.oracle.tools:oracle-tools-runtime:$oracleToolsVersion"
 		compile "com.oracle.tools:oracle-tools-core:$oracleToolsVersion"
 		compile "com.oracle.tools:oracle-tools-testing-support:$oracleToolsVersion"
-		testCompile "junit:junit:$junitVersion"
-		runtime "log4j:log4j:$log4jVersion",
-				"org.slf4j:jcl-over-slf4j:$slf4jVersion",
-				"org.slf4j:slf4j-log4j12:$slf4jVersion"
+		testCompile "junit:junit"
+		runtime "log4j:log4j",
+				"org.slf4j:jcl-over-slf4j",
+				"org.slf4j:slf4j-log4j12"
 	}
 
 }

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -49,6 +49,18 @@ def customizePom(pom, gradleProject) {
 				developerConnection = linkScmDevConnection
 			}
 
+			dependencyManagement {
+				dependencies {
+					dependency {
+						groupId = 'io.spring.platform'
+						artifactId = 'platform-bom'
+						version = platformVersion
+						scope = 'import'
+						type = 'pom'
+					}
+				}
+			}
+
 			developers {
 				developer {
 					id = 'markfisher'

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobExecutionsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobExecutionsControllerIntegrationTests.java
@@ -177,7 +177,7 @@ public class BatchJobExecutionsControllerIntegrationTests extends AbstractContro
 				get("/batch/executions").param("startJobExecution", "0").param("pageSize", "20").accept(
 						MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andExpect(
 				jsonPath("$", Matchers.hasSize(2))).andExpect(jsonPath("$[*].executionId", contains(0, 3))).andExpect(
-				jsonPath("$[*].jobExecution[*].stepExecutions", Matchers.hasSize(3))).andExpect(
+				jsonPath("$[*].jobExecution[*].stepExecutions", Matchers.hasSize(2))).andExpect(
 				jsonPath("$[*].jobId", contains(0, 2))).andExpect(jsonPath("$[*].deleted", contains(true, true))).andExpect(
 				jsonPath("$[*].deployed", contains(false, false))).andExpect(
 				jsonPath("$[*].jobExecution[*].id", contains(0, 3))).andExpect(


### PR DESCRIPTION
This PR reapplies the changes originally made in 246ef90b and updates `publish-maven.gradle` to import the Platform's bom for dependency management in each of the published poms.
