### PR TITLE
XD-2235 Allow for 'security.basic.realm' to control the security realm

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithUserBasedSecurityTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithUserBasedSecurityTest.java
@@ -18,6 +18,7 @@ package org.springframework.xd.dirt.security;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.Test;
@@ -30,20 +31,22 @@ public class SingleNodeApplicationWithUserBasedSecurityTest extends AbstractSing
 
 	@Test
 	public void testUnauthenticatedAccessToModulesEndpointFails() throws Exception {
-        mockMvc().perform(
-						get("/modules"))
+		mockMvc().perform(
+				get("/modules"))
 				.andExpect(
 						status().isUnauthorized()
-				);
+				).andExpect(header().string("WWW-Authenticate", "Basic realm=\"SpringXD\"")
+		);
 	}
 
 	@Test
 	public void testUnauthenticatedAccessToManagementEndpointFails() throws Exception {
 		mockMvc().perform(
-						get("/management/metrics")
-				).andExpect(
+				get("/management/metrics"))
+				.andExpect(
 						status().isUnauthorized()
-				);
+				).andExpect(header().string("WWW-Authenticate", "Basic realm=\"SpringXD\"")
+		);
 	}
 
 	@Test

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/config/SecurityConfiguration.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/config/SecurityConfiguration.java
@@ -15,6 +15,7 @@
 package org.springframework.xd.dirt.web.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -42,8 +43,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Autowired
 	private ContentNegotiationStrategy contentNegotiationStrategy;
 
-	@Autowired
-	Environment environment;
+	@Value("${security.basic.realm}")
+	private String realm;
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
@@ -52,6 +53,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				MediaType.TEXT_HTML);
 
 		final String loginPage = "/admin-ui/login";
+
+		BasicAuthenticationEntryPoint basicAuthenticationEntryPoint = new BasicAuthenticationEntryPoint();
+		basicAuthenticationEntryPoint.setRealmName(realm);
+		basicAuthenticationEntryPoint.afterPropertiesSet();
 
 		http.csrf().disable()
 				.authorizeRequests()
@@ -73,6 +78,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				.and()
 				.exceptionHandling()
 				.defaultAuthenticationEntryPointFor(new LoginUrlAuthenticationEntryPoint(loginPage), textHtmlMatcher)
-				.defaultAuthenticationEntryPointFor(new BasicAuthenticationEntryPoint(), AnyRequestMatcher.INSTANCE);
+				.defaultAuthenticationEntryPointFor(basicAuthenticationEntryPoint, AnyRequestMatcher.INSTANCE);
 	}
 }


### PR DESCRIPTION
This is a minor fix, but without it, the realm will always default to null
