### PR TITLE
[Sprint: 38] XD-2228 - Prompt for password if no value is provided on the command line

### DIFF
--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/Target.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/Target.java
@@ -79,7 +79,9 @@ public class Target {
 
 	public static final String DEFAULT_USERNAME = "";
 
-	public static final String DEFAULT_PASSWORD = "";
+	public static final String DEFAULT_SPECIFIED_PASSWORD = "";
+
+	public static final String DEFAULT_UNSPECIFIED_PASSWORD = "__NULL__";
 
 	public static final String DEFAULT_TARGET = DEFAULT_SCHEME + "://" + DEFAULT_HOST + ":" + DEFAULT_PORT + "/";
 

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ConsoleUserInput.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ConsoleUserInput.java
@@ -37,25 +37,47 @@ public class ConsoleUserInput implements UserInput {
 	 * {@code defaultValue}.
 	 */
 	@Override
-	public String prompt(String prompt, String defaultValue, String... options) {
+	public String promptWithOptions(String prompt, String defaultValue, String... options) {
 		List<String> optionsAsList = Arrays.asList(options);
 		InputStreamReader console = new InputStreamReader(System.in);
 		String answer;
 		do {
-			answer = "";
 			System.out.format("%s %s: ", prompt, optionsAsList);
-			try {
-				for (char c = (char) console.read(); !(c == '\n' || c == '\r'); c = (char) console.read()) {
-					System.out.print(c);
-					answer += c;
-				}
-				System.out.println();
-			}
-			catch (IOException e) {
-				throw new IllegalStateException(e);
-			}
+			answer = read(console, true);
 		}
 		while (!optionsAsList.contains(answer) && !"".equals(answer));
 		return "".equals(answer) && !optionsAsList.contains("") ? defaultValue : answer;
+	}
+
+	@Override
+	public String prompt(String prompt, String defaultValue, boolean echo) {
+		InputStreamReader console = new InputStreamReader(System.in);
+		System.out.format("%s: ", prompt);
+		String answer = read(console, echo);
+		return "".equals(answer) ? defaultValue : answer;
+	}
+
+  /**
+	 *  Reads a single line of input from the console.
+	 *
+	 *  @param console input
+	 *  @param echo    whether the input should be echoed (e.g. false for passwords, other sensitive data)
+   */
+	private String read(InputStreamReader console, boolean echo) {
+		String answer;
+		answer = "";
+		try {
+			for (char c = (char) console.read(); !(c == '\n' || c == '\r'); c = (char) console.read()) {
+				if (echo) {
+					System.out.print(c);
+				}
+				answer += c;
+			}
+			System.out.println();
+		}
+		catch (IOException e) {
+			throw new IllegalStateException(e);
+		}
+		return answer;
 	}
 }

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
@@ -307,7 +307,7 @@ public class JobCommands implements CommandMarker {
 	@CliCommand(value = STOP_ALL_JOB_EXECUTIONS, help = "Stop all the job executions that are running")
 	public String stopAllJobExecutions(
 			@CliOption(key = "force", help = "bypass confirmation prompt", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean force) {
-		if (force || "y".equalsIgnoreCase(userInput.prompt("Really stop all job executions?", "n", "y", "n"))) {
+		if (force || "y".equalsIgnoreCase(userInput.promptWithOptions("Really stop all job executions?", "n", "y", "n"))) {
 			jobOperations().stopAllJobExecutions();
 			return String.format("Stopped all the job executions");
 		}
@@ -358,7 +358,7 @@ public class JobCommands implements CommandMarker {
 	public String undeployAllJobs(
 			@CliOption(key = "force", help = "bypass confirmation prompt", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean force
 			) {
-		if (force || "y".equalsIgnoreCase(userInput.prompt("Really undeploy all jobs?", "n", "y", "n"))) {
+		if (force || "y".equalsIgnoreCase(userInput.promptWithOptions("Really undeploy all jobs?", "n", "y", "n"))) {
 			jobOperations().undeployAll();
 			return String.format("Un-deployed all the jobs");
 		}
@@ -414,7 +414,7 @@ public class JobCommands implements CommandMarker {
 			@CliOption(key = "force", help = "bypass confirmation prompt", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean force
 
 			) {
-		if (force || "y".equalsIgnoreCase(userInput.prompt("Really destroy all jobs?", "n", "y", "n"))) {
+		if (force || "y".equalsIgnoreCase(userInput.promptWithOptions("Really destroy all jobs?", "n", "y", "n"))) {
 			jobOperations().destroyAll();
 			return String.format("Destroyed all the jobs");
 		}

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/StreamCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/StreamCommands.java
@@ -79,7 +79,7 @@ public class StreamCommands implements CommandMarker {
 	public String destroyAllStreams(
 			@CliOption(key = "force", help = "bypass confirmation prompt", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean force) {
 		// Be sure to short-circuit prompt if force is true
-		if (force || "y".equalsIgnoreCase(userInput.prompt("Really destroy all streams?", "n", "y", "n"))) {
+		if (force || "y".equalsIgnoreCase(userInput.promptWithOptions("Really destroy all streams?", "n", "y", "n"))) {
 			streamOperations().destroyAll();
 			return "Destroyed all streams";
 		}
@@ -108,7 +108,7 @@ public class StreamCommands implements CommandMarker {
 	public String undeployAllStreams(
 			@CliOption(key = "force", help = "bypass confirmation prompt", unspecifiedDefaultValue = "false", specifiedDefaultValue = "true") boolean force
 			) {
-		if (force || "y".equalsIgnoreCase(userInput.prompt("Really undeploy all streams?", "n", "y", "n"))) {
+		if (force || "y".equalsIgnoreCase(userInput.promptWithOptions("Really undeploy all streams?", "n", "y", "n"))) {
 			streamOperations().undeployAll();
 			return String.format("Un-deployed all the streams");
 		}

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/UserInput.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/UserInput.java
@@ -21,12 +21,23 @@ package org.springframework.xd.shell.command;
  * Abstraction for a mechanism used to get user interactive user input.
  * 
  * @author Eric Bottard
+ * @author Marius Bogoevici
  */
 public interface UserInput {
 
 	/**
 	 * Display a prompt text to the user and expect one of {@code options} in return.
+	 * @param prompt the a message to prompt the user with
+	 * @param defaultValue the default value to be returned if the user simply presses Enter
+	 * @param options valid input option set
 	 */
-	public String prompt(String prompt, String defaultValue, String... options);
+	public String promptWithOptions(String prompt, String defaultValue, String... options);
 
+	/**
+	 * Display a prompt text to the user and expect them to enter a free-form value. Optionally, the input is echoed.
+	 * @param prompt the a message to prompt the user with
+	 * @param defaultValue the default value to be returned if the user simply presses Enter
+	 * @param echo echo the input to output (set to false for sensitive input, e.g. passwords)
+	 */
+	public String prompt(String prompt, String defaultValue, boolean echo);
 }

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTest.java
@@ -23,6 +23,10 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -68,7 +72,83 @@ public class SecuredShellAccessTest extends RandomConfigurationSupport {
 		assertThat(commandResult.isSuccess(), is(true));
 		assertThat(commandResult.getResult(), instanceOf(Table.class));
 		assertThat(((Table) commandResult.getResult()).getHeaders().size(), greaterThan(0));
+	}
 
+	@Test
+	public void testShellWithPasswordFlag() throws Exception {
+		try {
+			// Simulate user input by replacing the system input stream
+			SimulatedInputStream simulatedInputStream = new SimulatedInputStream("whosThere\n");
+			System.setIn(simulatedInputStream);
+			Bootstrap bootstrap = new Bootstrap();
+			JLineShellComponent shell = bootstrap.getJLineShellComponent();
+			assertThat(simulatedInputStream.isReadPerformed(), is(false));
+			assertThat(simulatedInputStream.hasUnreadData(), is(true));
+			CommandResult commandResult = shell.executeCommand("admin config server --uri http://localhost:" + adminPort + " --username admin --password");
+			assertThat(simulatedInputStream.isReadPerformed(), is(true));
+			assertThat(simulatedInputStream.hasUnreadData(), is(false));
+			assertThat(commandResult.isSuccess(), is(true));
+			commandResult = shell.executeCommand("module list");
+			assertThat(commandResult.isSuccess(), is(true));
+			assertThat(commandResult.getResult(), instanceOf(Table.class));
+			assertThat(((Table) commandResult.getResult()).getHeaders().size(), greaterThan(0));
+		}
+		finally {
+			// restore the system input stream
+			System.setIn(System.in);
+		}
+	}
+
+	@Test
+	public void testShellWithPasswordFlagFailsIfPasswordIsWrong() throws Exception {
+		try {
+			// Simulate user input by replacing the system input stream
+			SimulatedInputStream simulatedInputStream = new SimulatedInputStream("aWrongPassword\n");
+			System.setIn(simulatedInputStream);
+			Bootstrap bootstrap = new Bootstrap();
+			JLineShellComponent shell = bootstrap.getJLineShellComponent();
+			assertThat(simulatedInputStream.isReadPerformed(), is(false));
+			assertThat(simulatedInputStream.hasUnreadData(), is(true));
+			CommandResult commandResult = shell.executeCommand("admin config server --uri http://localhost:" + adminPort + " --username admin --password");
+			assertThat(simulatedInputStream.isReadPerformed(), is(true));
+			assertThat(simulatedInputStream.hasUnreadData(), is(false));
+			assertThat(commandResult.isSuccess(), is(true));
+			Configuration configuration = bootstrap.getApplicationContext().getBean(Configuration.class);
+			assertThat(configuration.getTarget().getTargetException(), instanceOf(HttpClientErrorException.class));
+			assertThat(((HttpClientErrorException) configuration.getTarget().getTargetException()).getStatusCode(), equalTo(HttpStatus.UNAUTHORIZED));
+			commandResult = shell.executeCommand("module list");
+			assertThat(commandResult.isSuccess(), is(false));
+		}
+		finally {
+			// restore the system input stream
+			System.setIn(System.in);
+		}
+	}
+
+	@Test
+	public void testShellNoPromptWithoutPasswordFlag() throws Exception {
+		try {
+			// Simulate user input by replacing the system input stream
+			SimulatedInputStream simulatedInputStream = new SimulatedInputStream("whosThere\n");
+			System.setIn(simulatedInputStream);
+			Bootstrap bootstrap = new Bootstrap();
+			JLineShellComponent shell = bootstrap.getJLineShellComponent();
+			assertThat(simulatedInputStream.isReadPerformed(), is(false));
+			assertThat(simulatedInputStream.hasUnreadData(), is(true));
+			CommandResult commandResult = shell.executeCommand("admin config server --uri http://localhost:" + adminPort + " --username admin");
+			assertThat(simulatedInputStream.isReadPerformed(), is(false)); // without the --password flag, the shell doesn't prompt and doesn't read from input
+			assertThat(simulatedInputStream.hasUnreadData(), is(true));
+			assertThat(commandResult.isSuccess(), is(true));
+			Configuration configuration = bootstrap.getApplicationContext().getBean(Configuration.class);
+			assertThat(configuration.getTarget().getTargetException(), instanceOf(HttpClientErrorException.class));
+			assertThat(((HttpClientErrorException) configuration.getTarget().getTargetException()).getStatusCode(), equalTo(HttpStatus.UNAUTHORIZED));
+			commandResult = shell.executeCommand("module list");
+			assertThat(commandResult.isSuccess(), is(false));
+		}
+		finally {
+			// restore the system input stream
+			System.setIn(System.in);
+		}
 	}
 
 	@Test
@@ -104,6 +184,31 @@ public class SecuredShellAccessTest extends RandomConfigurationSupport {
 			System.clearProperty("spring.config.location");
 		} else {
 			System.setProperty("spring.config.location", originalConfigLocation);
+		}
+	}
+
+	private static class SimulatedInputStream extends InputStream {
+
+		private ByteArrayInputStream content;
+
+		private boolean readPerformed;
+
+		public SimulatedInputStream(String content) {
+			this.content = new ByteArrayInputStream(content.getBytes());
+		}
+
+		@Override
+		public int read() throws IOException {
+			readPerformed = true;
+			return content.read();
+		}
+
+		public boolean isReadPerformed() {
+			return readPerformed;
+		}
+
+		public boolean hasUnreadData() throws IOException {
+			return content.available() > 0;
 		}
 	}
 }


### PR DESCRIPTION
(Targeting both 1.0.x and 1.1.0)

Prompt for password if no value is provided in the command line
- If there is no value provided for the `--password` parameter, the shell will prompt the user to type one, avoiding its display in cleartext on both screen and log;
- UserInput has been refactored, by renaming the original `prompt` method to `promptWithOptions`, and introducing a `prompt` method for freeform input`
- Added tests simulating user input
