### PR TITLE
XD-1953 Handle undeploy modules upon container shutdown

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerRegistrar.java
@@ -766,7 +766,7 @@ public class ContainerRegistrar implements ApplicationListener<ContextRefreshedE
 						client.delete().deletingChildrenIfNeeded().forPath(deploymentPath);
 					}
 				}
-				catch (KeeperException e) {
+				catch (Exception e) {
 					// it is common for a process shutdown to trigger this
 					// event; therefore any exception thrown while attempting
 					// to delete a deployment path will only be rethrown

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/CompositeModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/CompositeModule.java
@@ -214,12 +214,12 @@ public class CompositeModule extends AbstractModule {
 
 	@Override
 	public <T> T getComponent(Class<T> requiredType) {
-		return this.context.getBean(requiredType);
+		return (this.context.isActive()) ? this.context.getBean(requiredType) : null;
 	}
 
 	@Override
 	public <T> T getComponent(String componentName, Class<T> requiredType) {
-		if (this.context.containsBean(componentName)) {
+		if (this.context.isActive() && this.context.containsBean(componentName)) {
 			return context.getBean(componentName, requiredType);
 		}
 		return null;

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/SimpleModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/SimpleModule.java
@@ -155,12 +155,12 @@ public class SimpleModule extends AbstractModule {
 
 	@Override
 	public <T> T getComponent(Class<T> requiredType) {
-		return this.context.getBean(requiredType);
+		return (this.context.isActive()) ? this.context.getBean(requiredType) : null;
 	}
 
 	@Override
 	public <T> T getComponent(String componentName, Class<T> requiredType) {
-		if (this.context.containsBean(componentName)) {
+		if (this.context.isActive() && this.context.containsBean(componentName)) {
 			return context.getBean(componentName, requiredType);
 		}
 		return null;


### PR DESCRIPTION
- When the container process is shutdown, the `Stream/JobModuleWatcher` in
  ContainerRegistrar process `Stream/JobDeploymentsPath` node deleted event.
  In this case, it triggers undeployment of all the corresponding modules.
  But, by the time the undeployment happens the module context is already
  closed.
- The fix checks if the module context is active when any of the
  Module getComponent() is invoked.
- Fix JobModuleWatcher catch clause to catch `Exception` instead of `KeeperException`
  and subsequently check for Curator STARTED state
