### PR TITLE
Fix stream deploy form

### DIFF
--- a/spring-xd-ui/app/scripts/job/controllers.js
+++ b/spring-xd-ui/app/scripts/job/controllers.js
@@ -30,7 +30,7 @@ define(['angular'], function (angular) {
               $injector.invoke(jobDefinitionsController, this, {'$scope': $scope});
             });
           }])
-      .controller('DefinitionDeployController',
+      .controller('JobDefinitionDeployController',
           ['$scope', '$injector', function ($scope, $injector) {
             require(['job/controllers/definition-deploy'], function (jobDefinitionDeployController) {
               $injector.invoke(jobDefinitionDeployController, this, {'$scope': $scope});

--- a/spring-xd-ui/app/scripts/routes.js
+++ b/spring-xd-ui/app/scripts/routes.js
@@ -110,13 +110,13 @@ define(['./app'], function (xdAdmin) {
       controller: 'StreamsDefinitionsController'
     })
     .state('home.streams.deployStream', {
-      url : 'streams/definitions/{definitionName}/deploy/{definition}',
+      url : 'streams/definitions/{definitionName}/deploy',
       templateUrl : streamTemplatesPath + '/definition-deploy.html',
-      controller: 'DefinitionDeployController',
+      controller: 'StreamDefinitionDeployController',
       data:{
         authenticate: true
       }
-     })
+    })
     .state('home.jobs.tabs.modules', {
       url : '/modules',
       templateUrl : jobTemplatesPath + '/modules.html',
@@ -130,7 +130,7 @@ define(['./app'], function (xdAdmin) {
     .state('home.jobs.deployjob', {
       url : 'jobs/definitions/{definitionName}/deploy',
       templateUrl : jobTemplatesPath + '/definition-deploy.html',
-      controller: 'DefinitionDeployController',
+      controller: 'JobDefinitionDeployController',
       data:{
         authenticate: true
       }

--- a/spring-xd-ui/app/scripts/stream/controllers.js
+++ b/spring-xd-ui/app/scripts/stream/controllers.js
@@ -29,7 +29,7 @@ define(['angular'], function (angular) {
               $injector.invoke(streamDefinitionsController, this, {'$scope': $scope});
             });
           }])
-      .controller('DefinitionDeployController',
+      .controller('StreamDefinitionDeployController',
           ['$scope', '$injector', function ($scope, $injector) {
             require(['stream/controllers/definition-deploy'], function (streamDefinitionDeployController) {
               $injector.invoke(streamDefinitionDeployController, this, {'$scope': $scope});

--- a/spring-xd-ui/app/scripts/stream/controllers/definition-deploy.js
+++ b/spring-xd-ui/app/scripts/stream/controllers/definition-deploy.js
@@ -25,20 +25,24 @@ define([], function () {
   return ['$scope', 'XDUtils', '$state', '$stateParams', 'StreamService',
     function ($scope, utils, $state, $stateParams, streamService) {
       $scope.$apply(function () {
-        streamService.getModulesFromDSL($stateParams.definitionName, $stateParams.definition).$promise.then(
-            function (response) {
-              $scope.definitionName = $stateParams.definitionName;
-              $scope.definitionDeployRequest = {
-                streamDefinition: $stateParams.definition,
-                deploymentProperties: {}
-              };
-              $scope.modules = response;
-              response.forEach(function (resp) {
-                $scope.definitionDeployRequest.deploymentProperties[resp.moduleLabel] = {};
-              });
-            },
-            function () {
-              utils.growl.addErrorMessage('Error getting modules for the stream.');
+        streamService.getDefinition($stateParams.definitionName).$promise.then(
+            function (definitionResponse) {
+              streamService.getModulesFromDSL($stateParams.definitionName, definitionResponse.definition).$promise.then(
+                  function (response) {
+                    $scope.definitionName = $stateParams.definitionName;
+                    $scope.definitionDeployRequest = {
+                      streamDefinition: definitionResponse.definition,
+                      deploymentProperties: {}
+                    };
+                    $scope.modules = response;
+                    response.forEach(function (resp) {
+                      $scope.definitionDeployRequest.deploymentProperties[resp.moduleLabel] = {};
+                    });
+                  },
+                  function () {
+                    utils.growl.addErrorMessage('Error getting modules for the stream.');
+                  }
+              );
             }
         );
       });

--- a/spring-xd-ui/app/scripts/stream/controllers/definitions.js
+++ b/spring-xd-ui/app/scripts/stream/controllers/definitions.js
@@ -37,7 +37,7 @@ define([], function () {
         );
       })();
       $scope.deployStream = function (streamDefinition) {
-        $state.go('home.streams.deployStream', {definitionName: streamDefinition.name, definition: streamDefinition.definition});
+        $state.go('home.streams.deployStream', {definitionName: streamDefinition.name});
       };
       $scope.undeployStream = function (streamDefinition) {
         utils.$log.info('Undeploying Stream ' + streamDefinition.name);

--- a/spring-xd-ui/app/scripts/stream/services.js
+++ b/spring-xd-ui/app/scripts/stream/services.js
@@ -32,6 +32,13 @@ define(['angular'], function (angular) {
               }
             });
           },
+          getDefinition: function(name) {
+            return $resource($rootScope.xdAdminServerUrl + '/streams/definitions/' + name, {}, {
+              query: {
+                method: 'GET'
+              }
+            }).query();
+          },
           deploy: function (name, deploymentProperties) {
             $log.info('Deploy Stream ' + name);
             return $resource($rootScope.xdAdminServerUrl + '/streams/deployments/' + name, null, {

--- a/spring-xd-ui/test/spec/controllers/jobcontrollerSpec.js
+++ b/spring-xd-ui/test/spec/controllers/jobcontrollerSpec.js
@@ -65,8 +65,8 @@ define([
       expect(controller).toBeDefined();
     }));
 
-    it('should have a DefinitionDeployController', inject(function($rootScope, $controller) {
-      var controller = $controller('DefinitionDeployController', { $scope: $rootScope.$new(), $rootScope: $rootScope });
+    it('should have a JobDefinitionDeployController', inject(function($rootScope, $controller) {
+      var controller = $controller('JobDefinitionDeployController', { $scope: $rootScope.$new(), $rootScope: $rootScope });
       expect(controller).toBeDefined();
     }));
   });


### PR DESCRIPTION
- Stream deploy with tap `>` was not handled properly as the definition was
  set as state parameter.
  - Fix this by removing definition from the URL
