### PR TITLE
XD-721 Test Job Module addition after XD Start

### DIFF
--- a/spring-xd-integration-test/config/batchbasic.xml
+++ b/spring-xd-integration-test/config/batchbasic.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:batch="http://www.springframework.org/schema/batch" xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:tx="http://www.springframework.org/schema/tx" xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
+        http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+
+    <!-- Set up our reader and its properties -->
+    <bean id="itemReader" class="org.springframework.batch.item.file.FlatFileItemReader">
+        <property name="resource" value="file:/tmp/sample.txt" />
+        <property name="lineMapper" ref="lineMapper" />
+    </bean>
+
+    <bean id="lineMapper" class="org.springframework.batch.item.file.mapping.DefaultLineMapper">
+        <property name="lineTokenizer" ref="lineTokenizer" />
+        <property name="fieldSetMapper" ref="fieldSetMapper" />
+    </bean>
+
+    <bean id="lineTokenizer" class="org.springframework.batch.item.file.transform.DelimitedLineTokenizer">
+        <constructor-arg value="," />
+    </bean>
+
+    <bean id="fieldSetMapper" class="org.springframework.batch.item.file.mapping.PassThroughFieldSetMapper" />
+
+    <bean id="lineAggregator" class="org.springframework.batch.item.file.transform.DelimitedLineAggregator">
+        <property name="delimiter" value=" "/>
+    </bean>
+
+    <!-- Set up our writer, and it's properties -->
+    <bean id="itemWriter" class="org.springframework.batch.item.file.FlatFileItemWriter">
+        <property name="resource" value="file:/tmp/sample1out.txt" />
+        <property name="lineAggregator" ref="lineAggregator" />
+    </bean>
+    <batch:job id="job">
+        <batch:step id="step1">
+            <batch:tasklet>
+                <batch:chunk reader="itemReader" writer="itemWriter"
+                             commit-interval="1" />
+            </batch:tasklet>
+        </batch:step>
+    </batch:job>
+</beans>

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/JobUtils.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/JobUtils.java
@@ -18,12 +18,15 @@ package org.springframework.xd.integration.util;
 
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import org.springframework.hateoas.PagedResources;
 import org.springframework.util.Assert;
 import org.springframework.xd.rest.client.impl.SpringXDTemplate;
 import org.springframework.xd.rest.domain.JobDefinitionResource;
