### PR TITLE
XD-1873 Make jobexecution list performant

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/DistributedJobService.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/DistributedJobService.java
@@ -16,8 +16,6 @@
 
 package org.springframework.xd.dirt.plugins.job;
 
-import java.util.Collection;
-
 import org.springframework.batch.admin.service.SearchableJobExecutionDao;
 import org.springframework.batch.admin.service.SearchableJobInstanceDao;
 import org.springframework.batch.admin.service.SearchableStepExecutionDao;
@@ -46,18 +44,12 @@ public class DistributedJobService extends SimpleJobService {
 
 	private DistributedJobLocator distributedJobLocator;
 
-	private SearchableJobExecutionDao jobExecutionDao;
-
-	private SearchableStepExecutionDao stepExecutionDao;
-
 	public DistributedJobService(SearchableJobInstanceDao jobInstanceDao, SearchableJobExecutionDao jobExecutionDao,
 			SearchableStepExecutionDao stepExecutionDao, JobRepository jobRepository, JobLauncher jobLauncher,
 			DistributedJobLocator batchJobLocator, ExecutionContextDao executionContextDao) {
 		super(jobInstanceDao, jobExecutionDao, stepExecutionDao, jobRepository, jobLauncher, batchJobLocator,
 				executionContextDao);
 		this.distributedJobLocator = batchJobLocator;
-		this.jobExecutionDao = jobExecutionDao;
-		this.stepExecutionDao = stepExecutionDao;
 	}
 
 	@Override
@@ -89,16 +81,6 @@ public class DistributedJobService extends SimpleJobService {
 		// if the batch job is not launchable (the job is not deployed) then return false
 		// as the persistent job locator wouldn't have entries for the job.
 		return (isLaunchable(jobName) ? distributedJobLocator.isIncrementable(jobName) : false);
-	}
-
-	@Override
-	public Collection<JobExecution> listJobExecutions(int start, int count) {
-		Collection<JobExecution> jobExecutions = jobExecutionDao.getJobExecutions(start, count);
-		// Associate step executions for each of the job executions in the list.
-		for (JobExecution jobExecution : jobExecutions) {
-			stepExecutionDao.addStepExecutions(jobExecution);
-		}
-		return jobExecutions;
 	}
 
 	public Job getJob(String jobName) throws NoSuchJobException {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
@@ -18,7 +18,9 @@ package org.springframework.xd.dirt.rest;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
@@ -79,9 +81,9 @@ public class BatchJobExecutionsController extends AbstractBatchJobsController {
 
 		Collection<JobExecutionInfoResource> result = new ArrayList<JobExecutionInfoResource>();
 		JobExecutionInfoResource jobExecutionInfoResource;
-		Collection<String> restartableJobs = jobLocator.getAllRestartableJobs();
-		Collection<String> deployedJobs = jobLocator.getJobNames();
-		Collection<String> jobDefinitionNames = getJobDefinitionNames();
+		Set<String> restartableJobs = new HashSet<String>(jobLocator.getAllRestartableJobs());
+		Set<String> deployedJobs = new HashSet<String>(jobLocator.getJobNames());
+		Set<String> jobDefinitionNames = new HashSet<String>(getJobDefinitionNames());
 		for (JobExecution jobExecution : jobService.listJobExecutions(startJobExecution, pageSize)) {
 			jobExecutionInfoResource = jobExecutionInfoResourceAssembler.toResource(new JobExecutionInfo(jobExecution,
 					timeZone));


### PR DESCRIPTION
- Remove explicit addition of step executions to each of the job execution in the list
- Change `List` -> `Set` so that `contains` operation would be faster
