### PR TITLE
XD-2113: Fix redis agg-counter when right of interval on the hour

### DIFF
--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricUtils.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricUtils.java
@@ -38,22 +38,24 @@ public final class MetricUtils {
 	}
 
 	public static long[] concatArrays(List<long[]> arrays, int start, int size) {
-		long[] counts = new long[size];
-		long[] first = arrays.remove(0);
-		int index = Math.min(first.length - start, size);
-		System.arraycopy(first, start, counts, 0, index);
-		for (int i = 0; i < arrays.size(); i++) {
-			long[] sub = arrays.get(i);
-			for (int j = 0; j < sub.length; j++) {
-				if (index >= counts.length) {
-					break;
-				}
+		long[] result = new long[size];
+		int howManyLeft = size;
+		int targetPosition = 0;
 
-				counts[index++] = sub[j];
-			}
+		int from = start;
+		for (int i = 0; i < arrays.size() && howManyLeft > 0; i++) {
+			long[] current = arrays.get(i);
+			int howMany = Math.min(current.length - from, howManyLeft);
+			System.arraycopy(current, from, result, targetPosition, howMany);
+			from = 0;
+			howManyLeft -= howMany;
+			targetPosition += howMany;
 		}
-
-		return counts;
+		if (howManyLeft > 0) {
+			throw new ArrayIndexOutOfBoundsException(
+					String.format("Not enough data, short of %d elements", howManyLeft));
+		}
+		return result;
 	}
 
 	public static long sum(long[] array) {

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterRepository.java
@@ -156,7 +156,7 @@ public class RedisAggregateCounterRepository extends RedisCounterRepository impl
 			dt.setRounding(c.hourOfDay());
 			Duration step = Duration.standardHours(1);
 			List<long[]> hours = new ArrayList<long[]>();
-			while (dt.isBefore(end)) {
+			while (dt.isBefore(end) || dt.isEqual(end)) {
 				hours.add(getMinCountsForHour(name, dt));
 				dt.add(step);
 			}

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/MetricUtilsTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/MetricUtilsTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.analytics.metrics.core;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * Unit tests for the {@link MetricUtils} class.
+ */
+public class MetricUtilsTests {
+
+	private List<long[]> data = new ArrayList<long[]>();
+
+	@Before
+	public void setup() {
+		data.add(new long[] { 1, 2, 3, 4, 5 });
+		data.add(new long[] { 6, 7, 8, 9, 10, 11, 12, 13 });
+		data.add(new long[] { 14, 15, 16 });
+
+	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void testNotEnoughData() {
+		List<long[]> data = new ArrayList<long[]>();
+		data.add(new long[] { 1, 2, 3, 4, 5 });
+
+		MetricUtils.concatArrays(data, 3, 3);
+	}
+
+	@Test
+	public void testSpanChunks() {
+
+		long[] result = MetricUtils.concatArrays(data, 3, 6);
+		assertArrayEquals(new long[] { 4, 5, 6, 7, 8, 9 }, result);
+	}
+
+}


### PR DESCRIPTION
Will merge myself. 

When we go back to this issue and consider merging to master though, I think we should:
1) consider whether the `|| dt.isEqual(end)` part applies to others. Early tests seem to indicate that not, but..
2) review the interval handling altogether. For a fixed set of `--from` and `--to` boundaries datapoints are considered "in" or "out" depending on the `resolution` value
