### PR TITLE
XD-1949b - Ensure DSM matrix is diagonal

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobAlreadyExistsInRegistryException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobAlreadyExistsInRegistryException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.plugins.job;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.xd.dirt.XDRuntimeException;
+
+
+/**
+ * Exception thrown when a batch job already exists in the {@link JobRegistry}.
+ * 
+ * @author Mark Pollack
+ */
+@SuppressWarnings("serial")
+public class BatchJobAlreadyExistsInRegistryException extends XDRuntimeException {
+
+	/**
+	 * Creates a new {@link BatchJobAlreadyExistsInRegistryException} with the given job name.
+	 * 
+	 * @param name the name of the {@link Job} which should be unique
+	 */
+	public BatchJobAlreadyExistsInRegistryException(String name) {
+		super("Batch job with name " + name + " already exists in the JobRegistry.");
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobRegistryBeanPostProcessor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobRegistryBeanPostProcessor.java
@@ -32,7 +32,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.util.Assert;
-import org.springframework.xd.dirt.job.BatchJobAlreadyExistsException;
 import org.springframework.xd.dirt.plugins.job.support.listener.XDJobListenerConstants;
 
 
@@ -101,7 +100,7 @@ public class BatchJobRegistryBeanPostProcessor extends JobRegistryBeanPostProces
 				postProcessJob(bean, beanName);
 			}
 			else {
-				throw new BatchJobAlreadyExistsException(groupName);
+				throw new BatchJobAlreadyExistsInRegistryException(groupName);
 			}
 		}
 		return bean;


### PR DESCRIPTION
- Created new exception, the somewhat odd named
  BatchJobAlreadyExistsInRegistryException, that replaces the
  BatchJobAlreadyExistsException that references absence in the JobLocator.
- This exception block can likely be since this BBP should only be processing
  jobs that were not deployed.  Created https://jira.spring.io/browse/XD-2014
  to track.
