### PR TITLE
XD-2017 Log admin UI address

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.xd.dirt.plugins.job.support.ExecutionContextJacksonMixIn;
 import org.springframework.xd.dirt.plugins.job.support.StepExecutionJacksonMixIn;
+import org.springframework.xd.dirt.util.ConfigLocations;
 import org.springframework.xd.rest.domain.support.RestTemplateMessageConverterUtil;
 import org.springframework.xd.rest.domain.util.ISO8601DateFormatWithMilliSeconds;
 
@@ -96,14 +97,16 @@ public class RestConfiguration {
 			// add a static resource handler for the UI
 			@Override
 			public void addResourceHandlers(ResourceHandlerRegistry registry) {
-				registry.addResourceHandler("/admin-ui/**", "/admin-ui/").addResourceLocations(
+				registry.addResourceHandler("/" + ConfigLocations.XD_ADMIN_UI_BASE_PATH + "/**",
+						"/" + ConfigLocations.XD_ADMIN_UI_BASE_PATH + "/").addResourceLocations(
 						resourceRoot);
 			}
 
 			@Override
 			public void addViewControllers(ViewControllerRegistry registry) {
-				registry.addViewController("admin-ui").setViewName("redirect:/admin-ui/");
-				registry.addViewController("admin-ui/").setViewName("index.html");
+				registry.addViewController(ConfigLocations.XD_ADMIN_UI_BASE_PATH).setViewName(
+						"redirect:/" + ConfigLocations.XD_ADMIN_UI_BASE_PATH + "/");
+				registry.addViewController(ConfigLocations.XD_ADMIN_UI_BASE_PATH + "/").setViewName("index.html");
 			}
 		};
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/XdErrorController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/XdErrorController.java
@@ -27,6 +27,7 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
+import org.springframework.xd.dirt.util.ConfigLocations;
 
 /**
  * {@link ErrorController} that causes 404 errors to be redirected to the Admin-UI 404 page.
@@ -50,7 +51,7 @@ public class XdErrorController extends BasicErrorController {
 		// TODO: better to toss this class completely and use an error page for 404
 		switch (status) {
 			case 404:
-				return new ModelAndView(new RedirectView("/admin-ui/404.html"));
+				return new ModelAndView(new RedirectView("/" + ConfigLocations.XD_ADMIN_UI_BASE_PATH + "/404.html"));
 		}
 		return super.errorHtml(request);
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/ConfigLocations.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/ConfigLocations.java
@@ -38,6 +38,8 @@ public class ConfigLocations {
 	 */
 	public static final String XD_BATCH_CONFIG_ROOT = XD_CONFIG_ROOT + "batch/";
 
+	public static final String XD_ADMIN_UI_BASE_PATH = "admin-ui";
+
 	/**
 	 * Prevent instantiation.
 	 */


### PR DESCRIPTION
- Upon Admin/SingleNode startup, log the admin web UI
  address in the config logging
  - Use constant for admin UI base path
  - Resolve `server.port` from environment
  - Use RuntimeUtils to get host
