### PR TITLE
XD-2004: Containers stopped responding to Admin

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperContainerRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperContainerRepository.java
@@ -199,23 +199,6 @@ public class ZooKeeperContainerRepository implements ContainerRepository, Applic
 		String path = Paths.build(Paths.CONTAINERS, entity.getName());
 
 		try {
-			if (client.checkExists().forPath(path) != null) {
-				// if this container disconnected from ZooKeeper
-				// and reconnects, the ephemeral node may not
-				// have been cleaned up yet...this can happen
-				// in cases where the machine running both the
-				// container and ZooKeeper goes to sleep
-				client.delete().forPath(path);
-			}
-		}
-		catch (Exception e) {
-			// trapping the case where the ephemeral node exists
-			// but is removed by ZK before this container gets
-			// the chance to remove it
-			ZooKeeperUtils.wrapAndThrowIgnoring(e, KeeperException.NoNodeException.class);
-		}
-
-		try {
 			client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL)
 					.forPath(path, ZooKeeperUtils.mapToBytes(entity.getAttributes()));
 			return entity;
@@ -319,7 +302,15 @@ public class ZooKeeperContainerRepository implements ContainerRepository, Applic
 	 */
 	@Override
 	public void delete(String id) {
-		// Container metadata is "deleted" when a Container departs
+		CuratorFramework client = zkConnection.getClient();
+		String path = Paths.build(Paths.CONTAINERS, id);
+
+		try {
+			client.delete().forPath(path);
+		}
+		catch (Exception e) {
+			ZooKeeperUtils.wrapAndThrowIgnoring(e, KeeperException.NoNodeException.class);
+		}
 	}
 
 	/**
@@ -327,7 +318,7 @@ public class ZooKeeperContainerRepository implements ContainerRepository, Applic
 	 */
 	@Override
 	public void delete(Container entity) {
-		// Container metadata is "deleted" when a Container departs
+		delete(entity.getName());
 	}
 
 	/**
@@ -335,7 +326,9 @@ public class ZooKeeperContainerRepository implements ContainerRepository, Applic
 	 */
 	@Override
 	public void delete(Iterable<? extends Container> entities) {
-		// Container metadata is "deleted" when a Container departs
+		for (Container container : entities) {
+			delete(container);
+		}
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -82,7 +82,7 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 
 	/**
 	 * Map of channels that can be tapped. The keys are the tap channel names (e.g. tap:stream:ticktock.time.0),
-	 * and the values are the output channels from modules where the actual WireTap interceptors would be added. 
+	 * and the values are the output channels from modules where the actual WireTap interceptors would be added.
 	 */
 	private final Map<String, MessageChannel> tappableChannels = new HashMap<String, MessageChannel>();
 
@@ -331,7 +331,7 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 	 * Generates the name of a tap channel given a ZooKeeper tap path.
 	 *
 	 * @param path the ZooKeeper path under {@link Paths#TAPS}.
-	 * 
+	 *
 	 * @return the tap channel name
 	 */
 	private String buildTapChannelNameFromPath(String path) {
@@ -383,8 +383,16 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 		}
 
 		@Override
+		public void onSuspend(CuratorFramework client) {
+		}
+
+		@Override
 		public void onConnect(CuratorFramework client) {
 			startTapListener(client);
+		}
+
+		@Override
+		public void onResume(CuratorFramework client) {
 		}
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ArrivingContainerModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ArrivingContainerModuleRedeployer.java
@@ -102,9 +102,6 @@ public class ArrivingContainerModuleRedeployer extends ModuleRedeployer {
 	 */
 	@Override
 	protected void deployModules(Container container) throws Exception {
-		String containerName = container.getName();
-		logger.info("Container arrived: {}", containerName);
-
 		deployUnallocatedStreamModules();
 		deployUnallocatedJobModules();
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerListener.java
@@ -94,14 +94,19 @@ public class ContainerListener implements PathChildrenCacheListener {
 	@Override
 	public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
 		ZooKeeperUtils.logCacheEvent(logger, event);
+		Container container;
 		switch (event.getType()) {
 			case CHILD_ADDED:
-				this.arrivingContainerModuleRedeployer.deployModules(getContainer(event.getData()));
+				container = getContainer(event.getData());
+				logger.info("Container arrived: {}", container);
+				this.arrivingContainerModuleRedeployer.deployModules(container);
 				break;
 			case CHILD_UPDATED:
 				break;
 			case CHILD_REMOVED:
-				this.departingContainerModuleRedeployer.deployModules(getContainer(event.getData()));
+				container = getContainer(event.getData());
+				logger.info("Container departed: {}", container);
+				this.departingContainerModuleRedeployer.deployModules(container);
 				break;
 			case CONNECTION_SUSPENDED:
 				break;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DepartingContainerModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DepartingContainerModuleRedeployer.java
@@ -86,7 +86,6 @@ public class DepartingContainerModuleRedeployer extends ModuleRedeployer {
 	 */
 	@Override
 	protected void deployModules(Container container) throws Exception {
-		logger.info("Container departed: {}", container);
 		CuratorFramework client = getClient();
 		if (client.getState() == CuratorFrameworkState.STOPPED) {
 			return;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
@@ -275,7 +275,16 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 		 */
 		@Override
 		public void onConnect(CuratorFramework client) {
-			logger.info("Admin {} CONNECTED", getId());
+			logger.info("Admin {} connection established", getId());
+			requestLeadership(client);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public void onResume(CuratorFramework client) {
+			logger.info("Admin {} connection resumed", getId());
 			requestLeadership(client);
 		}
 
@@ -284,6 +293,7 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 		 */
 		@Override
 		public void onDisconnect(CuratorFramework client) {
+			logger.info("Admin {} connection terminated", getId());
 			try {
 				destroy();
 			}
@@ -291,6 +301,21 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 				logger.warn("exception occurred while closing leader selector", e);
 			}
 		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public void onSuspend(CuratorFramework client) {
+			logger.info("Admin {} connection suspended", getId());
+			try {
+				destroy();
+			}
+			catch (Exception e) {
+				logger.warn("exception occurred while closing leader selector", e);
+			}
+		}
+
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
@@ -212,7 +212,7 @@ public class JobDeploymentListener extends InitialDeploymentListener {
 				String statusPath = Paths.build(Paths.JOB_DEPLOYMENTS, job.getName(), Paths.STATUS);
 				Stat stat = client.checkExists().forPath(statusPath);
 				if (stat != null) {
-					logger.warn("Found unexpected path {}; stat: {}", statusPath, stat);
+					logger.trace("Found old status path {}; stat: {}", statusPath, stat);
 					client.delete().forPath(statusPath);
 				}
 				client.create().withMode(CreateMode.EPHEMERAL).forPath(statusPath,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
@@ -280,6 +280,11 @@ public class ModuleDeploymentWriter {
 		catch (KeeperException.NodeExistsException e) {
 			logger.info("Module {} is already deployed to container {}", descriptor, container);
 		}
+		catch (KeeperException.NoNodeException e) {
+			logger.error(String.format("Error creating the following deployment paths: %s, %s",
+					deploymentPath, statusPath), e);
+			throw e;
+		}
 	}
 
 	/**
@@ -325,7 +330,7 @@ public class ModuleDeploymentWriter {
 				path.getModuleLabel());
 
 		return new ModuleDeploymentStatus(path.getContainer(), path.getModuleSequence(), key,
-				ModuleDeploymentStatus.State.failed, t.toString());
+				ModuleDeploymentStatus.State.failed, ZooKeeperUtils.getStackTrace(t));
 	}
 
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
@@ -232,7 +232,7 @@ public class StreamDeploymentListener extends InitialDeploymentListener {
 				String statusPath = Paths.build(Paths.STREAM_DEPLOYMENTS, stream.getName(), Paths.STATUS);
 				Stat stat = client.checkExists().forPath(statusPath);
 				if (stat != null) {
-					logger.warn("Found unexpected path {}; stat: {}", statusPath, stat);
+					logger.trace("Found old status path {}; stat: {}", statusPath, stat);
 					client.delete().forPath(statusPath);
 				}
 				client.create().withMode(CreateMode.EPHEMERAL).forPath(statusPath,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/RepositoryConnectionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/RepositoryConnectionListener.java
@@ -48,7 +48,21 @@ public class RepositoryConnectionListener implements ZooKeeperConnectionListener
 	 * {@inheritDoc}
 	 */
 	@Override
+	public void onResume(CuratorFramework client) {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public void onDisconnect(CuratorFramework client) {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void onSuspend(CuratorFramework client) {
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnection.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnection.java
@@ -255,21 +255,33 @@ public class ZooKeeperConnection implements SmartLifecycle {
 			currentState = newState;
 			switch (newState) {
 				case CONNECTED:
-				case RECONNECTED:
 					logger.info(">>> Curator connected event: " + newState);
 					for (ZooKeeperConnectionListener listener : listeners) {
 						listener.onConnect(client);
 					}
 					break;
+				case RECONNECTED:
+					logger.info(">>> Curator reconnected event: " + newState);
+					for (ZooKeeperConnectionListener listener : listeners) {
+						listener.onResume(client);
+					}
+					break;
 				case LOST:
-				case SUSPENDED:
 					logger.info(">>> Curator disconnected event: " + newState);
 					for (ZooKeeperConnectionListener listener : listeners) {
 						listener.onDisconnect(client);
 					}
 					break;
+				case SUSPENDED:
+					logger.info(">>> Curator suspended event: " + newState);
+					for (ZooKeeperConnectionListener listener : listeners) {
+						listener.onSuspend(client);
+					}
+					break;
 				case READ_ONLY:
 					// todo: ?
+					logger.info(">>> Curator read-only event: " + newState);
+					break;
 			}
 		}
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnectionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnectionListener.java
@@ -21,27 +21,41 @@ import org.apache.curator.framework.state.ConnectionStateListener;
 
 /**
  * Listener for ZooKeeper connection and disconnection events.
- * 
+ *
  * @author Mark Fisher
  */
 public interface ZooKeeperConnectionListener {
 
 	/**
 	 * Called when the Curator {@link ConnectionStateListener} receives a
-	 * {@link org.apache.curator.framework.state.ConnectionState#CONNECTED} or
-	 * {@link org.apache.curator.framework.state.ConnectionState#RECONNECTED} event.
-	 * 
+	 * {@link org.apache.curator.framework.state.ConnectionState#CONNECTED} event.
+	 *
 	 * @param client the {@link CuratorFramework} instance
 	 */
 	void onConnect(CuratorFramework client);
 
 	/**
 	 * Called when the Curator {@link ConnectionStateListener} receives a
-	 * {@link org.apache.curator.framework.state.ConnectionState#SUSPENDED} or
+	 * {@link org.apache.curator.framework.state.ConnectionState#RECONNECTED} event.
+	 *
+	 * @param client the {@link CuratorFramework} instance
+	 */
+	void onResume(CuratorFramework client);
+
+	/**
+	 * Called when the Curator {@link ConnectionStateListener} receives a
 	 * {@link org.apache.curator.framework.state.ConnectionState#LOST} event.
-	 * 
+	 *
 	 * @param client the {@link CuratorFramework} instance
 	 */
 	void onDisconnect(CuratorFramework client);
+
+	/**
+	 * Called when the Curator {@link ConnectionStateListener} receives a
+	 * {@link org.apache.curator.framework.state.ConnectionState#SUSPENDED} event.
+	 *
+	 * @param client the {@link CuratorFramework} instance
+	 */
+	void onSuspend(CuratorFramework client);
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -17,6 +17,8 @@
 package org.springframework.xd.dirt.zookeeper;
 
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.Map;
@@ -137,8 +139,14 @@ public abstract class ZooKeeperUtils {
 	 */
 	public static void logCacheEvent(Logger logger, PathChildrenCacheEvent event) {
 		ChildData data = event.getData();
-		String path = (data == null) ? "null" : data.getPath();
-		logger.info("Path cache event: {}, type: {}", path, event.getType());
+		StringBuilder builder = new StringBuilder();
+		builder.append("Path cache event: ");
+		if (data != null && data.getPath() != null) {
+			builder.append("path=").append(data.getPath()).append(", ");
+		}
+		builder.append("type=").append(event.getType());
+
+		logger.info(builder.toString());
 		if (data != null && logger.isTraceEnabled()) {
 			String content;
 			byte[] bytes = data.getData();
@@ -153,8 +161,22 @@ public abstract class ZooKeeperUtils {
 					content = "Could not convert content to UTF-8: " + e.toString();
 				}
 			}
-			logger.trace("Data for path {}: {}", path, content);
+			logger.trace("Data for path {}: {}", data.getPath(), content);
 		}
+	}
+
+	/**
+	 * Return the full stack trace for a Throwable.
+	 *
+	 * @param t throwable for which to obtain the full stack trace
+	 * @return string containing the full stack trace
+	 */
+	public static String getStackTrace(Throwable t) {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(stringWriter);
+		t.printStackTrace(printWriter);
+
+		return stringWriter.toString();
 	}
 
 

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/ContainerRedeploymentTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/ContainerRedeploymentTests.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
+import org.springframework.integration.test.util.SocketUtils;
 import org.springframework.xd.dirt.core.DeploymentUnitStatus;
 import org.springframework.xd.rest.client.impl.SpringXDTemplate;
 
@@ -53,8 +54,9 @@ public class ContainerRedeploymentTests extends AbstractDistributedTests {
 		String streamName = testName.getMethodName() + "-upper-case";
 
 		SpringXDTemplate template = ensureTemplate();
+		int httpPort = SocketUtils.findAvailableServerSocket();
 		template.streamOperations().createStream(streamName,
-				"http --port=9003 | transform --expression='payload.toUpperCase()' | log",
+				String.format("http --port=%d | transform --expression='payload.toUpperCase()' | log", httpPort),
 				false);
 		verifyStreamCreated(streamName);
 


### PR DESCRIPTION
Fixed race condition between the container creating the `/xd/deployments/modules/allocated/container-id` path and the supervisor removing the path when the container exits. The container will now wait for the supervisor to remove the path before proceeding with startup.

Added `onSuspend` and `onResume` to `ZooKeeperConnectionListener`. This allows us to distinguish between events where container ephemeral nodes need to be created after a network disconnect.

Temporary network disconnects will raise `SUSPENDED` events followed by `RECONNECTED` events. Containers will now avoid undeploying modules upon `SUSPENDED` events. `LOST` events still
cause modules to be undeployed. `RECONNECTED` events will force a re-registration with ZooKeeper if the connection was previously `LOST` or if the container's ephemeral node is no longer present.

Testing was done on Linux via `iptables` DROP rules.
