### PR TITLE
XD-1970 Improve Thread Naming for Rabbit Bus

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -41,6 +41,7 @@ import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.expression.Expression;
 import org.springframework.http.MediaType;
 import org.springframework.integration.amqp.AmqpHeaders;
@@ -335,6 +336,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		}
 		listenerContainer.setPrefetchCount(properties.getPrefetchCount(this.defaultPrefetchCount));
 		listenerContainer.setTxSize(properties.getTxSize(this.defaultTxSize));
+		listenerContainer.setTaskExecutor(new SimpleAsyncTaskExecutor(queue.getName() + "-"));
 		listenerContainer.setQueues(queue);
 		int maxAttempts = properties.getMaxAttempts(this.defaultMaxAttempts);
 		if (maxAttempts > 1) {


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-1970

Previously, all listener container threads in the
RabbitMessageBus had the same name.

This made it difficult to debug.

Use the queue name as the thread prefix so that you
can easily identify the module in the log.
