### PR TITLE
Force versions from platform transitively

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,8 +116,6 @@ ext {
 def forceDependencyVersions(project) {
 	project.configurations.all { configuration ->
 		if ('versionManagement' != configuration.name) {
-			def forcedGroups = [ 'org.springframework', 'org.springframework.amqp', 'org.slf4j', 'org.codehaus.groovy']
-			def forcedNames = ['spring-data-redis']
 
 			def versions = [:]
 
@@ -131,8 +129,9 @@ def forceDependencyVersions(project) {
 
 			resolutionStrategy {
 				eachDependency { details ->
-					if (forcedGroups.contains(details.requested.group) || forcedNames.contains(details.requested.name)) {
-						details.useVersion versions["$details.requested.group:$details.requested.name"]
+					def version = versions["$details.requested.group:$details.requested.name"]
+					if (version) {
+						details.useVersion version
 					}
 				}
 			}


### PR DESCRIPTION
This started because I witnessed a build failure in eclipse. Those interested can search for "After a gradle cleanEclipse eclipse, and import of spring-xd-extension-batch (which is new) I get a complaint that org.springframework.integration.Message cannot be found" in hipchat and read down from there.

@wilkinsona provided the following fix, which basically applies a version from platform when there is one (not just at first level like the boot plugin does, but across the board)
