### PR TITLE
XD-1941 Re-enabled Boot repackaging for spring-xd-yarn sub-projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -907,6 +907,7 @@ project('spring-xd-hadoop:phd20') {
 		include 'jersey-server-*'
 	}
 }
+
 project('spring-xd-yarn:spring-xd-yarn-client') {
     description = 'Spring XD YARN Client App'
 
@@ -940,6 +941,11 @@ project('spring-xd-yarn:spring-xd-yarn-client') {
     jar {
     	setExcludes([])
 	}
+
+	bootRepackage  {
+        enabled = true
+	}
+
 }
 
 project('spring-xd-yarn:spring-xd-yarn-appmaster') {
@@ -973,6 +979,10 @@ project('spring-xd-yarn:spring-xd-yarn-appmaster') {
 
     jar {
     	setExcludes([])
+	}
+
+	bootRepackage  {
+        enabled = true
 	}
 }
 


### PR DESCRIPTION
- These were disabled during the switch to use Spring IO Platform
