### PR TITLE
XD-2029 Use AlternativeJdkIdGenerator instead of 3rd party library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,6 @@ ext {
 	springBatchAdminMgrVersion = '1.3.0.RELEASE'
 	springIntegrationSplunkVersion = '1.1.0.RELEASE'
 	springShellVersion = '1.1.0.RELEASE'
-	uuidVersion = '3.2'
 	zookeeperVersion = '3.4.6'
 
 	// Also in IO
@@ -485,7 +484,6 @@ project('spring-xd-dirt') {
 		// ************* Dirt-Container only (per se)
 		compile project(":spring-xd-module")
 		compile "com.jayway.jsonpath:json-path"
-		compile "com.eaio.uuid:uuid:$uuidVersion"
 
 		// ************* Container: Modules (should move on their own: XD-915)
 		compile project(":spring-xd-hadoop")
@@ -1141,7 +1139,6 @@ project('spring-xd-tuple') {
 		compile "org.springframework.integration:spring-integration-core"
 		compile "org.springframework.batch:spring-batch-infrastructure"
 		compile "org.springframework:spring-jdbc"
-		compile "com.eaio.uuid:uuid:$uuidVersion"
 	}
 }
 

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/DefaultTuple.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/DefaultTuple.java
@@ -33,10 +33,10 @@ import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.format.support.FormattingConversionService;
+import org.springframework.util.AlternativeJdkIdGenerator;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-
-import com.eaio.uuid.UUIDGen;
+import org.springframework.util.IdGenerator;
 
 /**
  * Default implementation of Tuple interface
@@ -62,6 +62,10 @@ public class DefaultTuple implements Tuple {
 
 	private transient Converter<Tuple, String> tupleToStringConverter = new DefaultTupleToStringConverter();
 
+	private static volatile IdGenerator idGenerator = null;
+
+	private static final IdGenerator defaultIdGenerator = new AlternativeJdkIdGenerator();
+
 	private UUID id;
 
 	private Long timestamp;
@@ -81,7 +85,7 @@ public class DefaultTuple implements Tuple {
 		this.names = new ArrayList<String>(names);
 		this.values = new ArrayList<Object>(values); // shallow copy
 		this.formattingConversionService = formattingConversionService;
-		this.id = new UUID(UUIDGen.newTime(), UUIDGen.getClockSeqAndNode());
+		this.id = getIdGenerator().generateId();
 		this.timestamp = Long.valueOf(System.currentTimeMillis());
 	}
 
@@ -655,6 +659,10 @@ public class DefaultTuple implements Tuple {
 	protected void setTupleToStringConverter(Converter<Tuple, String> tupleToStringConverter) {
 		Assert.notNull(tupleToStringConverter, "tupleToStringConverter cannot be null");
 		this.tupleToStringConverter = tupleToStringConverter;
+	}
+
+	protected static IdGenerator getIdGenerator() {
+		return (idGenerator != null ? idGenerator : defaultIdGenerator);
 	}
 
 	@Override

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/Tuple.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/Tuple.java
@@ -562,14 +562,20 @@ public interface Tuple {
 	 * Get the unique Id of this tuple, not included in comparisons for equality.
 	 * 
 	 * @return unique Id
+	 * @deprecated Use the UUID header in {@link org.springframework.messaging.MessageHeaders} by  
+	 * using a Tuple as the payload type for a {@link org.springframework.messaging.Message}
 	 */
+	@Deprecated
 	UUID getId();
 
 	/**
 	 * Get the creation timestamp of this tuple, not included in comparisons for equality
 	 * 
 	 * @return creation timestamp
+	 * @deprecated Use the timestamp header in {@link org.springframework.messaging.MessageHeaders} by 
+	 * using a Tuple as the payload type for a {@link org.springframework.messaging.Message}
 	 */
+	@Deprecated
 	Long getTimestamp();
 
 


### PR DESCRIPTION
- Followed pattern in MessageHeaders but did not include any easy
  way to change the default generator as in SI.
- Deprecated the use of ID and Timestamp in the tuple class itself, suggesting to use headers that are part of 
  Message<Tuple>
