### PR TITLE
XD-1881 followup

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ResourcePatternScanningOptionHandlers.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ResourcePatternScanningOptionHandlers.java
@@ -109,7 +109,7 @@ public final class ResourcePatternScanningOptionHandlers {
 			String resolved = CommandLinePropertySourceOverridingListener.getCurrentEnvironment()
 					.resolvePlaceholders("${xd.home:.}/lib/*");
 			resolved = StringUtils.cleanPath(resolved).replace("//", "/");
-			return "file:" + (resolved.startsWith("/") ? resolved : "/" + resolved);
+			return "file:" + resolved;
 		}
 
 		@Override


### PR DESCRIPTION
Tested with and without XD_HOME set
When set, tested with
- relative path
- absolute path
- path ending with a '/'
- path not ending with a '/'

Tested on
- Mac
- Windows

(phew)
