### PR TITLE
[Sprint: 38] XD-2296 Configure enable/disable message rate monitoring

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -285,3 +285,8 @@ typeconversion:
  json:
   prettyPrint: true
 ---
+#Enable collecting message rates from containers that have management port enabled.
+#xd:
+#  messageRateMonitoring:
+#    enabled: true
+---

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ContainersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ContainersController.java
@@ -72,6 +72,9 @@ public class ContainersController {
 	@Value("${management.contextPath:/management}")
 	private String managementContextPath;
 
+	@Value("${xd.messageRateMonitoring.enabled:false}")
+	private boolean enableMessageRates;
+
 	private final static String CONTAINER_HOST_URI_PROTOCOL = "http://";
 
 	private final static String SHUTDOWN_ENDPOINT = "/shutdown";
@@ -98,7 +101,7 @@ public class ContainersController {
 		for (DetailedContainer container : containers) {
 			String containerHost = container.getAttributes().getIp();
 			String containerManagementPort = container.getAttributes().getManagementPort();
-			if (StringUtils.hasText(containerManagementPort)) {
+			if (StringUtils.hasText(containerManagementPort) && enableMessageRates) {
 				Map<String, HashMap<String, Double>> messageRates = new HashMap<String, HashMap<String, Double>>();
 				for (ModuleMetadata moduleMetadata : container.getDeployedModules()) {
 					String moduleName = moduleMetadata.getName();

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -35,6 +35,8 @@ xd:
     groups: ${XD_CONTAINER_GROUPS:}
     host: ${XD_CONTAINER_HOSTNAME:}
     ip: ${XD_CONTAINER_IP:}
+  messageRateMonitoring:
+    enabled: false
   messagebus:
     rabbit:
       default:

--- a/spring-xd-ui/app/scripts/container/controllers/containers.js
+++ b/spring-xd-ui/app/scripts/container/controllers/containers.js
@@ -33,7 +33,7 @@ define([], function () {
                   var deployedModules = container.deployedModules;
                   deployedModules.forEach(function (deployedModule) {
                     console.log(deployedModule);
-                    if (container.messageRates[deployedModule.moduleId]) {
+                    if (container.messageRates && container.messageRates[deployedModule.moduleId]) {
                       if (container.messageRates[deployedModule.moduleId].hasOwnProperty('input')) {
                         deployedModule.incomingRate = container.messageRates[deployedModule.moduleId].input.toFixed(5);
                       }

--- a/spring-xd-ui/app/scripts/routes.js
+++ b/spring-xd-ui/app/scripts/routes.js
@@ -221,7 +221,7 @@ define(['./app'], function (xdAdmin) {
     $rootScope.authenticationEnabled = false;
     $rootScope.user = userService;
     $rootScope.pageRefreshTime = 5000;
-    $rootScope.enableMessageRates = false;
+    $rootScope.enableMessageRates = true;
 
     $rootScope.$on('$stateChangeStart', function(event, toState) {
         $log.info('Need to authenticate? ' + toState.data.authenticate);


### PR DESCRIPTION
- Add new property `xd.messageRateMonitoring.enabled`
- Gather message rates metrics only if this property is set to `true`
- Set the client side property to `true` as we want this to be driven
  from server side
