### PR TITLE
XD-1849 Move batch jobs configurations endpoint

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
@@ -68,7 +68,7 @@ public class AdminController {
 		xdRuntime.add(entityLinks.linkFor(ModuleMetadataResource.class).withRel("runtime/modules"));
 		xdRuntime.add(entityLinks.linkFor(ContainerAttributesResource.class).withRel("runtime/containers"));
 
-		xdRuntime.add(entityLinks.linkFor(DetailedJobInfoResource.class).withRel("batch/jobs"));
+		xdRuntime.add(entityLinks.linkFor(DetailedJobInfoResource.class).withRel("jobs/configurations"));
 		xdRuntime.add(entityLinks.linkFor(JobExecutionInfoResource.class).withRel("jobs/executions"));
 		xdRuntime.add(entityLinks.linkFor(JobInstanceInfoResource.class).withRel("jobs/instances"));
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
@@ -49,7 +49,7 @@ import org.springframework.xd.rest.client.domain.JobInstanceInfoResource;
  * 
  */
 @RestController
-@RequestMapping("/batch/jobs")
+@RequestMapping("/jobs/configurations")
 @ExposesResourceFor(DetailedJobInfoResource.class)
 public class BatchJobsController extends AbstractBatchJobsController {
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobExecutionsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobExecutionsControllerIntegrationTests.java
@@ -196,6 +196,30 @@ public class BatchJobExecutionsControllerIntegrationTests extends AbstractContro
 	}
 
 	@Test
+	public void testGetJobExecutionsByName() throws Exception {
+		mockMvc.perform(
+				get("/jobs/executions").param("jobname", "job2")
+						.param("startJobExecution", "0").param("pageSize", "20").accept(
+								MediaType.APPLICATION_JSON)).andExpect(status().isOk())
+				.andExpect(jsonPath("$", Matchers.hasSize(1)))
+				.andExpect(jsonPath("$[0].executionId").value(3))
+				.andExpect(jsonPath("$[0].jobId").value(2))
+				.andExpect(jsonPath("$[0].jobExecution[*].id").value(3))
+				.andExpect(
+						jsonPath("$[0].jobExecution[*].jobParameters.parameters.param1.value").value("test"))
+				.andExpect(
+						jsonPath("$[0].jobExecution[*].jobParameters.parameters.param1.type").value("STRING"))
+				.andExpect(jsonPath("$[0].jobExecution[*].jobParameters.parameters.param1.identifying").value(
+						true))
+				.andExpect(
+						jsonPath("$[0].jobExecution[*].jobParameters.parameters.param2.value").value(123))
+				.andExpect(
+						jsonPath("$[0].jobExecution[*].jobParameters.parameters.param2.type").value("LONG"))
+				.andExpect(jsonPath("$[0].jobExecution[*].jobParameters.parameters.param2.identifying").value(
+						false));
+	}
+
+	@Test
 	public void testGetBatchJobExecutions() throws Exception {
 		mockMvc.perform(
 				get("/jobs/executions").param("startJobExecution", "0").param("pageSize", "20").accept(

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobsControllerIntegrationTests.java
@@ -146,7 +146,8 @@ public class BatchJobsControllerIntegrationTests extends AbstractControllerInteg
 	public void testGetBatchJobs() throws Exception {
 		JobExecutionInfo info = new JobExecutionInfo(execution, timeZone);
 		mockMvc.perform(
-				get("/batch/jobs").param("startJob", "0").param("pageSize", "20").accept(MediaType.APPLICATION_JSON)).andExpect(
+				get("/jobs/configurations").param("startJob", "0").param("pageSize", "20").accept(
+						MediaType.APPLICATION_JSON)).andExpect(
 				status().isOk()).andExpect(jsonPath("$", Matchers.hasSize(2))).andExpect(
 				jsonPath("$[*].executionCount", contains(2, 1))).andExpect(
 				jsonPath("$[*].launchable", contains(false, true))).andExpect(
@@ -178,7 +179,7 @@ public class BatchJobsControllerIntegrationTests extends AbstractControllerInteg
 	@Test
 	public void testGetJobInstanceByJobName() throws Exception {
 		mockMvc.perform(
-				get("/batch/jobs/job1/instances").param("startJobInstance", "0").param("pageSize", "20").accept(
+				get("/jobs/configurations/job1/instances").param("startJobInstance", "0").param("pageSize", "20").accept(
 						MediaType.APPLICATION_JSON)).andExpect(status().isOk())
 				.andExpect(jsonPath("$", Matchers.hasSize(2)))
 				.andExpect(jsonPath("$[*].instanceId", contains(0, 3)))
@@ -188,35 +189,11 @@ public class BatchJobsControllerIntegrationTests extends AbstractControllerInteg
 	@Test
 	public void testGetJobInfoByJobName() throws Exception {
 		mockMvc.perform(
-				get("/batch/jobs/job1").param("startJobInstance", "0").param("pageSize", "20").accept(
+				get("/jobs/configurations/job1").param("startJobInstance", "0").param("pageSize", "20").accept(
 						MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andExpect(
 				jsonPath("$.executionCount").value(2)).andExpect(jsonPath("$.launchable").value(false)).andExpect(
 				jsonPath("$.incrementable").value(false)).andExpect(jsonPath("$.deployed").value(false)).andExpect(
 				jsonPath("$.jobInstanceId", nullValue()));
 
-	}
-
-	@Test
-	public void testGetJobExecutionsByName() throws Exception {
-		mockMvc.perform(
-				get("/jobs/executions").param("jobname", "job2")
-						.param("startJobExecution", "0").param("pageSize", "20").accept(
-								MediaType.APPLICATION_JSON)).andExpect(status().isOk())
-				.andExpect(jsonPath("$", Matchers.hasSize(1)))
-				.andExpect(jsonPath("$[0].executionId").value(3))
-				.andExpect(jsonPath("$[0].jobId").value(2))
-				.andExpect(jsonPath("$[0].jobExecution[*].id").value(3))
-				.andExpect(
-						jsonPath("$[0].jobExecution[*].jobParameters.parameters.param1.value").value("test"))
-				.andExpect(
-						jsonPath("$[0].jobExecution[*].jobParameters.parameters.param1.type").value("STRING"))
-				.andExpect(jsonPath("$[0].jobExecution[*].jobParameters.parameters.param1.identifying").value(
-						true))
-				.andExpect(
-						jsonPath("$[0].jobExecution[*].jobParameters.parameters.param2.value").value(123))
-				.andExpect(
-						jsonPath("$[0].jobExecution[*].jobParameters.parameters.param2.type").value("LONG"))
-				.andExpect(jsonPath("$[0].jobExecution[*].jobParameters.parameters.param2.identifying").value(
-						false));
 	}
 }

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDTemplate.java
@@ -103,7 +103,7 @@ public class SpringXDTemplate extends AbstractTemplate implements SpringXDOperat
 		resources.put("jobs/deployments", new UriTemplate(xdRuntime.getLink("jobs").getHref() + "/deployments"));
 		resources.put("modules", new UriTemplate(xdRuntime.getLink("modules").getHref()));
 
-		resources.put("batch/jobs", new UriTemplate(xdRuntime.getLink("batch/jobs").getHref()));
+		resources.put("jobs/configurations", new UriTemplate(xdRuntime.getLink("jobs/configurations").getHref()));
 		resources.put("jobs/executions", new UriTemplate(xdRuntime.getLink("jobs/executions").getHref()));
 		resources.put("jobs/instances", new UriTemplate(xdRuntime.getLink("jobs/instances").getHref()));
 

--- a/spring-xd-ui/app/scripts/job/services.js
+++ b/spring-xd-ui/app/scripts/job/services.js
@@ -130,7 +130,7 @@ define(['angular'], function (angular) {
         };
       })
       .factory('JobDeployments', function ($resource, $rootScope) {
-        return $resource($rootScope.xdAdminServerUrl + '/batch/jobs.json', {}, {
+        return $resource($rootScope.xdAdminServerUrl + '/jobs/configurations.json', {}, {
           getArray: {method: 'GET', isArray: true}
         });
       })


### PR DESCRIPTION
- Move REST endpoint `/batch/jobs` to `/jobs/configurations`
- Fix admin UI
- Fix tests
- Move `jobs/executions` endpoint tests into `BatchJobExecutionsControllerIntegrationTests`
