### PR TITLE
XD-1927 - Find logging configuration relative to environment

### DIFF
--- a/scripts/xd/xd-admin
+++ b/scripts/xd/xd-admin
@@ -182,7 +182,7 @@ if [ x"$XD_MODULE_CONFIG_NAME" = x ] ; then
 fi
 
 # set app name etc. via SPRING_XD_OPTS
-SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-admin-logger.properties -Dxd.home=$XD_HOME"
+SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_CONFIG_LOCATION/xd-admin-logger.properties -Dxd.home=$XD_HOME"
 SPRING_XD_OPTS="$SPRING_XD_OPTS -Dspring.config.location=$XD_CONFIG_LOCATION -Dxd.config.home=$XD_CONFIG_LOCATION -Dspring.config.name=$XD_CONFIG_NAME"
 SPRING_XD_OPTS="$SPRING_XD_OPTS -Dxd.module.config.location=$XD_MODULE_CONFIG_LOCATION -Dxd.module.config.name=$XD_MODULE_CONFIG_NAME"
 

--- a/scripts/xd/xd-admin.bat
+++ b/scripts/xd/xd-admin.bat
@@ -102,7 +102,7 @@ if not defined XD_MODULE_CONFIG_NAME (
 @rem make sure to append '/' to XD_MODULE_CONFIG_LOCATION until the path issue is resoloved in EnvironmentAwareModuleOptionsMetadataResolver
 set XD_MODULE_CONFIG_LOCATION=%XD_MODULE_CONFIG_LOCATION%/
 
-set SPRING_XD_OPTS=-Dspring.application.name=admin -Dlogging.config=file:%XD_HOME%/config/xd-admin-logger.properties -Dxd.home=%XD_HOME%
+set SPRING_XD_OPTS=-Dspring.application.name=admin -Dlogging.config=file:%XD_CONFIG_LOCATION%/xd-admin-logger.properties -Dxd.home=%XD_HOME%
 set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dspring.config.location=%XD_CONFIG_LOCATION% -Dxd.config.home=%XD_CONFIG_LOCATION% -Dspring.config.name=%XD_CONFIG_NAME%
 set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dxd.module.config.location=%XD_MODULE_CONFIG_LOCATION% -Dxd.module.config.name=%XD_MODULE_CONFIG_NAME%
 

--- a/scripts/xd/xd-container
+++ b/scripts/xd/xd-container
@@ -197,7 +197,7 @@ if [ x"$XD_MODULE_CONFIG_NAME" = x ] ; then
 fi
 
 # set app name etc. via SPRING_XD_OPTS
-SPRING_XD_OPTS="-Dspring.application.name=container -Dlogging.config=file:$XD_HOME/config/xd-container-logger.properties -Dxd.home=$XD_HOME"
+SPRING_XD_OPTS="-Dspring.application.name=container -Dlogging.config=file:$XD_CONFIG_LOCATION/xd-container-logger.properties -Dxd.home=$XD_HOME"
 SPRING_XD_OPTS="$SPRING_XD_OPTS -Dspring.config.location=$XD_CONFIG_LOCATION -Dxd.config.home=$XD_CONFIG_LOCATION -Dspring.config.name=$XD_CONFIG_NAME"
 SPRING_XD_OPTS="$SPRING_XD_OPTS -Dxd.module.config.location=$XD_MODULE_CONFIG_LOCATION -Dxd.module.config.name=$XD_MODULE_CONFIG_NAME"
 

--- a/scripts/xd/xd-container.bat
+++ b/scripts/xd/xd-container.bat
@@ -116,7 +116,7 @@ if not defined XD_MODULE_CONFIG_NAME (
 @rem make sure to append '/' to XD_MODULE_CONFIG_LOCATION until the path issue is resoloved in EnvironmentAwareModuleOptionsMetadataResolver
 set XD_MODULE_CONFIG_LOCATION=%XD_MODULE_CONFIG_LOCATION%/
 
-set SPRING_XD_OPTS=-Dspring.application.name=container -Dlogging.config=file:%XD_HOME%/config/xd-container-logger.properties -Dxd.home=%XD_HOME%
+set SPRING_XD_OPTS=-Dspring.application.name=container -Dlogging.config=file:%XD_CONFIG_LOCATION%/xd-container-logger.properties -Dxd.home=%XD_HOME%
 set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dspring.config.location=%XD_CONFIG_LOCATION% -Dxd.config.home=%XD_CONFIG_LOCATION% -Dspring.config.name=%XD_CONFIG_NAME%
 set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dxd.module.config.location=%XD_MODULE_CONFIG_LOCATION% -Dxd.module.config.name=%XD_MODULE_CONFIG_NAME%
 

--- a/scripts/xd/xd-singlenode
+++ b/scripts/xd/xd-singlenode
@@ -198,7 +198,7 @@ if [ x"$XD_MODULE_CONFIG_NAME" = x ] ; then
 fi
 
 # set app name etc. via SPRING_XD_OPTS
-SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_HOME/config/xd-singlenode-logger.properties -Dxd.home=$XD_HOME"
+SPRING_XD_OPTS="-Dspring.application.name=admin -Dlogging.config=file:$XD_CONFIG_LOCATION/xd-singlenode-logger.properties -Dxd.home=$XD_HOME"
 SPRING_XD_OPTS="$SPRING_XD_OPTS -Dspring.config.location=$XD_CONFIG_LOCATION -Dxd.config.home=$XD_CONFIG_LOCATION -Dspring.config.name=$XD_CONFIG_NAME"
 SPRING_XD_OPTS="$SPRING_XD_OPTS -Dxd.module.config.location=$XD_MODULE_CONFIG_LOCATION -Dxd.module.config.name=$XD_MODULE_CONFIG_NAME"
 

--- a/scripts/xd/xd-singlenode.bat
+++ b/scripts/xd/xd-singlenode.bat
@@ -117,7 +117,7 @@ if not defined XD_MODULE_CONFIG_NAME (
 @rem make sure to append '/' to XD_MODULE_CONFIG_LOCATION until the path issue is resoloved in EnvironmentAwareModuleOptionsMetadataResolver
 set XD_MODULE_CONFIG_LOCATION=%XD_MODULE_CONFIG_LOCATION%/
 
-set SPRING_XD_OPTS=-Dspring.application.name=singlenode -Dlogging.config=file:%XD_HOME%/config/xd-singlenode-logger.properties -Dxd.home=%XD_HOME%
+set SPRING_XD_OPTS=-Dspring.application.name=singlenode -Dlogging.config=file:%XD_CONFIG_LOCATION%/xd-singlenode-logger.properties -Dxd.home=%XD_HOME%
 set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dspring.config.location=%XD_CONFIG_LOCATION% -Dxd.config.home=%XD_CONFIG_LOCATION% -Dspring.config.name=%XD_CONFIG_NAME%
 set SPRING_XD_OPTS=%SPRING_XD_OPTS% -Dxd.module.config.location=%XD_MODULE_CONFIG_LOCATION% -Dxd.module.config.name=%XD_MODULE_CONFIG_NAME%
 


### PR DESCRIPTION
Previously, the scripts all looked for the logging configuration in `$XD_HOME/config` (or `%XD_HOME%/config`).  This caused issues because it meant that if you moved all of the configuration and overrode `$XD_CONFIG_LOCATION` (or `%XD_CONFIG_LOCATION%`), the logging configuration changes would not be found in the new location.  This change updates the scripts to look for logging configuration in `$XD_CONFIG_LOCATION` (or `%XD_CONFIG_LOCATION%`).
