### PR TITLE
Acceptance test uses guava 15.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1535,6 +1535,7 @@ project('spring-xd-integration-test') {
 		compile "com.fasterxml.jackson.core:jackson-databind"
 		compile ("org.apache.hadoop:hadoop-common:$hadoop22Version")
 		compile ("org.apache.hadoop:hadoop-client:$hadoop22Version")
+		compile "com.google.guava:guava:15.0"
 		compile ("org.springframework.data:spring-data-mongodb") { exclude group: 'org.slf4j' }
 		testCompile "mysql:mysql-connector-java"
 		testCompile "commons-collections:commons-collections"


### PR DESCRIPTION
Had to set this to version 15 because JClouds will not be able to use any guava above 15 until they release 1.8.
