### PR TITLE
[Sprint 37] XD-2269: Remove module definition display

### DIFF
--- a/spring-xd-ui/app/scripts/job/controllers/module-details.js
+++ b/spring-xd-ui/app/scripts/job/controllers/module-details.js
@@ -36,11 +36,6 @@ define([], function () {
                 utils.growl.addErrorMessage('Error fetching module details. ' + error.data[0].message);
               }
             );
-        var moduleDefinitionPromise = jobModuleService.getModuleDefinition($stateParams.moduleName);
-        utils.addBusyPromise(moduleDefinitionPromise);
-        moduleDefinitionPromise.success(function(data){
-          $scope.moduleDefinition = data;
-        });
         $scope.closeModuleDetails = function () {
             utils.$log.info('Closing Job Details Window');
             $state.go('home.jobs.tabs.modules');

--- a/spring-xd-ui/app/scripts/job/services.js
+++ b/spring-xd-ui/app/scripts/job/services.js
@@ -117,13 +117,6 @@ define(['angular'], function (angular) {
                 }
               }
             }).createDefinition();
-          },
-          getModuleDefinition: function (moduleName) {
-            $log.info('Getting module definition file for module ' + moduleName);
-            return $http({
-              method: 'GET',
-              url: $rootScope.xdAdminServerUrl + '/modules/job/' + moduleName + '/definition'
-            });
           }
         };
       })

--- a/spring-xd-ui/app/scripts/job/views/module-details.html
+++ b/spring-xd-ui/app/scripts/job/views/module-details.html
@@ -18,7 +18,4 @@
   </tbody>
 </table>
 
-<h4>Definition File</h4>
-
-<div id="module-definition-file" hljs source="moduleDefinition" language="xml" ng-show="moduleDefinition"></div>
 <button id="back-button" type="button" class="btn btn-default" ng-click="closeModuleDetails()">Back</button>


### PR DESCRIPTION
This is following the removal of the REST endpoint for downloading a (xml only) definition.

It appears the shell command has already been removed (unless I'm mistaken)
