### PR TITLE
XD-1335 Fix STS Gradle Import

### DIFF
--- a/spring-xd-exec/README.md
+++ b/spring-xd-exec/README.md
@@ -1,0 +1,2 @@
+## spring-xd-exec project
+


### PR DESCRIPTION
Gradle plugin import fails due to missing directory for
spring-xd-exec.

Add a README to force the directory to exist.
