### PR TITLE
XD-1749 un-ignored MessageStoreBenchmarkTests

### DIFF
--- a/modules/processor/aggregator/config/aggregator.xml
+++ b/modules/processor/aggregator/config/aggregator.xml
@@ -78,9 +78,9 @@
 		</beans:bean>
 
 		<beans:bean id="redisConnectionFactory" lazy-init="true"
-			class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory">
-			<beans:constructor-arg index="0" value="${hostname}" />
-			<beans:constructor-arg index="1" value="${port}" />
+			class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory">
+			<beans:property name="hostName" value="${hostname}" />
+			<beans:property name="port" value="${port}" />
 			<beans:property name="password" value="${password}" />
 		</beans:bean>
 	</beans:beans>

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
@@ -154,7 +154,7 @@ public abstract class AbstractShellIntegrationTest {
 	}
 
 	private String generateUniqueName() {
-		return generateUniqueName(name.getMethodName());
+		return generateUniqueName(name.getMethodName().replace('[', '-').replaceAll("]", ""));
 	}
 
 	protected String generateStreamName(String name) {


### PR DESCRIPTION
The test had been ignored and therefore became out-of-date (i.e. it no longer worked).

The test does not contain any asserts for benchmarking (i.e. it does not assert any performance thresholds).
It only prints out the time spent within each execution.

The following vars can be updated for benchmarking:
- EXECUTIONS_PER_STORE_TYPE
- MESSAGE_GROUPS_PER_EXECUTION
- MESSAGES_PER_GROUP

It is useful as a test for the aggregator processor itself, exercising each message store type.

Also updated the aggregator processor so that it uses the correct Redis client lib (Jedis, no longer Lettuce).
