### PR TITLE
Changing default port from 9102 to 9101

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -60,7 +60,7 @@ xd:
 #hsql:
 #  server:
 #    host: localhost
-#    port: 9102
+#    port: 9101
 #    dbname: xdjob
 #Change database username and password
 #spring:


### PR DESCRIPTION
The default port for hsqldb is 9101, the jdbc URL reflects this correctly, but the hsql section shows 9102, making the changes to be consistent.
