### PR TITLE
Restore PubSub Producer Exchange Declaration

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -425,6 +425,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		validateProducerProperties(name, properties, SUPPORTED_PUBSUB_PRODUCER_PROPERTIES);
 		RabbitPropertiesAccessor accessor = new RabbitPropertiesAccessor(properties);
 		String exchangeName = accessor.getPrefix(this.defaultPrefix) + "topic." + name;
+		this.rabbitAdmin.declareExchange(new FanoutExchange(exchangeName));
 		AmqpOutboundEndpoint fanout = new AmqpOutboundEndpoint(rabbitTemplate);
 		fanout.setExchangeName(exchangeName);
 		configureOutboundHandler(fanout, accessor);


### PR DESCRIPTION
XD-1786 incorrectly removed the declaration of the exchange
on the producer side.

Although tap producers are not created before consumers, a
named 'topic:' would publish to a non-existent exchange
until a consumer is bound.

Spring AMQP now logs such publications as an ERROR.
