### PR TITLE
XD-1958 Fix Partitioned Batch Jobs

### DIFF
--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
@@ -35,21 +35,33 @@
 
 	<!-- Master -->
 
-	<int:channel id="stepExecutionRequests.output" />
-
-	<int:channel id="stepExecutionReplies.input" />
-
 	<bean id="partitionHandler" class="org.springframework.batch.integration.partition.MessageChannelPartitionHandler">
 		<property name="messagingOperations">
 			<bean class="org.springframework.integration.core.MessagingTemplate">
-				<property name="defaultChannel" ref="stepExecutionRequests.output" />
+				<property name="defaultChannel" ref="setHeaderReplyChannelChannel" />
 				<property name="receiveTimeout" value="${partitionResultsTimeout:3600000}" />
 			</bean>
 		</property>
 		<property name="stepName" value="step1" />
 	</bean>
 
-	<int:aggregator ref="partitionHandler" send-timeout="10000" input-channel="stepExecutionReplies.input" />
+	<int:header-enricher input-channel="setHeaderReplyChannelChannel" output-channel="stepExecutionRequests.output">
+		<int:header name="xdReplyChannel" expression="@replyChannelRegistry.channelToChannelName(headers.replyChannel)" />
+	</int:header-enricher>
+
+	<int:channel id="stepExecutionRequests.output" />
+
+			<!-- Message Bus  -->
+
+	<int:channel id="stepExecutionReplies.input" />
+
+	<int:header-enricher input-channel="stepExecutionReplies.input" output-channel="resultAggregationChannel">
+		<int:reply-channel expression="@replyChannelRegistry.channelNameToChannel(headers.xdReplyChannel)" />
+	</int:header-enricher>
+
+	<int:channel id="resultAggregationChannel" />
+
+	<int:aggregator ref="partitionHandler" send-timeout="10000" input-channel="resultAggregationChannel" />
 
 	<job id="job" restartable="${restartable}" xmlns="http://www.springframework.org/schema/batch">
 		<step id="step1-master">
@@ -77,6 +89,10 @@
 		<property name="serializer">
 			<bean class="org.springframework.batch.core.repository.dao.XStreamExecutionContextStringSerializer" />
 		</property>
+	</bean>
+
+	<bean id="replyChannelRegistry" class="org.springframework.integration.channel.DefaultHeaderChannelRegistry">
+		<constructor-arg value="${partitionResultsTimeout:3600000}" />
 	</bean>
 
 </beans>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/RedisMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/RedisMessageBusTests.java
@@ -23,9 +23,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
@@ -36,6 +39,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.expression.Expression;
@@ -326,6 +330,15 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 		Object rightPop = template.boundListOps("ERRORS:retry.0").rightPop(5, TimeUnit.SECONDS);
 		assertNotNull(rightPop);
 		assertThat(new String((byte[]) rightPop), containsString("foo"));
+	}
+
+	@Test
+	public void testMoreHeaders() {
+		RedisMessageBus bus = new RedisMessageBus(mock(RedisConnectionFactory.class), getCodec(), "foo", "bar");
+		Collection<String> headers = Arrays.asList(TestUtils.getPropertyValue(bus, "headersToMap", String[].class));
+		assertEquals(9, headers.size());
+		assertTrue(headers.contains("foo"));
+		assertTrue(headers.contains("bar"));
 	}
 
 	private RedisTemplate<String, Object> createTemplate() {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-1958

With the `RabbitMessageBus`, the `replyChanel` header was
not propagated and so the aggregator failed to deliver
the step execution results to the partition handler.

Use a `HeaderChannelRegistry` to propagate a key
referencing the `replyChannel`.

With the `RedisMessagebus` there was no provision to
propagate _any_ headers needed for paritioning
(`correlationId`, `sequenceSize` etc).

Add a list of standard headers to propagate and a
facility to add additional headers (at the bus level).

Add tests to assert propagation; also tested manually
with the file->jdbc job with 3 partitions (both Rabbit
and Redis).
