### PR TITLE
XD-1976 Unable to deploy job in UI

### DIFF
--- a/spring-xd-ui/app/scripts/job/views/definition-deploy.html
+++ b/spring-xd-ui/app/scripts/job/views/definition-deploy.html
@@ -6,6 +6,9 @@
 		please see the <a href="https://github.com/spring-projects/spring-xd/wiki/XD-Distributed-Runtime#deployment-manifest"
 		target="_blank">Technical Documentation</a>.
 	</p>
+	<p ng-show="!definitionDeployRequest.moduleName" class="index-page--subtitle"> An error occurred. We were unable to retrieve
+		the module name from the provided definition '<strong>{{definitionName}}</strong>'.
+	</p>
 	<form name="deployDefinitionForm" class="form-horizontal" role="form">
 		<div class="form-group" ng-class="deployDefinitionForm.containerMatchCriteria.$invalid ? 'has-warning has-feedback' : ''">
 			<label for="containerMatchCriteria" class="col-sm-3 control-label">Container Match Criteria</label>
@@ -34,5 +37,5 @@
 	<div class="row">
 		<div class="col-md-6 text-right"><button id="back-button"   type="button" class="btn btn-default" ng-click="cancelDefinitionDeploy()">Back</button></div>
 		<div class="col-md-6 text-left"><button  id="submit-button" type="button" class="btn btn-default"
-		ng-click="deployDefinition(definitionDeployRequest)" ng-disabled="deployDefinitionForm.$invalid">Deploy</button></div>
+		ng-click="deployDefinition(definitionDeployRequest)" ng-disabled="deployDefinitionForm.$invalid || !definitionDeployRequest.moduleName">Deploy</button></div>
 	</div>

--- a/spring-xd-ui/app/scripts/shared/services.js
+++ b/spring-xd-ui/app/scripts/shared/services.js
@@ -39,8 +39,15 @@ define(['angular', 'xregexp'], function (angular) {
           getModuleNameFromJobDefinition: function(jobDefinition) {
             $log.info('Processing job definition: ' + jobDefinition);
             var module = XRegExp.exec(jobDefinition, moduleNameRegex);
-            $log.info('Found Module Name: ' + module);
-            return module[0];
+            var moduleName;
+            if (module) {
+              moduleName = module[0];
+            }
+            else {
+              moduleName = jobDefinition;
+            }
+            $log.info('Found Module Name: ' + moduleName);
+            return moduleName;
           }
         };
       });

--- a/spring-xd-ui/test/spec/services/shared-services-spec.js
+++ b/spring-xd-ui/test/spec/services/shared-services-spec.js
@@ -25,11 +25,15 @@ define([
       angular.mock.module('xdAdmin');
     });
 
-    it('should contain a JobDefinitions service', inject(function(XDUtils) {
+    it('The module name should be retrieved from a definition with parameters.', inject(function(XDUtils) {
       expect(XDUtils.getModuleNameFromJobDefinition).toBeDefined();
       expect(XDUtils.getModuleNameFromJobDefinition('myMod --param=1234')).toEqual('myMod');
     }));
 
+    it('The module name should be retrieved from a definition without parameters.', inject(function(XDUtils) {
+      expect(XDUtils.getModuleNameFromJobDefinition).toBeDefined();
+      expect(XDUtils.getModuleNameFromJobDefinition('myMod2')).toEqual('myMod2');
+    }));
   });
 });
 


### PR DESCRIPTION
- Add test case for `getModuleNameFromJobDefinition` when retrieving the module name for definitions without parameters
- Fix `getModuleNameFromJobDefinition`
- Disable the `Deploy` button as long as no module name has been retrieved
