### PR TITLE
XD-1652 Fix inconsistent test failures

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractDistributedTransportSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractDistributedTransportSingleNodeStreamDeploymentIntegrationTests.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.xd.dirt.integration.bus.Binding;
 
 /**
@@ -38,7 +39,7 @@ public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentInte
 	@Test
 	public void directBindingEnabledWithExplicitModuleCounts() throws InterruptedException {
 		String streamName = "directBindingEnabledWithExplicitModuleCounts";
-		StreamDefinition sd = new StreamDefinition(streamName, "http | log");
+		StreamDefinition sd = new StreamDefinition(streamName, getHttpLogStream());
 		integrationSupport.streamDefinitionRepository().save(sd);
 		Map<String, String> props = new HashMap<String, String>();
 		props.put("module.http.count", "0");
@@ -55,7 +56,7 @@ public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentInte
 	@Test
 	public void directBindingEnabledWithWildcardModuleCount() throws InterruptedException {
 		String streamName = "directBindingEnabledWithWildcardModuleCount";
-		StreamDefinition sd = new StreamDefinition(streamName, "http | log");
+		StreamDefinition sd = new StreamDefinition(streamName, getHttpLogStream());
 		integrationSupport.streamDefinitionRepository().save(sd);
 		integrationSupport.deployStream(sd, Collections.singletonMap("module.*.count", "0"));
 		List<Binding> bindings = getMessageBusBindingsForStream(streamName);
@@ -69,7 +70,7 @@ public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentInte
 	@Test
 	public void directBindingEnabledWithCriteria() throws InterruptedException {
 		String streamName = "directBindingEnabledWithCriteria";
-		StreamDefinition sd = new StreamDefinition(streamName, "http | log");
+		StreamDefinition sd = new StreamDefinition(streamName, getHttpLogStream());
 		integrationSupport.streamDefinitionRepository().save(sd);
 		Map<String, String> props = new HashMap<String, String>();
 		props.put("module.http.count", "0");
@@ -88,7 +89,7 @@ public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentInte
 	@Test
 	public void directBindingNotEnabledWithMismatchedCounts() throws InterruptedException {
 		String streamName = "directBindingNotEnabledWithMismatchedCounts";
-		StreamDefinition sd = new StreamDefinition(streamName, "http | log");
+		StreamDefinition sd = new StreamDefinition(streamName, getHttpLogStream());
 		integrationSupport.streamDefinitionRepository().save(sd);
 		Map<String, String> props = new HashMap<String, String>();
 		props.put("module.http.count", "0");
@@ -122,7 +123,7 @@ public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentInte
 	@Test
 	public void directBindingNotEnabledWithMismatchedCriteria() throws InterruptedException {
 		String streamName = "directBindingNotEnabledWithMismatchedCriteria";
-		StreamDefinition sd = new StreamDefinition(streamName, "http | log");
+		StreamDefinition sd = new StreamDefinition(streamName, getHttpLogStream());
 		integrationSupport.streamDefinitionRepository().save(sd);
 		Map<String, String> props = new HashMap<String, String>();
 		props.put("module.http.count", "0");
@@ -141,7 +142,8 @@ public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentInte
 	@Test
 	public void directBindingEnabledForPartOfStream() throws InterruptedException {
 		String streamName = "directBindingEnabledForPartOfStream";
-		StreamDefinition sd = new StreamDefinition(streamName, "http | filter | log");
+		StreamDefinition sd = new StreamDefinition(streamName, String.format("http --port=%s | filter | log",
+				SocketUtils.findAvailableServerSocket()));
 		integrationSupport.streamDefinitionRepository().save(sd);
 		Map<String, String> props = new HashMap<String, String>();
 		props.put("module.http.count", "0");


### PR DESCRIPTION
- Fix inconsistent test failures at `StreamDeploymentIntegrationTests`
  - Use random available port for http source module
