### PR TITLE
XD-2038 Restore JDK6 compatibility

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperContainerRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperContainerRepository.java
@@ -275,9 +275,12 @@ public class ZooKeeperContainerRepository implements ContainerRepository, Applic
 
 		// sort containers by node creation date (cluster join time)
 		Collections.sort(children, new Comparator<ChildData>() {
+
 			@Override
 			public int compare(ChildData c1, ChildData c2) {
-				return Long.compare(c1.getStat().getCtime(), c2.getStat().getCtime());
+				long t1 = c1.getStat().getCtime();
+				long t2 = c2.getStat().getCtime();
+				return (t1 < t2) ? -1 : ((t1 == t2) ? 0 : 1);
 			}
 		});
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/PasswordUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/PasswordUtils.java
@@ -41,8 +41,8 @@ public class PasswordUtils {
 	}
 
 	public static Pattern passwordParameterPattern = Pattern.compile(
-			"(?i)(--[\\s|\\w]*(password|passwd)\\w*\\s*=[\\s]*)([\\w|.]*)",
-			Pattern.UNICODE_CHARACTER_CLASS);
+			"(?i)(--[\\p{Z}]*(password|passwd)[\\p{Z}]*=[\\p{Z}]*)([\\p{N}|\\p{L}|\\p{Po}]*)",
+			Pattern.UNICODE_CASE);
 
 	/**
 	 * This method takes a definition String as input parameter. The method

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ChildPathIterator.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ChildPathIterator.java
@@ -58,7 +58,10 @@ public class ChildPathIterator<T> implements Iterator<T> {
 
 		this.converter = converter;
 		List<ChildData> list = cache.getCurrentData();
-		this.iterator = list == null ? Collections.<ChildData> emptyIterator() : list.iterator();
+		if (list == null) {
+			list = Collections.<ChildData> emptyList();
+		}
+		this.iterator = list.iterator();
 	}
 
 	/**

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
@@ -262,7 +262,7 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
 	@Override
 	public int compareTo(ModuleDescriptor o) {
 		Assert.notNull(o, "ModuleDescriptor must not be null");
-		return Integer.compare(index, o.index);
+		return (index < o.index) ? -1 : ((index == o.index) ? 0 : 1);
 	}
 
 


### PR DESCRIPTION
Avoid JDK7+ methods:
- Long.compare(x,y) in ZooKeeperContainerRepository
- Integer.compare(x,y) in ModuleDescriptor
- Collections.emptyIterator() in ChildPathIterator

Avoid this JDK7+ constant:
- PasswordUtils.UNICODE_CHARACTER_CLASS in PasswordUtils