+import org.springframework.xd.rest.domain.JobExecutionInfoResource;
 
 
 /**
@@ -43,7 +46,7 @@ public class JobUtils {
 	 * @param adminServer The admin server that this job will be deployed against.
 	 */
 	public static void job(final String jobName, final String jobDefinition,
-			final URL adminServer) {
+						   final URL adminServer) {
 		Assert.hasText(jobName, "The job name must be specified.");
 		Assert.hasText(jobDefinition, "a job definition must be supplied.");
 		Assert.notNull(adminServer, "The admin server must be specified.");
@@ -67,8 +70,7 @@ public class JobUtils {
 	 * @param adminServer The admin server that the command will be executed against.
 	 * @param jobName The name of the job to undeploy
 	 */
-	public static void undeployJob(final URL adminServer, final String jobName)
-	{
+	public static void undeployJob(final URL adminServer, final String jobName) {
 		Assert.notNull(adminServer, "The admin server must be specified.");
 		Assert.hasText(jobName, "The jobName must not be empty nor null");
 		createSpringXDTemplate(adminServer).jobOperations().undeploy(jobName);
@@ -147,6 +149,28 @@ public class JobUtils {
 					result = false;
 					break;
 				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Retrieve a list of JobExecutionInfoResources that have the name contained in the jobName parameter
+	 *
+	 * @param jobName The name of the job to search.
+	 * @param adminServer The URL of the adminServer that will be interrogated to retrieve job info.
+	 * @return a list of JobExecutionInfoResources
+	 */
+	public static List<JobExecutionInfoResource> getJobExecInfoByName(String jobName, URL adminServer) {
+		Assert.hasText(jobName, "jobName must not empty nor null");
+		Assert.notNull(adminServer, "adminServer must not be null");
+		List<JobExecutionInfoResource> jobExecutions = createSpringXDTemplate(adminServer).jobOperations().listJobExecutions();
+		Iterator<JobExecutionInfoResource> iter = jobExecutions.iterator();
+		List<JobExecutionInfoResource> result = new ArrayList<JobExecutionInfoResource>();
+		while (iter.hasNext()) {
+			JobExecutionInfoResource resource = iter.next();
+			if (resource.getName().equals(jobName)) {
+				result.add(resource);
 			}
 		}
 		return result;

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
@@ -16,24 +16,12 @@
 
 package org.springframework.xd.integration.util;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.net.URL;
-import java.util.Iterator;
-import java.util.List;
-
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
@@ -46,10 +34,18 @@ import org.springframework.xd.integration.util.jmxresult.JMXChannelResult;
 import org.springframework.xd.integration.util.jmxresult.JMXResult;
 import org.springframework.xd.integration.util.jmxresult.Module;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.*;
 
 /**
  * Validates that all instances of the cluster is up and running. Also verifies that streams are running and available.
@@ -326,14 +322,14 @@ public class XdEc2Validation {
 	}
 
 	/**
-	 * Asserts that the expected number of messages were processed by the modules in the stream and that no errors
+	 * Asserts that the expected minimum number of messages were processed by the modules in the stream and that no errors
 	 * occurred.
 	 *
 	 * @param modules The list of modules in the stream
 	 * @param msgCountExpected The expected count
 	 */
 	private void verifySendCounts(List<Module> modules, int msgCountExpected) {
-		verifySendCounts(modules, msgCountExpected, false);
+		verifySendCounts(modules, msgCountExpected, true);
 	}
 
 	/**

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/BasicJobTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/BasicJobTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.integration.test;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.batch.core.BatchStatus;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Test that a Batch Basic job module can be installed on XD and is recognized after XD has started.
+ *
+ * @author Glenn Renfro
+ */
+public class BasicJobTest extends AbstractIntegrationTest {
+
+	private final static String JOB_NAME = "batchbasic";
+
+	@Before
+	public void initialize() {
+		List<File> jars = new ArrayList<>();
+		List<File> configFiles = new ArrayList<>();
+		configFiles.add(new File("config/batchbasic.xml"));
+		copyJobToCluster(JOB_NAME, jars, configFiles);
+	}
+
+	/**
+	 * Verifies that batch basic (batchbasic) can be deployed and executed.
+	 */
+	@Test
+	public void testBasicJob() {
+		String jobName = "bb" + UUID.randomUUID().toString();
+		job(jobName, JOB_NAME, WAIT_TIME);
+		assertTrue(JOB_NAME + " did not deploy", waitForJobDeployment(jobName, WAIT_TIME));
+		setupDataFiles(getContainerHostForJob(jobName), "/tmp", "sample.txt", "h,e,l,l,o,w,o,r,l,d");
+		jobLaunch(jobName);
+		assertEquals(BatchStatus.COMPLETED, getJobExecutionStatus(jobName));
+	}
+
+}


### PR DESCRIPTION
This is an acceptance test that will copy batch simple job (from the spring-xd-samples project) to the targeted admin server and its associated containers.  Then create, deploy, launch and check to see if the job launched.  
It will look for the myjob.xml and springxd-batch-simple-1.0.0.BUILD-SNAPSHOT.jar in the spring-xd-integration-test directory, if it is not there the test will be ignored.

The CI Acceptance Test has been updated with a new stage that builds the spring-xd-batch-simple project and has the myjob.xml and springxd-batch-simple-1.0.0.BUILD-SNAPSHOT.jar marked as artifacts .  These artifacts have been added to the "Run Integration tests Rabbit" & "Run Integration tests Redis" jobs and will be installed in the spring-xd-integration-test directory.   
