### PR TITLE
XD-1849: Move executions by name

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
@@ -108,6 +108,32 @@ public class BatchJobExecutionsController extends AbstractBatchJobsController {
 	}
 
 	/**
+	 * Return a paged collection of job executions for a given job.
+	 * 
+	 * @param jobName name of the job
+	 * @param startJobExecution start index for the job execution list
+	 * @param pageSize page size for the list
+	 * @return collection of JobExecutionInfo
+	 */
+	@RequestMapping(value = "", method = RequestMethod.GET, params = "jobname")
+	@ResponseStatus(HttpStatus.OK)
+	public Collection<JobExecutionInfoResource> executionsForJob(@RequestParam("jobname") String jobName,
+			@RequestParam(defaultValue = "0") int startJobExecution,
+			@RequestParam(defaultValue = "20") int pageSize) {
+
+		Collection<JobExecutionInfoResource> result = new ArrayList<JobExecutionInfoResource>();
+		try {
+			for (JobExecution jobExecution : jobService.listJobExecutionsForJob(jobName, startJobExecution, pageSize)) {
+				result.add(jobExecutionInfoResourceAssembler.toResource(new JobExecutionInfo(jobExecution, timeZone)));
+			}
+		}
+		catch (NoSuchJobException e) {
+			throw new NoSuchBatchJobException(jobName);
+		}
+		return result;
+	}
+
+	/**
 	 * Get all existing job definition names.
 	 *
 	 * @return the collection of job definition names

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
@@ -37,7 +37,6 @@ import org.springframework.xd.dirt.job.JobInstanceInfo;
 import org.springframework.xd.dirt.job.NoSuchBatchJobException;
 import org.springframework.xd.dirt.stream.Job;
 import org.springframework.xd.rest.client.domain.DetailedJobInfoResource;
-import org.springframework.xd.rest.client.domain.JobExecutionInfoResource;
 import org.springframework.xd.rest.client.domain.JobInstanceInfoResource;
 
 
@@ -165,29 +164,4 @@ public class BatchJobsController extends AbstractBatchJobsController {
 		}
 	}
 
-	/**
-	 * Return a paged collection of job executions for a given job.
-	 * 
-	 * @param jobName name of the job
-	 * @param startJobExecution start index for the job execution list
-	 * @param pageSize page size for the list
-	 * @return collection of JobExecutionInfo
-	 */
-	@RequestMapping(value = "/{jobName}/executions", method = RequestMethod.GET)
-	@ResponseStatus(HttpStatus.OK)
-	public Collection<JobExecutionInfoResource> executionsForJob(@PathVariable String jobName,
-			@RequestParam(defaultValue = "0") int startJobExecution,
-			@RequestParam(defaultValue = "20") int pageSize) {
-
-		Collection<JobExecutionInfoResource> result = new ArrayList<JobExecutionInfoResource>();
-		try {
-			for (JobExecution jobExecution : jobService.listJobExecutionsForJob(jobName, startJobExecution, pageSize)) {
-				result.add(jobExecutionInfoResourceAssembler.toResource(new JobExecutionInfo(jobExecution, timeZone)));
-			}
-		}
-		catch (NoSuchJobException e) {
-			throw new NoSuchBatchJobException(jobName);
-		}
-		return result;
-	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobsControllerIntegrationTests.java
@@ -199,8 +199,9 @@ public class BatchJobsControllerIntegrationTests extends AbstractControllerInteg
 	@Test
 	public void testGetJobExecutionsByName() throws Exception {
 		mockMvc.perform(
-				get("/batch/jobs/job2/executions").param("startJobExecution", "0").param("pageSize", "20").accept(
-						MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				get("/jobs/executions").param("jobname", "job2")
+						.param("startJobExecution", "0").param("pageSize", "20").accept(
+								MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$", Matchers.hasSize(1)))
 				.andExpect(jsonPath("$[0].executionId").value(3))
 				.andExpect(jsonPath("$[0].jobId").value(2))


### PR DESCRIPTION
This endpoint seems to exist but is not currently used by anything, unless I'm mistaken.
When trying to invoke it, I encountered an infinite loop serverside.
Need to look at current master to see if it is introduced by my refactoring or not
