### PR TITLE
Use strict REST domain objects

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModuleMetadataResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModuleMetadataResourceAssembler.java
@@ -19,6 +19,8 @@ package org.springframework.xd.dirt.rest;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.xd.dirt.module.store.ModuleMetadata;
 import org.springframework.xd.rest.domain.ModuleMetadataResource;
+import org.springframework.xd.rest.domain.RESTDeploymentState;
+import org.springframework.xd.rest.domain.RESTModuleType;
 
 
 /**
@@ -41,9 +43,10 @@ public class ModuleMetadataResourceAssembler extends
 	@Override
 	protected ModuleMetadataResource instantiateResource(ModuleMetadata entity) {
 		String moduleType = (entity.getModuleType() != null) ? entity.getModuleType().name() : null;
-		String deploymentStatus = (entity.getDeploymentStatus() != null) ? entity.getDeploymentStatus().name() : null;
+		RESTDeploymentState deploymentStatus = (entity.getDeploymentStatus() != null) ? RESTDeploymentState.valueOf(entity.getDeploymentStatus().name())
+				: null;
 		return new ModuleMetadataResource(entity.getId(), entity.getName(), entity.getUnitName(),
-				moduleType, entity.getContainerId(), entity.getModuleOptions(),
+				RESTModuleType.valueOf(moduleType), entity.getContainerId(), entity.getModuleOptions(),
 				entity.getDeploymentProperties(), deploymentStatus);
 	}
 

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/AbstractDistributedTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/AbstractDistributedTests.java
@@ -39,7 +39,6 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.xd.dirt.core.DeploymentUnitStatus;
 import org.springframework.xd.distributed.util.DefaultDistributedTestSupport;
 import org.springframework.xd.distributed.util.DistributedTestSupport;
-import org.springframework.xd.module.ModuleType;
 import org.springframework.xd.rest.client.impl.SpringXDTemplate;
 import org.springframework.xd.rest.domain.ModuleMetadataResource;
 import org.springframework.xd.rest.domain.StreamDefinitionResource;
@@ -222,12 +221,11 @@ public abstract class AbstractDistributedTests implements DistributedTestSupport
 		for (ModuleMetadataResource module : distributedTestSupport.ensureTemplate()
 				.runtimeOperations().listDeployedModules()) {
 			String moduleStreamName = module.getUnitName();
-			ModuleType moduleType = ModuleType.valueOf(module.getModuleType());
 			String[] fields = module.getName().split("\\.");
 			String moduleLabel = fields[0];
 
 			if (moduleStreamName.equals(streamName)) {
-				switch (moduleType) {
+				switch (module.getModuleType()) {
 					case source:
 						containers.addSourceContainer(module.getContainerId());
 						break;

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/ModuleMetadataResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/ModuleMetadataResource.java
@@ -38,7 +38,7 @@ public class ModuleMetadataResource extends ResourceSupport {
 
 	private String unitName;
 
-	private String moduleType;
+	private RESTModuleType moduleType;
 
 	private String containerId;
 
@@ -46,15 +46,15 @@ public class ModuleMetadataResource extends ResourceSupport {
 
 	private Properties deploymentProperties;
 
-	private String deploymentStatus;
+	private RESTDeploymentState deploymentStatus;
 
 	@SuppressWarnings("unused")
 	private ModuleMetadataResource() {
 	}
 
-	public ModuleMetadataResource(String moduleId, String name, String unitName, String moduleType,
-			String containerId,
-			Properties moduleProperties, Properties deploymentProperties, String deploymentStatus) {
+	public ModuleMetadataResource(String moduleId, String name, String unitName, RESTModuleType moduleType,
+			String containerId, Properties moduleProperties, Properties deploymentProperties,
+			RESTDeploymentState deploymentStatus) {
 		this.moduleId = moduleId;
 		this.name = name;
 		this.unitName = unitName;
@@ -77,7 +77,7 @@ public class ModuleMetadataResource extends ResourceSupport {
 		return this.unitName;
 	}
 
-	public String getModuleType() {
+	public RESTModuleType getModuleType() {
 		return this.moduleType;
 	}
 
@@ -93,7 +93,7 @@ public class ModuleMetadataResource extends ResourceSupport {
 		return deploymentProperties;
 	}
 
-	public String getDeploymentStatus() {
+	public RESTDeploymentState getDeploymentStatus() {
 		return deploymentStatus;
 	}
 

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/RESTDeploymentState.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/RESTDeploymentState.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.rest.domain;
+
+
+/**
+ * REST domain representation of org.springframework.xd.dirt.core.DeploymentUnitStatus.State.
+ * 
+ * @author Ilayaperumal Gopinathan
+ */
+public enum RESTDeploymentState {
+
+	/**
+	 * The deployment unit is not deployed.
+	 */
+	undeployed,
+
+	/**
+	 * One or more of the deployment unit modules are being deployed.
+	 */
+	deploying,
+
+	/**
+	 * All expected modules for the deployment unit have been deployed.
+	 */
+	deployed,
+
+	/**
+	 * Some expected modules for the deployment unit have not been
+	 * deployed; however the deployment unit is considered functional.
+	 */
+	incomplete,
+
+	/**
+	 * Some or all of the expected modules for the deployment unit
+	 * have failed to deploy; the deployment unit is not considered functional.
+	 */
+	failed,
+
+	/**
+	 * The deployment unit is in the process of being undeployed.
+	 */
+	undeploying
+
+}

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ClusterCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ClusterCommands.java
@@ -103,9 +103,10 @@ public class ClusterCommands implements CommandMarker {
 				new TableHeader("Deployment Properties")).addHeader(5, new TableHeader("Unit status"));
 		for (ModuleMetadataResource module : runtimeModules) {
 			final TableRow row = table.newRow();
+			String unitStatus = (module.getDeploymentStatus() != null) ? module.getDeploymentStatus().name() : "";
 			row.addValue(1, String.format("%s.%s.%s", module.getUnitName(), module.getModuleType(), module.getName()))
 					.addValue(2, module.getContainerId()).addValue(3, module.getModuleOptions().toString()).addValue(4,
-							module.getDeploymentProperties().toString()).addValue(5, module.getDeploymentStatus());
+							module.getDeploymentProperties().toString()).addValue(5, unitStatus);
 		}
 		return table;
 	}


### PR DESCRIPTION
- For `ModuleMetadataResource`'s module type and deployment status,
  use `RESTModuleType` and `RESTDeploymentState` that represent the
  module type and DeploymentUnitStatus.State.
