### PR TITLE
[Sprint 38] XD-2323 Fix Batch replyChannel Header

### DIFF
--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
@@ -56,7 +56,7 @@
 	<int:channel id="stepExecutionReplies.input" />
 
 	<int:header-enricher input-channel="stepExecutionReplies.input" output-channel="resultAggregationChannel">
-		<int:reply-channel expression="@replyChannelRegistry.channelNameToChannel(headers.xdReplyChannel)" />
+		<int:reply-channel expression="@replyChannelRegistry.channelNameToChannel(headers.xdReplyChannel)" overwrite="true" />
 	</int:header-enricher>
 
 	<int:channel id="resultAggregationChannel" />


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2323

Spring Integration 4.1.0 incorrectly mapped the `replyChannel`
header as a String, preventing the replacement with
the `xdReplyChannel` (transmitted as a String to the slave).

See INT-3555.

Set `overwrite="true"`.
