### PR TITLE
XD-2310 Fix kafka-bus.xml

### DIFF
--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/kafka-bus.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/transports/kafka-bus.xml
@@ -6,9 +6,10 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<bean id="messageBus" class="org.springframework.xd.dirt.integration.kafka.KafkaMessageBus">
-		<constructor-arg value=${xd.messagebus.kafka.brokers}/>
-		<constructor-arg value=${xd.messagebus.kafka.zkAddress}/>
+		<constructor-arg value="${xd.messagebus.kafka.brokers}"/>
+		<constructor-arg value="${xd.messagebus.kafka.zkAddress}"/>
 		<constructor-arg ref="codec"/>
+		<constructor-arg value="#{new String[0]}"/>
 	</bean>
 
 </beans>


### PR DESCRIPTION
- add missing quotation marks
- Inject empty array as dependency - otherwise the constructor argument is treated as missing
