### PR TITLE
XD-1964 Suppress LoggingApplicationListener warning

### DIFF
--- a/config/xd-admin-logger.properties
+++ b/config/xd-admin-logger.properties
@@ -33,3 +33,5 @@ log4j.logger.org.apache.zookeeper.server.PrepRequestProcessor=WARN
 # This prevents the WARN level about a non-static, @Bean method in Spring Batch that is irrelevant
 log4j.logger.org.springframework.context.annotation.ConfigurationClassEnhancer=ERROR
 
+# This prevents boot LoggingApplicationListener logger's misleading warning message
+log4j.logger.org.springframework.boot.logging.LoggingApplicationListener=ERROR

--- a/config/xd-container-logger.properties
+++ b/config/xd-container-logger.properties
@@ -33,3 +33,5 @@ log4j.logger.org.apache.zookeeper.server.PrepRequestProcessor=WARN
 # This prevents the WARN level about a non-static, @Bean method in Spring Batch that is irrelevant
 log4j.logger.org.springframework.context.annotation.ConfigurationClassEnhancer=ERROR
 
+# This prevents boot LoggingApplicationListener logger's misleading warning message
+log4j.logger.org.springframework.boot.logging.LoggingApplicationListener=ERROR

--- a/config/xd-singlenode-logger.properties
+++ b/config/xd-singlenode-logger.properties
@@ -37,3 +37,6 @@ log4j.logger.org.springframework.context.annotation.ConfigurationClassEnhancer=E
 # logged by ZooKeeper when a parent node does not exist while
 # invoking Curator's creatingParentsIfNeeded node builder.
 log4j.logger.org.apache.zookeeper.server.PrepRequestProcessor=WARN
+
+# This prevents boot LoggingApplicationListener logger's misleading warning message
+log4j.logger.org.springframework.boot.logging.LoggingApplicationListener=ERROR


### PR DESCRIPTION
- The issue with LoggingApplicationListener's incorrect warning
  message is fixed in spring-boot but since we can't upgrade to
  the latest, as a temporary fix setting the log level for
  LoggingApplicationListener to `ERROR`
