### PR TITLE
XD-1509 Exclude projects for maven publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ ext {
 		project(':redis'),
 		project(':spring-xd-ui')
 	]
-	moduleProjects  = subprojects.findAll { project -> project.path.startsWith(':modules.')}
+	moduleProjects  = subprojects.findAll { project -> project.path.startsWith(':modules')}
 	javaProjects    = subprojects - (moduleProjects + nonJavaProjects)
 	coverageProjects = [
 		'spring-xd-dirt',
@@ -540,7 +540,9 @@ project('spring-xd-dirt') {
 	}
 
 	task moduleFiles {
-		def modules = file("$rootDir/modules")
+		def modules = fileTree("$rootDir/modules")
+		modules.exclude 'lib'
+		modules.exclude 'build'
 		outputs.dir modules
 	}
 

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -6,6 +6,12 @@ ext.providedDeps = []
 ext.optional = { optionalDeps << it }
 ext.provided = { providedDeps << it }
 
+// exclude hadoop install sub projects
+def hadoopInstalls=['cdh5','hadoop22','hadoop24','hdp21','phd1','phd20']
+if (hadoopInstalls.contains(project.name)) {
+	install.enabled = false
+}
+
 install {
 	repositories.mavenInstaller {
 		customizePom(pom, project)


### PR DESCRIPTION
- Exclude modules and all the hadoop distro subprojects
  - disable maven plugin `install` task
- For `modules` project, make sure the build and lib directories
  aren't included as part of the modules' files bundle
