### PR TITLE
Use `localhost` as the target URL for test

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/AbstractSingleNodeApplicationSecurityTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/AbstractSingleNodeApplicationSecurityTest.java
@@ -35,7 +35,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.xd.dirt.server.SingleNodeApplication;
-import org.springframework.xd.dirt.util.RuntimeUtils;
 
 /**
  * Base class for Security Tests - allows for starting single node applications with different
@@ -55,8 +54,6 @@ public abstract class AbstractSingleNodeApplicationSecurityTest {
 	private static String originalConfigLocation = null;
 
 	private static String adminPort;
-
-	private static String adminHost;
 
 	protected RestTemplate restTemplate;
 
@@ -83,7 +80,6 @@ public abstract class AbstractSingleNodeApplicationSecurityTest {
 					                 .addFilters(configurableApplicationContext.getBeansOfType(Filter.class).values().toArray(new Filter[]{}))
 					                 .build();
 			adminPort = application().adminContext().getEnvironment().resolvePlaceholders("${server.port}");
-			adminHost = RuntimeUtils.getHost();
 		}
 
 		@Override
@@ -107,10 +103,6 @@ public abstract class AbstractSingleNodeApplicationSecurityTest {
 
 	public static SingleNodeApplication application() {
 		return singleNodeApplication;
-	}
-
-	protected static String adminHost() {
-		return adminHost;
 	}
 
 	protected static String adminPort() {

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithDefaultSecurityTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithDefaultSecurityTest.java
@@ -54,13 +54,13 @@ public class SingleNodeApplicationWithDefaultSecurityTest extends AbstractSingle
 	@Test
 	public void testSslNotEnabledByDefaultForAdminEndpoints() throws Exception {
 		try {
-			restTemplate.getForEntity("https://" + adminHost() + ":" + adminPort() + "/modules", Object.class);
+			restTemplate.getForEntity("https://localhost" + ":" + adminPort() + "/modules", Object.class);
 		} catch (RestClientException e) {
 			// the request fails because the protocol is not HTTPS
 			assertThat(e.getCause(), instanceOf(SSLException.class));
 		}
 		// HTTP, however, succeeds
-		ResponseEntity<Object> responseEntity = restTemplate.getForEntity("http://" + adminHost() + ":" + adminPort() + "/modules", Object.class);
+		ResponseEntity<Object> responseEntity = restTemplate.getForEntity("http://localhost" + ":" + adminPort() + "/modules", Object.class);
 		assertThat(responseEntity.getStatusCode(), equalTo(HttpStatus.OK));
 	}
 
@@ -68,12 +68,12 @@ public class SingleNodeApplicationWithDefaultSecurityTest extends AbstractSingle
 	public void testSslNotEnabledByDefaultForManagementEndpoints() throws Exception {
 		try {
 			// the request fails because the protocol is not HTTPS
-			restTemplate.getForEntity("https://" + adminHost() + ":" + adminPort() + "/management/metrics", Object.class);
+			restTemplate.getForEntity("https://localhost" + ":" + adminPort() + "/management/metrics", Object.class);
 		} catch (RestClientException e) {
 			assertThat(e.getCause(), instanceOf(SSLException.class));
 		}
 		// HTTP, however, succeeds
-		ResponseEntity<Object> responseEntity = restTemplate.getForEntity("http://" + adminHost() + ":" + adminPort() + "/management/metrics", Object.class);
+		ResponseEntity<Object> responseEntity = restTemplate.getForEntity("http://localhost" + ":" + adminPort() + "/management/metrics", Object.class);
 		assertThat(responseEntity.getStatusCode(), equalTo(HttpStatus.OK));
 	}
 }


### PR DESCRIPTION
 This replaces the previous look up to `RuntimeUtils.getHost()`. The latter has been noticed to cause issues on systems where the result points to an interface to which embedded Tomcat doesn't bind, causing a ConnectException.
