### PR TITLE
XD-2006: Logging improvements

### DIFF
--- a/config/xd-admin-logger.properties
+++ b/config/xd-admin-logger.properties
@@ -9,9 +9,9 @@ log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2} - %m%n
 log4j.appender.file=org.apache.log4j.RollingFileAppender
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2} - %m%n
-log4j.appender.file.File=${xd.home}/logs/admin.log
-log4j.appender.file.Append=false
-log4j.appender.file.MaxFileSize=100KB
+log4j.appender.file.File=${xd.home}/logs/admin-${PID}.log
+log4j.appender.file.Append=true
+log4j.appender.file.MaxFileSize=100MB
 
 log4j.logger.org.springframework.xd=WARN
 log4j.logger.org.springframework.xd.dirt.server=INFO

--- a/config/xd-container-logger.properties
+++ b/config/xd-container-logger.properties
@@ -9,9 +9,9 @@ log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2} - %m%n
 log4j.appender.file=org.apache.log4j.RollingFileAppender
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2} - %m%n
-log4j.appender.file.File=${xd.home}/logs/container.log
-log4j.appender.file.Append=false
-log4j.appender.file.MaxFileSize=100KB
+log4j.appender.file.File=${xd.home}/logs/container-${PID}.log
+log4j.appender.file.Append=true
+log4j.appender.file.MaxFileSize=100MB
 
 log4j.logger.org.springframework.xd=WARN
 log4j.logger.org.springframework.xd.dirt.server=INFO


### PR DESCRIPTION
Ensure that each admin and container process has its own unique log file.

Increased the log file size threshold for rollover.
