### PR TITLE
XD-1975 Avoid IllegalStateException on stream stop

### DIFF
--- a/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/AbstractTwitterInboundChannelAdapter.java
+++ b/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/AbstractTwitterInboundChannelAdapter.java
@@ -255,6 +255,10 @@ public abstract class AbstractTwitterInboundChannelAdapter extends MessageProduc
 		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
+			if (!this.running.get()) {
+				// no longer running
+				return;
+			}
 			throw new IllegalStateException(e);
 		}
 	}


### PR DESCRIPTION
We need a better fix for the twitterstream "MessageDeliveryException: Dispatcher has no subscribers" warning, but at least this fixes IllegalStateException for twittersearch and twitterstream
