### PR TITLE
XD-386(kinda): Add copyright header to files that miss it

### DIFF
--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReader.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReader.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.jdbc;
 
 import org.springframework.batch.item.database.JdbcCursorItemReader;

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/AbstractFieldMappingAwareDataMapperTest.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/AbstractFieldMappingAwareDataMapperTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.analytics.ml;
 
 import static org.hamcrest.CoreMatchers.*;

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyAnalytic.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyAnalytic.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.ml;
 

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyInputMapper.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyInputMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.ml;
 

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyMappedAnalytic.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyMappedAnalytic.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.ml;
 

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyOutputMapper.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyOutputMapper.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.ml;
 

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/MappedAnalyticTest.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/MappedAnalyticTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.ml;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCountResolution.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCountResolution.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.analytics.metrics.core;
 
 import org.joda.time.DateTime;

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCounterRepository.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.core;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/Metric.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/Metric.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.core;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricRepository.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.core;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricUtils.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.core;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/RichGauge.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/RichGauge.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.core;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/MessageCounterHandler.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/MessageCounterHandler.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.integration;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/AbstractRedisMetricRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/AbstractRedisMetricRepository.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.redis;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/AggregateKeyGenerator.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/AggregateKeyGenerator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.redis;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterRepository.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.redis;
 

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisUtils.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.redis;
 

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/RichGaugeTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/RichGaugeTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.core;
 

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/FieldValueCounterHandlerTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/FieldValueCounterHandlerTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.integration;
 

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/SimpleTweet.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/SimpleTweet.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.integration;
 

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisRichGaugeRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisRichGaugeRepositoryTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.analytics.metrics.redis;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/package-info.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Provides classes for the Spring Batch Admin Support
  */
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/package-info.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Provides classes for the Spring Batch Support
  */
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/FileDeletionStepExecutionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/FileDeletionStepExecutionListener.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.dirt.plugins.job.support.listener;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/package-info.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Contains classes for improved Spring Batch support.
  */
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/package-info.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Base Package for Spring XD plugins
  */
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/package-info.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Provides a REST-style API for interacting with the XD runtime.
  */
 

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/package-info.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Provides classes for configuration - parsers, namespace handlers, factory beans.
  */
 

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/package-info.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Provides classes supporting outbound endpoints.
  */
 

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/package-info.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Base package for Hadoop/HDFS support
  */
 

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/test/TestPojo.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/test/TestPojo.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.test;
 
 import org.apache.avro.reflect.Nullable;

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/package-info.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/package-info.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * @author grenfro

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/package-info.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * @author renfrg
  *
  */

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/package-info.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Contains the Module core classes.
  */
 

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/package-info.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Contains the {@link org.springframework.xd.module.options.ModuleOption} related classes.
  */
 

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/package-info.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Root package of the Module support.
  */
 

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/support/package-info.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/support/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Contains support classes for the Module support
  */
 

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolverTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolverTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.module.options;
 

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/package-info.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Contains REST client operation implementations.
  */
 

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/package-info.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Defines the various REST client operation interfaces.
  */
 

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/package-info.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/client/domain/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Contains the resources managed by the REST API.
  */
 

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/package-info.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Defines the various Spring XD Shell commands.
  */
 

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/package-info.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Contains core Spring XD Shell classes.
  */
 

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/package-info.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Contains utilities for rendering textual contents (E.g. text tables), to the
  * console.
  */

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpringBatchStepExecutionTestTasklet.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpringBatchStepExecutionTestTasklet.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.shell.command;
 

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpringBatchWithParametersTasklet.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpringBatchWithParametersTasklet.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.shell.command;
 

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FilePollHdfsJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FilePollHdfsJob.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.test.fixtures;
 

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpHdfsJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpHdfsJob.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.test.fixtures;
 

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/mqtt/MqttTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/mqtt/MqttTestSupport.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.test.mqtt;
 
 import org.eclipse.paho.client.mqttv3.MqttClient;

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/FieldSetType.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/FieldSetType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.tuple.batch;
 

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/SpringToDateConverterTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/SpringToDateConverterTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.tuple;
 

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleFieldExtractorTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleFieldExtractorTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.tuple.batch;
 

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleFieldSetMapperTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleFieldSetMapperTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.tuple.batch;
 

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleRowMapperTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleRowMapperTests.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package org.springframework.xd.tuple.batch;
 

--- a/spring-xd-yarn/spring-xd-yarn-appmaster/src/main/java/org/springframework/xd/yarn/AppMaster.java
+++ b/spring-xd-yarn/spring-xd-yarn-appmaster/src/main/java/org/springframework/xd/yarn/AppMaster.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.yarn;
 
 import org.springframework.boot.SpringApplication;

--- a/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/ClientApp.java
+++ b/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/ClientApp.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.xd.yarn;
 
 import org.springframework.boot.SpringApplication;


### PR DESCRIPTION
Still can't apply https://github.com/hierynomus/license-gradle-plugin as it suffers from https://github.com/hierynomus/license-gradle-plugin/issues/39 (and we don't want headers on **all** our files, including txt, xml, properties, etc)

So configured exclusions and ran it once by hand for now.
