### PR TITLE
Rename REST endpoints `cluster` to `runtime`

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
@@ -66,8 +66,8 @@ public class AdminController {
 		xdRuntime.add(entityLinks.linkFor(JobDefinitionResource.class).withRel("jobs"));
 		xdRuntime.add(entityLinks.linkFor(ModuleDefinitionResource.class).withRel("modules"));
 
-		xdRuntime.add(entityLinks.linkFor(ModuleMetadataResource.class).withRel("cluster/modules"));
-		xdRuntime.add(entityLinks.linkFor(DetailedContainerResource.class).withRel("cluster/containers"));
+		xdRuntime.add(entityLinks.linkFor(ModuleMetadataResource.class).withRel("runtime/modules"));
+		xdRuntime.add(entityLinks.linkFor(DetailedContainerResource.class).withRel("runtime/containers"));
 
 		xdRuntime.add(entityLinks.linkFor(DetailedJobInfoResource.class).withRel("jobs/configurations"));
 		xdRuntime.add(entityLinks.linkFor(JobExecutionInfoResource.class).withRel("jobs/executions"));

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ContainersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ContainersController.java
@@ -57,7 +57,7 @@ import org.springframework.xd.rest.domain.DetailedContainerResource;
  * @author Mark Fisher
  */
 @Controller
-@RequestMapping("/cluster/containers")
+@RequestMapping("/runtime/containers")
 @ExposesResourceFor(DetailedContainerResource.class)
 public class ContainersController {
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModulesMetadataController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModulesMetadataController.java
@@ -46,7 +46,7 @@ import org.springframework.xd.rest.domain.ModuleMetadataResource;
  * @author Gunnar Hillert
  */
 @Controller
-@RequestMapping("/cluster/modules")
+@RequestMapping("/runtime/modules")
 @ExposesResourceFor(ModuleMetadataResource.class)
 public class ModulesMetadataController {
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ContainersControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ContainersControllerIntegrationTests.java
@@ -72,7 +72,7 @@ public class ContainersControllerIntegrationTests extends AbstractControllerInte
 
 	@Test
 	public void testListContainers() throws Exception {
-		mockMvc.perform(get("/cluster/containers").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andExpect(
+		mockMvc.perform(get("/runtime/containers").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andExpect(
 				jsonPath("$.content", Matchers.hasSize(2))).andExpect(
 				jsonPath("$.content[*].attributes.id", contains("1", "2"))).andExpect(
 				jsonPath("$.content[*].attributes.pid", contains("1234", "2345"))).andExpect(
@@ -83,7 +83,7 @@ public class ContainersControllerIntegrationTests extends AbstractControllerInte
 	@Test
 	public void testShutdownNonExistingContainer() throws Exception {
 		String containerId = "random";
-		mockMvc.perform(delete("/cluster/containers").param("containerId", containerId)).andExpect(
+		mockMvc.perform(delete("/runtime/containers").param("containerId", containerId)).andExpect(
 				status().isNotFound()).andExpect(
 				jsonPath("$[0].message", Matchers.is("Container could not be found with id " + containerId)));
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ModuleMetadataControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ModuleMetadataControllerIntegrationTests.java
@@ -164,7 +164,7 @@ public class ModuleMetadataControllerIntegrationTests extends AbstractController
 
 	@Test
 	public void testListModules() throws Exception {
-		mockMvc.perform(get("/cluster/modules").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andExpect(
+		mockMvc.perform(get("/runtime/modules").accept(MediaType.APPLICATION_JSON)).andExpect(status().isOk()).andExpect(
 				jsonPath("$.content", Matchers.hasSize(3))).andExpect(
 				jsonPath("$.content[*].moduleId", contains("s1.source.http.0", "s2.sink.log.1", "j3.job.myjob.0"))).andExpect(
 				jsonPath("$.content[*].name", contains("http.0", "log.1", "myjob.0"))).andExpect(
@@ -177,7 +177,7 @@ public class ModuleMetadataControllerIntegrationTests extends AbstractController
 
 	@Test
 	public void testListModulesByJobName() throws Exception {
-		mockMvc.perform(get("/cluster/modules?jobname=j3").accept(MediaType.APPLICATION_JSON)).andExpect(
+		mockMvc.perform(get("/runtime/modules?jobname=j3").accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isOk()).andExpect(
 				jsonPath("$", Matchers.hasSize(1))).andExpect(
 				jsonPath("$[*].moduleId", contains("j3.job.myjob.0"))).andExpect(
@@ -190,7 +190,7 @@ public class ModuleMetadataControllerIntegrationTests extends AbstractController
 
 	@Test
 	public void testListModuleByModuleId() throws Exception {
-		mockMvc.perform(get("/cluster/modules?moduleId=j3.job.myjob.0").accept(MediaType.APPLICATION_JSON)).andExpect(
+		mockMvc.perform(get("/runtime/modules?moduleId=j3.job.myjob.0").accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isOk()).andExpect(
 				jsonPath("$.content", Matchers.hasSize(1))).andExpect(
 				jsonPath("$.content[*].name", contains("myjob.0"))).andExpect(
@@ -203,14 +203,14 @@ public class ModuleMetadataControllerIntegrationTests extends AbstractController
 
 	@Test
 	public void testListModulesByNonExistingJobName() throws Exception {
-		mockMvc.perform(get("/cluster/modules?jobname=notthere").accept(MediaType.APPLICATION_JSON)).andExpect(
+		mockMvc.perform(get("/runtime/modules?jobname=notthere").accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isOk()).andExpect(
 				jsonPath("$", Matchers.hasSize(0)));
 	}
 
 	@Test
 	public void testListModulesByContainer() throws Exception {
-		mockMvc.perform(get("/cluster/modules?containerId=2").accept(MediaType.APPLICATION_JSON)).andExpect(
+		mockMvc.perform(get("/runtime/modules?containerId=2").accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isOk()).andExpect(
 				jsonPath("$.content", Matchers.hasSize(1))).andExpect(
 				jsonPath("$.content[*].name", contains("log.1"))).andExpect(
@@ -225,7 +225,7 @@ public class ModuleMetadataControllerIntegrationTests extends AbstractController
 	@Test
 	public void testListModulesByContainerAndModuleId() throws Exception {
 		mockMvc.perform(
-				get("/cluster/modules?containerId=1&moduleId=s1.source.http.0").accept(MediaType.APPLICATION_JSON)).andExpect(
+				get("/runtime/modules?containerId=1&moduleId=s1.source.http.0").accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isOk()).andExpect(
 				jsonPath("$.name", containsString("http.0"))).andExpect(
 				jsonPath("$.unitName", containsString("s1"))).andExpect(
@@ -237,7 +237,7 @@ public class ModuleMetadataControllerIntegrationTests extends AbstractController
 	@Test
 	public void testListNonExistingModule() throws Exception {
 		mockMvc.perform(
-				get("/cluster/modules?containerId=1&moduleId=random").accept(MediaType.APPLICATION_JSON)).andExpect(
+				get("/runtime/modules?containerId=1&moduleId=random").accept(MediaType.APPLICATION_JSON)).andExpect(
 				status().isNotFound()).andExpect(
 				jsonPath("$[0].message",
 						Matchers.is("The module with id 'random' doesn't exist in the container with id '1'")));

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/RuntimeOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/RuntimeOperations.java
@@ -25,7 +25,7 @@ import org.springframework.xd.rest.domain.ModuleMetadataResource;
  * 
  * @author Ilayaperumal Gopinathan
  */
-public interface ClusterOperations {
+public interface RuntimeOperations {
 
 	public PagedResources<DetailedContainerResource> listContainers();
 

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/SpringXDOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/SpringXDOperations.java
@@ -43,7 +43,7 @@ public interface SpringXDOperations {
 	/**
 	 * Returns the portion of the API for interaction with runtime containers/modules.
 	 */
-	public ClusterOperations runtimeOperations();
+	public RuntimeOperations runtimeOperations();
 
 	/**
 	 * Returns the portion of the API for interaction with Counters.

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/RuntimeTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/RuntimeTemplate.java
@@ -21,7 +21,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.springframework.xd.rest.client.ClusterOperations;
+import org.springframework.xd.rest.client.RuntimeOperations;
 import org.springframework.xd.rest.domain.DetailedContainerResource;
 import org.springframework.xd.rest.domain.ModuleMetadataResource;
 
@@ -30,22 +30,22 @@ import org.springframework.xd.rest.domain.ModuleMetadataResource;
  * 
  * @author Ilayaperumal Gopinathan
  */
-public class ClusterTemplate extends AbstractTemplate implements ClusterOperations {
+public class RuntimeTemplate extends AbstractTemplate implements RuntimeOperations {
 
-	ClusterTemplate(AbstractTemplate source) {
+	RuntimeTemplate(AbstractTemplate source) {
 		super(source);
 	}
 
 	@Override
 	public DetailedContainerResource.Page listContainers() {
-		String uriTemplate = resources.get("cluster/containers").toString();
+		String uriTemplate = resources.get("runtime/containers").toString();
 		uriTemplate = uriTemplate + "?size=10000";
 		return restTemplate.getForObject(uriTemplate, DetailedContainerResource.Page.class);
 	}
 
 	@Override
 	public ModuleMetadataResource.Page listDeployedModules() {
-		String uriTemplate = resources.get("cluster/modules").toString();
+		String uriTemplate = resources.get("runtime/modules").toString();
 		uriTemplate = uriTemplate + "?size=10000";
 		return restTemplate.getForObject(uriTemplate, ModuleMetadataResource.Page.class);
 	}
@@ -54,7 +54,7 @@ public class ClusterTemplate extends AbstractTemplate implements ClusterOperatio
 	public ModuleMetadataResource listDeployedModule(String containerId, String moduleId) {
 		Assert.isTrue(StringUtils.hasText(containerId));
 		Assert.isTrue(StringUtils.hasText(moduleId));
-		String url = resources.get("cluster/modules").toString();
+		String url = resources.get("runtime/modules").toString();
 		MultiValueMap<String, String> values = new LinkedMultiValueMap<String, String>();
 		values.add("containerId", containerId);
 		values.add("moduleId", moduleId);
@@ -65,7 +65,7 @@ public class ClusterTemplate extends AbstractTemplate implements ClusterOperatio
 	@Override
 	public ModuleMetadataResource.Page listDeployedModulesByContainer(String containerId) {
 		Assert.isTrue(StringUtils.hasText(containerId));
-		String url = resources.get("cluster/modules").toString();
+		String url = resources.get("runtime/modules").toString();
 		String uriString = UriComponentsBuilder.fromUriString(url).queryParam("containerId", containerId).build().toUriString();
 		return restTemplate.getForObject(uriString, ModuleMetadataResource.Page.class);
 	}
@@ -73,7 +73,7 @@ public class ClusterTemplate extends AbstractTemplate implements ClusterOperatio
 	@Override
 	public ModuleMetadataResource.Page listDeployedModulesByModuleId(String moduleId) {
 		Assert.isTrue(StringUtils.hasText(moduleId));
-		String url = resources.get("cluster/modules").toString();
+		String url = resources.get("runtime/modules").toString();
 		String uriString = UriComponentsBuilder.fromUriString(url).queryParam("moduleId", moduleId).build().toUriString();
 		return restTemplate.getForObject(uriString, ModuleMetadataResource.Page.class);
 	}

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDTemplate.java
@@ -22,7 +22,7 @@ import org.springframework.hateoas.UriTemplate;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.xd.rest.client.AggregateCounterOperations;
-import org.springframework.xd.rest.client.ClusterOperations;
+import org.springframework.xd.rest.client.RuntimeOperations;
 import org.springframework.xd.rest.client.CompletionOperations;
 import org.springframework.xd.rest.client.CounterOperations;
 import org.springframework.xd.rest.client.FieldValueCounterOperations;
@@ -60,7 +60,7 @@ public class SpringXDTemplate extends AbstractTemplate implements SpringXDOperat
 	/**
 	 * Holds the Module-related part of the API.
 	 */
-	private ClusterOperations runtimeOperations;
+	private RuntimeOperations runtimeOperations;
 
 	/**
 	 * Holds the Counter-related part of the API.
@@ -107,8 +107,8 @@ public class SpringXDTemplate extends AbstractTemplate implements SpringXDOperat
 		resources.put("jobs/executions", new UriTemplate(xdRuntime.getLink("jobs/executions").getHref()));
 		resources.put("jobs/instances", new UriTemplate(xdRuntime.getLink("jobs/instances").getHref()));
 
-		resources.put("cluster/containers", new UriTemplate(xdRuntime.getLink("cluster/containers").getHref()));
-		resources.put("cluster/modules", new UriTemplate(xdRuntime.getLink("cluster/modules").getHref()));
+		resources.put("runtime/containers", new UriTemplate(xdRuntime.getLink("runtime/containers").getHref()));
+		resources.put("runtime/modules", new UriTemplate(xdRuntime.getLink("runtime/modules").getHref()));
 
 		resources.put("completions/stream", new UriTemplate(xdRuntime.getLink("completions/stream").getHref()));
 		resources.put("completions/job", new UriTemplate(xdRuntime.getLink("completions/job").getHref()));
@@ -129,7 +129,7 @@ public class SpringXDTemplate extends AbstractTemplate implements SpringXDOperat
 		gaugeOperations = new GaugeTemplate(this);
 		richGaugeOperations = new RichGaugeTemplate(this);
 		moduleOperations = new ModuleTemplate(this);
-		runtimeOperations = new ClusterTemplate(this);
+		runtimeOperations = new RuntimeTemplate(this);
 		completionOperations = new CompletionTemplate(this);
 	}
 
@@ -153,7 +153,7 @@ public class SpringXDTemplate extends AbstractTemplate implements SpringXDOperat
 	}
 
 	@Override
-	public ClusterOperations runtimeOperations() {
+	public RuntimeOperations runtimeOperations() {
 		return runtimeOperations;
 	}
 

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RuntimeCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RuntimeCommands.java
@@ -28,7 +28,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-import org.springframework.xd.rest.client.ClusterOperations;
+import org.springframework.xd.rest.client.RuntimeOperations;
 import org.springframework.xd.rest.domain.DetailedContainerResource;
 import org.springframework.xd.rest.domain.ModuleMetadataResource;
 import org.springframework.xd.shell.XDShell;
@@ -42,11 +42,11 @@ import org.springframework.xd.shell.util.TableRow;
  * @author Ilayaperumal Gopinathan
  */
 @Component
-public class ClusterCommands implements CommandMarker {
+public class RuntimeCommands implements CommandMarker {
 
-	private static final String LIST_CONTAINERS = "cluster containers";
+	private static final String LIST_CONTAINERS = "runtime containers";
 
-	private static final String LIST_MODULES = "cluster modules";
+	private static final String LIST_MODULES = "runtime modules";
 
 	@Autowired
 	private XDShell xdShell;
@@ -111,7 +111,7 @@ public class ClusterCommands implements CommandMarker {
 		return table;
 	}
 
-	private ClusterOperations runtimeOperations() {
+	private RuntimeOperations runtimeOperations() {
 		return xdShell.getSpringXDOperations().runtimeOperations();
 	}
 

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/RuntimeCommandTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/RuntimeCommandTests.java
@@ -43,14 +43,14 @@ import org.springframework.xd.shell.util.TableRow;
  * @author Ilayaperumal Gopinathan
  * @author Patrick Peralta
  */
-public class ClusterCommandTests extends AbstractStreamIntegrationTest {
+public class RuntimeCommandTests extends AbstractStreamIntegrationTest {
 
-	private static final Log logger = LogFactory.getLog(ClusterCommandTests.class);
+	private static final Log logger = LogFactory.getLog(RuntimeCommandTests.class);
 
 	@Test
 	public void testListContainers() {
-		logger.info("List cluster containers");
-		CommandResult cmdResult = executeCommand("cluster containers");
+		logger.info("List runtime containers");
+		CommandResult cmdResult = executeCommand("runtime containers");
 		Table table = (Table) cmdResult.getResult();
 		for (TableRow row : table.getRows()) {
 			// Verify host name & ip address are not empty
@@ -62,7 +62,7 @@ public class ClusterCommandTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testListRuntimeModules() {
-		logger.info("List cluster modules");
+		logger.info("List runtime modules");
 		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
 
@@ -71,17 +71,17 @@ public class ClusterCommandTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testListRuntimeModulesByModuleId() {
-		logger.info("List cluster modules");
+		logger.info("List runtime modules");
 		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
-		CommandResult cmdResult = executeCommand("cluster modules --moduleId " + streamName + ".sink.log.1");
+		CommandResult cmdResult = executeCommand("runtime modules --moduleId " + streamName + ".sink.log.1");
 		Table table = (Table) cmdResult.getResult();
 		assertEquals(1, table.getRows().size());
 	}
 
 	@Test
 	public void testListRuntimeModulesAfterUndeploy() {
-		logger.info("List cluster modules after undeploy");
+		logger.info("List runtime modules after undeploy");
 		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
 		stream().undeploy(streamName);
@@ -91,7 +91,7 @@ public class ClusterCommandTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testListRuntimeModulesByContainerId() {
-		logger.info("Test listing of cluster modules by containerId");
+		logger.info("Test listing of runtime modules by containerId");
 		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
 
@@ -101,7 +101,7 @@ public class ClusterCommandTests extends AbstractStreamIntegrationTest {
 
 		// Get containerId for a runtime module
 		String containerId = runtimeModules.get(0).getValue(2);
-		CommandResult cmdResult = executeCommand("cluster modules --containerId " + containerId);
+		CommandResult cmdResult = executeCommand("runtime modules --containerId " + containerId);
 		Table table = (Table) cmdResult.getResult();
 		List<TableRow> fooStreamModules = new ArrayList<TableRow>();
 		for (TableRow row : table.getRows()) {
@@ -118,23 +118,23 @@ public class ClusterCommandTests extends AbstractStreamIntegrationTest {
 
 	@Test
 	public void testListRuntimeModulesByInvalidContainerId() {
-		logger.info("Test listing of cluster modules by invalid containerId");
+		logger.info("Test listing of runtime modules by invalid containerId");
 		String streamName = generateStreamName();
 		stream().create(streamName, "time | log");
-		CommandResult cmdResult = executeCommand("cluster modules --containerId 10000");
+		CommandResult cmdResult = executeCommand("runtime modules --containerId 10000");
 		Table table = (Table) cmdResult.getResult();
 		assertEquals(0, table.getRows().size());
 	}
 
 	/**
-	 * Return a list of cluster modules for the stream name.
+	 * Return a list of runtime modules for the stream name.
 	 *
-	 * @param streamName name of stream for which to obtain cluster modules
+	 * @param streamName name of stream for which to obtain runtime modules
 	 * @return list of table rows containing runtime module information
 	 *         for the requested stream
 	 */
 	private List<TableRow> getRuntimeModulesForStream(String streamName) {
-		CommandResult cmdResult = executeCommand("cluster modules");
+		CommandResult cmdResult = executeCommand("runtime modules");
 		Table table = (Table) cmdResult.getResult();
 		List<TableRow> modules = new ArrayList<TableRow>();
 		for (TableRow row : table.getRows()) {

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/ReferenceDoc.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/ReferenceDoc.java
@@ -51,7 +51,7 @@ import org.springframework.xd.shell.command.HttpCommands;
 import org.springframework.xd.shell.command.JobCommands;
 import org.springframework.xd.shell.command.ModuleCommands;
 import org.springframework.xd.shell.command.RichGaugeCommands;
-import org.springframework.xd.shell.command.ClusterCommands;
+import org.springframework.xd.shell.command.RuntimeCommands;
 import org.springframework.xd.shell.command.StreamCommands;
 import org.springframework.xd.shell.hadoop.ConfigurationCommands;
 import org.springframework.xd.shell.hadoop.FsShellCommands;
@@ -101,7 +101,7 @@ public class ReferenceDoc {
 		 */
 		titles.put(ConfigCommands.class, "Configuration Commands");
 		// ===== Runtime Containers/Modules ======
-		titles.put(ClusterCommands.class, "Runtime Commands");
+		titles.put(RuntimeCommands.class, "Runtime Commands");
 
 		// ===== Streams etc. ======
 		titles.put(StreamCommands.class, "Stream Commands");


### PR DESCRIPTION
- This change is required for backward compatibility with 1.0 GA
- Also fixed the shell command to read `runtime`
