### PR TITLE
XD-2059 Add retry for remote file copy FilePollHdfsTest

### DIFF
--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/JobUtils.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/JobUtils.java
@@ -18,12 +18,15 @@ package org.springframework.xd.integration.util;
 
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import org.springframework.hateoas.PagedResources;
 import org.springframework.util.Assert;
 import org.springframework.xd.rest.client.impl.SpringXDTemplate;
 import org.springframework.xd.rest.domain.JobDefinitionResource;
+import org.springframework.xd.rest.domain.JobExecutionInfoResource;
 
 
 /**
@@ -147,6 +150,24 @@ public class JobUtils {
 					result = false;
 					break;
 				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Retrieve a list of JobExecutionInfoResources with the jobName.
+	 * @param jobName The search name
+	 * @return a list of JobExecutionInfoResources
+	 */
+	public static List<JobExecutionInfoResource> getJobExecInfoByName(String jobName, URL adminServer) {
+		List<JobExecutionInfoResource> jobExecutions = createSpringXDTemplate(adminServer).jobOperations().listJobExecutions();
+		Iterator<JobExecutionInfoResource> iter = jobExecutions.iterator();
+		List<JobExecutionInfoResource> result = new ArrayList<JobExecutionInfoResource>();
+		while (iter.hasNext()) {
+			JobExecutionInfoResource resource = iter.next();
+			if (resource.getName().equals(jobName)) {
+				result.add(resource);
 			}
 		}
 		return result;

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FilePollHdfsTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FilePollHdfsTest.java
@@ -54,17 +54,18 @@ public class FilePollHdfsTest extends AbstractIntegrationTest {
 	@Test
 	public void testFilePollHdfsJob() {
 		String data = UUID.randomUUID().toString();
+		String jobName = "tfphj" + UUID.randomUUID().toString();
 		String sourceFileName = UUID.randomUUID().toString() + ".out";
 		String sourceDir = "/tmp/xd/" + FilePollHdfsJob.DEFAULT_FILE_NAME;
 
 		SimpleFileSource fileSource = sources.file(sourceDir, sourceFileName).reference(true);
-		job(jobs.filePollHdfsJob(DEFAULT_NAMES).toDSL());
-		stream(fileSource + XD_TAP_DELIMITER + " queue:job:" + JOB_NAME);
+		job(jobName, jobs.filePollHdfsJob(DEFAULT_NAMES).toDSL(), WAIT_TIME);
+		stream(fileSource + XD_TAP_DELIMITER + " queue:job:" + jobName);
 		//Since the job may be on a different container you will have to copy the file to the job's container.
-		setupDataFiles(getContainerHostForJob(), sourceDir, sourceFileName, data);
+		setupDataFiles(getContainerHostForJob(jobName), sourceDir, sourceFileName, data);
 		//Copy file to source container instance.
 		setupSourceDataFiles(sourceDir, sourceFileName, data);
-		waitForXD();
+		waitForJobToComplete(jobName);
 		assertValidHdfs(data, FilePollHdfsJob.DEFAULT_DIRECTORY + "/" + FilePollHdfsJob.DEFAULT_FILE_NAME + "-0.csv");
 	}
 


### PR DESCRIPTION
FilePollHdfs sporadically fails to create files on remote machines
- Added waitForJobToComplete instead of waitForXD
- createDataFileOnRemote retries to create data file if file is not present of data of file is incorrect, up until wait time is exhausted.
