### PR TITLE
XD-2021 WebUI: Handle tooltip upon navigation

### DIFF
--- a/spring-xd-ui/app/scripts/job/controllers/definitions.js
+++ b/spring-xd-ui/app/scripts/job/controllers/definitions.js
@@ -71,5 +71,9 @@ define([], function () {
             }
         );
       };
+      $scope.$on('$destroy', function() {
+        // Remove deployment status tooltip
+        angular.element('.popover').hide();
+      });
     }];
 });

--- a/spring-xd-ui/app/scripts/stream/controllers/definitions.js
+++ b/spring-xd-ui/app/scripts/stream/controllers/definitions.js
@@ -79,5 +79,11 @@ define([], function () {
             }
         );
       };
+
+      $scope.$on('$destroy', function() {
+        // Remove deployment status tooltip
+        angular.element('.popover').hide();
+      });
+
     }];
 });


### PR DESCRIPTION
- Remove active `deployment status` tooltip when the stream/job
  definition page is navigated outside.
