### PR TITLE
Appends file: to XD_CONFIG_LOCATION

### DIFF
--- a/scripts/xd/xd-admin
+++ b/scripts/xd/xd-admin
@@ -168,8 +168,9 @@ fi
 # Check for explicity set XD_CONFIG_* and XD_MODULE_CONFIG_*
 if [ x"$XD_CONFIG_LOCATION" = x ] ; then
     export XD_CONFIG_LOCATION=file:$XD_HOME/config/
+else
+    export XD_CONFIG_LOCATION=file:$XD_CONFIG_LOCATION/
 fi
-export XD_CONFIG_LOCATION=$XD_CONFIG_LOCATION/
 if [ x"$XD_CONFIG_NAME" = x ] ; then
     export XD_CONFIG_NAME=servers
 fi

--- a/scripts/xd/xd-admin.bat
+++ b/scripts/xd/xd-admin.bat
@@ -85,8 +85,9 @@ if not defined XD_HOME (
 @rem Check for an explicitly set XD_CONFIG_* and XD_MODULE_CONFIG_*
 if not defined XD_CONFIG_LOCATION (
     set XD_CONFIG_LOCATION=file:%XD_HOME%/config/
+) else (
+	set XD_CONFIG_LOCATION=file:%XD_CONFIG_LOCATION%/
 )
-set XD_CONFIG_LOCATION=%XD_CONFIG_LOCATION%/
 
 if not defined XD_CONFIG_NAME (
     set XD_CONFIG_NAME=servers

--- a/scripts/xd/xd-container
+++ b/scripts/xd/xd-container
@@ -183,8 +183,9 @@ fi
 # Check for explicity set XD_CONFIG_* and XD_MODULE_CONFIG_*
 if [ x"$XD_CONFIG_LOCATION" = x ] ; then
     export XD_CONFIG_LOCATION=file:$XD_HOME/config/
+else
+    export XD_CONFIG_LOCATION=file:$XD_CONFIG_LOCATION/
 fi
-export XD_CONFIG_LOCATION=$XD_CONFIG_LOCATION/
 if [ x"$XD_CONFIG_NAME" = x ] ; then
     export XD_CONFIG_NAME=servers
 fi

--- a/scripts/xd/xd-container.bat
+++ b/scripts/xd/xd-container.bat
@@ -100,8 +100,10 @@ if not defined XD_HOME (
 @rem Check for an explicitly set XD_CONFIG_* and XD_MODULE_CONFIG_*
 if not defined XD_CONFIG_LOCATION (
     set XD_CONFIG_LOCATION=file:%XD_HOME%/config/
+) else (
+	set XD_CONFIG_LOCATION=file:%XD_CONFIG_LOCATION%/
 )
-set XD_CONFIG_LOCATION=%XD_CONFIG_LOCATION%/
+
 if not defined XD_CONFIG_NAME (
     set XD_CONFIG_NAME=servers
 )

--- a/scripts/xd/xd-singlenode
+++ b/scripts/xd/xd-singlenode
@@ -184,8 +184,9 @@ fi
 # Check for explicity set XD_CONFIG_* and XD_MODULE_CONFIG_*
 if [ x"$XD_CONFIG_LOCATION" = x ] ; then
     export XD_CONFIG_LOCATION=file:$XD_HOME/config/
+else
+    export XD_CONFIG_LOCATION=file:$XD_CONFIG_LOCATION/
 fi
-export XD_CONFIG_LOCATION=$XD_CONFIG_LOCATION/
 if [ x"$XD_CONFIG_NAME" = x ] ; then
     export XD_CONFIG_NAME=servers
 fi

--- a/scripts/xd/xd-singlenode.bat
+++ b/scripts/xd/xd-singlenode.bat
@@ -100,8 +100,9 @@ if not defined XD_HOME (
 @rem Check for an explicitly set XD_CONFIG_* and XD_MODULE_CONFIG_*
 if not defined XD_CONFIG_LOCATION (
     set XD_CONFIG_LOCATION=file:%XD_HOME%/config/
+) else (
+	set XD_CONFIG_LOCATION=file:%XD_CONFIG_LOCATION%/
 )
-set XD_CONFIG_LOCATION=%XD_CONFIG_LOCATION%/
 
 if not defined XD_CONFIG_NAME (
     set XD_CONFIG_NAME=servers


### PR DESCRIPTION
When user sets XD_CONFIG_LOCATION modules would fail because they could not find the config directory.
This was because the first / was missing.  To resolve this "file:" is appended to the XD_CONFIG_LOCATION.

To reproduce:
1. export XD_CONFIG_LOCATION=<config directory>
2. deploy the following: 'stream create foo --definition "time|hdfs" --deploy .

The hdfs will not deploy properly because it can not find hadoop.properties.

This PR should resolve the issue.
