### PR TITLE
XD-2066 change send count validation from == to >=

### DIFF
--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
@@ -326,14 +326,14 @@ public class XdEc2Validation {
 	}
 
 	/**
-	 * Asserts that the expected number of messages were processed by the modules in the stream and that no errors
+	 * Asserts that the expected minimum number of messages were processed by the modules in the stream and that no errors
 	 * occurred.
 	 *
 	 * @param modules The list of modules in the stream
 	 * @param msgCountExpected The expected count
 	 */
 	private void verifySendCounts(List<Module> modules, int msgCountExpected) {
-		verifySendCounts(modules, msgCountExpected, false);
+		verifySendCounts(modules, msgCountExpected, true);
 	}
 
 	/**


### PR DESCRIPTION
Tests sporadically fail when checking send counts with rabbit as a transport. Because if a send fails XD will retry thus a sendCount gets bumped up.  The test needed to be changed to allow for the retries.
