### PR TITLE
[Sprint: 38] [MERGE POST 1.0.1 RELEASE] XD-2148 add distShellZip gradle task

### DIFF
--- a/gradle/build-dist.gradle
+++ b/gradle/build-dist.gradle
@@ -153,41 +153,24 @@ task distShellZip(type: Zip, dependsOn: [copyInstall], overwrite: true) {
         ext.baseDir = "${project.name}-${project.version}-shell";
 
         from("$buildDir/dist/spring-xd/shell") {
-                into "${baseDir}/shell"
+                into "${baseDir}"
         }
-
-        from("$buildDir/dist/spring-xd/xd/lib") {
-                include "hadoop22/hadoop-auth-*.jar"
-                include "hadoop22/hadoop-common-*.jar"
-                include "hadoop22/hadoop-hdfs-*.jar"
-                include "hadoop22/hadoop-mapreduce-client-core-*.jar"
-                include "hadoop22/protobuf-java-*.jar"
-                include "hadoop24/hadoop-auth-*.jar"
-                include "hadoop24/hadoop-common-*.jar"
-                include "hadoop24/hadoop-hdfs-*.jar"
-                include "hadoop24/hadoop-mapreduce-client-core-*.jar"
-                include "hadoop24/protobuf-java-*.jar"
-                include "hdp21/hadoop-auth-*.jar"
-                include "hdp21/hadoop-common-*.jar"
-                include "hdp21/hadoop-hdfs-*.jar"
-                include "hdp21/hadoop-mapreduce-client-core-*.jar"
-                include "hdp21/protobuf-java-*.jar"
-                include "phd1/hadoop-auth-*.jar"
-                include "phd1/hadoop-common-*.jar"
-                include "phd1/hadoop-hdfs-*.jar"
-                include "phd1/hadoop-mapreduce-client-core-*.jar"
-                include "phd1/protobuf-java-*.jar"
-                include "phd20/hadoop-auth-*.jar"
-                include "phd20/hadoop-common-*.jar"
-                include "phd20/hadoop-hdfs-*.jar"
-                include "phd20/hadoop-mapreduce-client-core-*.jar"
-                include "phd20/protobuf-java-*.jar"
-                include "cdh5/hadoop-auth-*.jar"
-                include "cdh5/hadoop-common-*.jar"
-                include "cdh5/hadoop-hdfs-*.jar"
-                include "cdh5/hadoop-mapreduce-client-core-*.jar"
-                include "cdh5/protobuf-java-*.jar"
-                into "${baseDir}/xd/lib"
+        [
+                'hadoop24',
+                'hadoop22',
+                'cdh5',
+                'hdp21',
+                'phd1',
+                'phd20'
+        ].each { distro ->
+                        from("$buildDir/dist/spring-xd/xd/lib/$distro") {
+                            include "hadoop-auth-*.jar"
+                            include "hadoop-common-*.jar"
+                            include "hadoop-hdfs-*.jar"
+                            include "hadoop-mapreduce-client-core-*.jar"
+                            include "protobuf-java-*.jar"
+                            into "${baseDir}/lib/$distro/"
+                }
         }
 }
 

--- a/scripts/shell/xd-shell
+++ b/scripts/shell/xd-shell
@@ -92,10 +92,14 @@ addJarsToClassPath( ) {
 
 
 CLASSPATH="$APP_HOME/config"
-XD_LIB=$APP_HOME/../xd/lib
 APP_HOME_LIB=$APP_HOME/lib
+XD_LIB=$APP_HOME/../xd/lib
 addJarsToClassPath $APP_HOME_LIB
-HADOOP_LIB=$XD_LIB/$HADOOP_DISTRO
+if [ -d $XD_LIB ]; then
+    HADOOP_LIB=$XD_LIB/$HADOOP_DISTRO
+else
+    HADOOP_LIB=$APP_HOME_LIB/$HADOOP_DISTRO
+fi
 addJarsToClassPath $HADOOP_LIB
 
 # Determine the Java command to use to start the JVM.

--- a/scripts/shell/xd-shell.bat
+++ b/scripts/shell/xd-shell.bat
@@ -99,13 +99,15 @@ if exist "%APP_HOME_LIB%" (
     set CLASSPATH=!CLASSPATH!;%APP_HOME_LIB%\*
 )
 
-@rem add xd/lib/hadoop libs to CLASSPATH
+@rem add lib/hadoop libs to CLASSPATH
 set XD_LIB=%APP_HOME%\..\xd\lib
 if exist "%XD_LIB%" (
     set HADOOP_LIB=%XD_LIB%\!HADOOP_DISTRO!
-    if exist "!HADOOP_LIB!" (
-        set CLASSPATH=!CLASSPATH!;!HADOOP_LIB!\*
-    )
+) else (
+    set HADOOP_LIB=%APP_HOME_LIB%\!HADOOP_DISTRO!
+)
+if exist "!HADOOP_LIB!" (
+    set CLASSPATH=!CLASSPATH!;!HADOOP_LIB!\*
 )
 
 @rem Execute spring-xd-shell


### PR DESCRIPTION
With this change gradle dist task now creates spring-xd-shell zip distro under build/distributions. 
The spring-xd-shell distro size is rather large - 144MB. 
Next in line is XD-2149 to remove unused libraries.
