### PR TITLE
XD-2047 Expose Redis Bus Headers Customization

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -38,7 +38,10 @@
 #        txSize:                    1
 
 #    redis:
+#      headers:
+            # comman-delimited list of additional (string-valued) header names to transport
 #      default:
+            # default bus properties, if not specified at the module level
 #        backOffInitialInterval:    1000
 #        backOffMaxInterval:        10000
 #        backOffMultiplier:         2.0

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -171,7 +171,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		setCodec(codec);
 		this.errorAdapter = new RedisQueueOutboundChannelAdapter(
 				parser.parseExpression("headers['" + ERROR_HEADER + "']"), connectionFactory);
-		if (headersToMap != null || headersToMap.length > 0) {
+		if (headersToMap != null && headersToMap.length > 0) {
 			String[] combinedHeadersToMap =
 					Arrays.copyOfRange(STANDARD_HEADERS, 0, STANDARD_HEADERS.length + headersToMap.length);
 			System.arraycopy(headersToMap, 0, combinedHeadersToMap, STANDARD_HEADERS.length, headersToMap.length);

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/redis-bus.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/redis-bus.xml
@@ -10,6 +10,7 @@
 	<bean id="messageBus" class="org.springframework.xd.dirt.integration.redis.RedisMessageBus">
 		<constructor-arg ref="redisConnectionFactory" />
 		<constructor-arg ref="codec"/>
+		<constructor-arg value="${xd.messagebus.redis.headers:}" />
 		<property name="defaultBackOffInitialInterval" value="${xd.messagebus.redis.default.backOffInitialInterval}" />
 		<property name="defaultBackOffMaxInterval" value="${xd.messagebus.redis.default.backOffMaxInterval}" />
 		<property name="defaultBackOffMultiplier" value="${xd.messagebus.redis.default.backOffMultiplier}" />

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -58,7 +58,10 @@ xd:
         transacted:                false
         txSize:                    1
     redis:
+      headers:
+            # comman-delimited list of additional (string-valued) header names to transport
       default:
+            # default bus properties, if not specified at the module level
         backOffInitialInterval:    1000
         backOffMaxInterval:        10000
         backOffMultiplier:         2.0


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2047

The redis bus supports passing custom (string-valued) headers but
there was no easy way to configure them.

Add a property to `application.yml`, `servers.yml` to allow
customization.
