### PR TITLE
[Sprint: 38] XD-2296 Show/Hide message rates at WebUI

### DIFF
--- a/spring-xd-ui/app/scripts/container/controllers/containers.js
+++ b/spring-xd-ui/app/scripts/container/controllers/containers.js
@@ -23,6 +23,7 @@ define([], function () {
   'use strict';
   return ['$scope', 'ContainerService', 'XDUtils', '$timeout', '$rootScope',
     function ($scope, containerService, utils, $timeout, $rootScope) {
+      $scope.enableMessageRates = $rootScope.enableMessageRates;
       function loadContainers() {
         containerService.getContainers().$promise.then(
             function (result) {
@@ -49,9 +50,11 @@ define([], function () {
             }
         );
       }
+
       function loadContainersWithTimeout() {
         $scope.containerTimeOutPromise = $timeout(loadContainers, $rootScope.pageRefreshTime);
       }
+
       loadContainers();
 
       $scope.$on('$destroy', function () {
@@ -80,6 +83,10 @@ define([], function () {
               $scope.closeModal();
             }
         );
+      };
+      $scope.enableDisableMessageRates = function () {
+        $rootScope.enableMessageRates = !$scope.enableMessageRates;
+        $scope.enableMessageRates = $rootScope.enableMessageRates;
       };
     }];
 });

--- a/spring-xd-ui/app/scripts/container/views/containerlist.html
+++ b/spring-xd-ui/app/scripts/container/views/containerlist.html
@@ -1,10 +1,17 @@
 <div class="row">
     <div class="col-md-12">
         <div class="col-md-12 table-filter">
-            <div class="col-md-4 col-md-offset-8">
+            <div class="col-md-4 col-md-offset-4">
+                <button type="button" class="btn btn-default" ng-click="enableDisableMessageRates()">
+                    <span ng-show="!enableMessageRates">Show</span><span
+                        ng-show="enableMessageRates">Hide</span> MessageRates
+                </button>
+            </div>
+            <div class="col-md-4">
                 <input type="text" class="form-control" ng-model="filterQuery" id="filterTable"
                        placeholder="Quick filter">
             </div>
+
         </div>
     </div>
 </div>
@@ -22,23 +29,39 @@
         ng-show="!item.inactive">
         <td id="container-id">
             <a xd-popover=".containerDetails{{$index}}" rel="popover" data-original-title="Container Attributes">{{item.containerId}}</a>
+
             <div class="containerDetails{{$index}} hide">
-              <table class="table-hover table-condensed container-details-table">
-                <tbody>
-                  <tr><td class="text-left"><strong>Ip</strong></td><td>{{item.attributes.ip}}</td></tr>
-                  <tr><td class="text-left"><strong>Groups</strong></td><td>{{item.attributes.groups}}</td></tr>
-                  <tr><td class="text-left"><strong>Pid</strong></td><td>{{item.attributes.pid}}</td></tr>
-                  <tr><td class="text-left"><strong>Management Port</strong></td><td>{{item.attributes.managementPort}}</td></tr>
-                  <tr><td class="text-left"><strong>Host</strong></td><td>{{item.attributes.host}}</td></tr>
-                </tbody>
-              </table>
+                <table class="table-hover table-condensed container-details-table">
+                    <tbody>
+                    <tr>
+                        <td class="text-left"><strong>Ip</strong></td>
+                        <td>{{item.attributes.ip}}</td>
+                    </tr>
+                    <tr>
+                        <td class="text-left"><strong>Groups</strong></td>
+                        <td>{{item.attributes.groups}}</td>
+                    </tr>
+                    <tr>
+                        <td class="text-left"><strong>Pid</strong></td>
+                        <td>{{item.attributes.pid}}</td>
+                    </tr>
+                    <tr>
+                        <td class="text-left"><strong>Management Port</strong></td>
+                        <td>{{item.attributes.managementPort}}</td>
+                    </tr>
+                    <tr>
+                        <td class="text-left"><strong>Host</strong></td>
+                        <td>{{item.attributes.host}}</td>
+                    </tr>
+                    </tbody>
+                </table>
             </div>
         </td>
         <td>
             <table>
                 <tr ng-repeat="group in item.groups.split(',')">
                     <td class="label label-default">
-                      {{group || 'N/A'}}
+                        {{group || 'N/A'}}
                     </td>
                 </tr>
             </table>
@@ -51,30 +74,38 @@
                             title="{{deployments.deploymentStatus || 'N/A'}}">{{deployments.unitName}}</span>
                     </td>
                     <td class="input-group-addon">
-                        <a xd-popover=".deploymentDetails{{$index}}" rel="popover" data-original-title="Deployment Details">
-                        {{deployments.name}}</a>
+                        <a xd-popover=".deploymentDetails{{$index}}" rel="popover"
+                           data-original-title="Deployment Details">
+                            {{deployments.name}}</a>
+
                         <div class="deploymentDetails{{$index}} hide">
-                          <table class="table-hover table-condensed table-bordered container-details-table">
-                            <thead>
-                              <tr><th colspan="2">Module Options</th></tr>
-                            </thead>
-                            <tbody>
-                              <tr ng-repeat="(key, value) in deployments.moduleOptions">
-                                <td class="text-left"><strong>{{key}}</strong></td><td>{{value}}</td>
-                              </tr>
-                            </tbody>
-                            <thead>
-                              <tr><th colspan="2">Deployment Properties</th></tr>
-                            </thead>
-                            <tbody>
-                              <tr ng-repeat="(key, value) in deployments.deploymentProperties">
-                                <td class="text-left"><strong>{{key}}</strong></td><td>{{value}}</td>
-                              </tr>
-                            </tbody>
-                          </table>
+                            <table class="table-hover table-condensed table-bordered container-details-table">
+                                <thead>
+                                <tr>
+                                    <th colspan="2">Module Options</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr ng-repeat="(key, value) in deployments.moduleOptions">
+                                    <td class="text-left"><strong>{{key}}</strong></td>
+                                    <td>{{value}}</td>
+                                </tr>
+                                </tbody>
+                                <thead>
+                                <tr>
+                                    <th colspan="2">Deployment Properties</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr ng-repeat="(key, value) in deployments.deploymentProperties">
+                                    <td class="text-left"><strong>{{key}}</strong></td>
+                                    <td>{{value}}</td>
+                                </tr>
+                                </tbody>
+                            </table>
                         </div>
                     </td>
-                    <td class="input-group-addon" ng-show="item.attributes.managementPort !== undefined">
+                    <td class="input-group-addon" ng-show="item.attributes.managementPort !== undefined && enableMessageRates">
                       <span xd-tooltip title="Incoming msgs/second" data-placement="bottom"
                             class="glyphicon glyphicon-arrow-down">{{deployments.incomingRate || 'N/A'}}
                       </span>
@@ -86,7 +117,8 @@
         </td>
         <td class="action-column">
             <div>
-                <button ng-disabled="item.attributes.managementPort === undefined" type="button" ng-click="confirmShutdown(item.containerId)"
+                <button ng-disabled="item.attributes.managementPort === undefined" type="button"
+                        ng-click="confirmShutdown(item.containerId)"
                         class="btn btn-default" data-toggle="modal" data-target="#confirm-shutdown"
                         ><span class="glyphicon glyphicon-remove"></span> Shutdown
                 </button>

--- a/spring-xd-ui/app/scripts/container/views/containers.html
+++ b/spring-xd-ui/app/scripts/container/views/containers.html
@@ -10,6 +10,7 @@
         </li>
     </ul>
     <div class="tab-content">
-        <div ui-view></div>
+        <div ui-view>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
- If the management port for the container is enabled, we will start
  collecting the message rates as part of `/containers` REST endpoint
  - Provide an option to show/hide message rates at the cluster view
