### PR TITLE
XD-2069 Enable HTTP source debugging

### DIFF
--- a/config/xd-admin-logger.properties
+++ b/config/xd-admin-logger.properties
@@ -24,6 +24,9 @@ log4j.logger.org.springframework.integration=WARN
 log4j.logger.org.springframework.retry=WARN
 log4j.logger.org.springframework.amqp=WARN
 
+#Netty logging (for the HTTP source)
+log4j.logger.org.jboss.netty.handler.logging.LoggingHandler=DEBUG
+
 
 # Below this line are specific settings for things that are too noisy
 

--- a/config/xd-container-logger.properties
+++ b/config/xd-container-logger.properties
@@ -24,6 +24,9 @@ log4j.logger.org.springframework.integration=WARN
 log4j.logger.org.springframework.retry=WARN
 log4j.logger.org.springframework.amqp=WARN
 
+#Netty logging (for the HTTP source)
+log4j.logger.org.jboss.netty.handler.logging.LoggingHandler=DEBUG
+
 
 # Below this line are specific settings for things that are too noisy
 

--- a/config/xd-singlenode-logger.properties
+++ b/config/xd-singlenode-logger.properties
@@ -24,6 +24,9 @@ log4j.logger.org.springframework.integration=WARN
 log4j.logger.org.springframework.retry=WARN
 log4j.logger.org.springframework.amqp=WARN
 
+#Netty logging (for the HTTP source)
+log4j.logger.org.jboss.netty.handler.logging.LoggingHandler=DEBUG
+
 
 # Below this line are specific settings for things that are too noisy
 log4j.logger.org.springframework.beans.factory.config=ERROR

--- a/modules/source/http/config/http.xml
+++ b/modules/source/http/config/http.xml
@@ -13,6 +13,7 @@
 		<beans:property name="autoStartup" value="false"/>
 		<beans:property name="outputChannel" ref="output"/>
 		<beans:property name="sslPropertiesLocation" value="${sslPropertiesLocation}"/>
+		<beans:property name="verboseLogging" value="${verboseLogging:#{false}}"/>
 	</beans:bean>
 
 	<channel id="output"/>

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
@@ -22,6 +22,7 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * Describes options to the {@code http} source module.
  * 
  * @author Gary Russell
+ * @author Marius Bogoevici
  */
 public class HttpSourceOptionsMetadata {
 
@@ -31,6 +32,7 @@ public class HttpSourceOptionsMetadata {
 
 	private String sslPropertiesLocation = "classpath:httpSSL.properties";
 
+	private boolean verboseLogging;
 
 	public int getPort() {
 		return port;
@@ -57,6 +59,15 @@ public class HttpSourceOptionsMetadata {
 	@ModuleOption("location (resource) of properties containing the location of the pkcs12 keyStore and pass phrase")
 	public void setSslPropertiesLocation(String sslProperties) {
 		this.sslPropertiesLocation = sslProperties;
+	}
+
+	public boolean getVerboseLogging() {
+		return verboseLogging;
+	}
+
+	@ModuleOption(value = "true if verbose logging (via Netty) is enabled", defaultValue = "false")
+	public void setVerboseLogging(boolean verboseLogging) {
+		this.verboseLogging = verboseLogging;
 	}
 
 }


### PR DESCRIPTION
- Add logging statements at DEBUG level in NettyHttpInboundChannelAdapter
- Add HTTP source module option for more verbose logging via Netty's own LoggingHandler, which can be turned on by `--verboseLogging=true` in the stream definition
