### PR TITLE
[Sprint 39] XD-2201 Fix LocalMessageBus Taps

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/LocalMessageBus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/LocalMessageBus.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executors;
 import org.springframework.http.MediaType;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.ExecutorChannel;
+import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.handler.BridgeHandler;
@@ -52,20 +53,50 @@ import org.springframework.util.Assert;
  */
 public class LocalMessageBus extends MessageBusSupport {
 
-	private PollerMetadata poller;
+	private volatile PollerMetadata poller;
 
 	private final Map<String, ExecutorChannel> requestReplyChannels = new HashMap<String, ExecutorChannel>();
 
 	private final ExecutorService executor = Executors.newCachedThreadPool();
 
-	@SuppressWarnings("unused")
-	private boolean hasCodec;
+	private volatile int queueSize = Integer.MAX_VALUE;
+
+	/**
+	 * Used to create and customize {@link QueueChannel}s when the binding operation involves aliased names.
+	 */
+	private final SharedChannelProvider<QueueChannel> queueChannelProvider = new SharedChannelProvider<QueueChannel>(
+			QueueChannel.class) {
+
+		@Override
+		protected QueueChannel createSharedChannel(String name) {
+			QueueChannel queueChannel = new QueueChannel(queueSize);
+			return queueChannel;
+		}
+	};
+
+	private final SharedChannelProvider<PublishSubscribeChannel> pubsubChannelProvider = new SharedChannelProvider<PublishSubscribeChannel>(
+			PublishSubscribeChannel.class) {
+
+		@Override
+		protected PublishSubscribeChannel createSharedChannel(String name) {
+			PublishSubscribeChannel publishSubscribeChannel = new PublishSubscribeChannel(executor);
+			publishSubscribeChannel.setIgnoreFailures(true);
+			return publishSubscribeChannel;
+		}
+	};
 
 	/**
 	 * Set the poller to use when QueueChannels are used.
 	 */
 	public void setPoller(PollerMetadata poller) {
 		this.poller = poller;
+	}
+
+	/**
+	 * Set the size of the queue when using {@link QueueChannel}s.
+	 */
+	public void setQueueSize(int queueSize) {
+		this.queueSize = queueSize;
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -46,8 +46,6 @@ import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.channel.PublishSubscribeChannel;
-import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.expression.IntegrationEvaluationContextAware;
 import org.springframework.integration.support.MessageBuilder;
@@ -88,8 +86,6 @@ public abstract class MessageBusSupport
 	protected final Log logger = LogFactory.getLog(getClass());
 
 	private volatile AbstractApplicationContext applicationContext;
-
-	private int queueSize = Integer.MAX_VALUE;
 
 	private volatile MultiTypeCodec<Object> codec;
 
@@ -155,29 +151,6 @@ public abstract class MessageBusSupport
 		}
 	};
 
-	/**
-	 * Used to create and customize {@link QueueChannel}s when the binding operation involves aliased names.
-	 */
-	protected final SharedChannelProvider<QueueChannel> queueChannelProvider = new SharedChannelProvider<QueueChannel>(
-			QueueChannel.class) {
-
-		@Override
-		protected QueueChannel createSharedChannel(String name) {
-			QueueChannel queueChannel = new QueueChannel(queueSize);
-			return queueChannel;
-		}
-	};
-
-	protected final SharedChannelProvider<PublishSubscribeChannel> pubsubChannelProvider = new SharedChannelProvider<PublishSubscribeChannel>(
-			PublishSubscribeChannel.class) {
-
-		@Override
-		protected PublishSubscribeChannel createSharedChannel(String name) {
-			PublishSubscribeChannel publishSubscribeChannel = new PublishSubscribeChannel();
-			return publishSubscribeChannel;
-		}
-	};
-
 	protected volatile long defaultBackOffInitialInterval = DEFAULT_BACKOFF_INITIAL_INTERVAL;
 
 	protected volatile long defaultBackOffMaxInterval = DEFAULT_BACKOFF_MAX_INTERVAL;
@@ -200,13 +173,6 @@ public abstract class MessageBusSupport
 
 	protected ConfigurableListableBeanFactory getBeanFactory() {
 		return this.applicationContext.getBeanFactory();
-	}
-
-	/**
-	 * Set the size of the queue when using {@link QueueChannel}s.
-	 */
-	public void setQueueSize(int queueSize) {
-		this.queueSize = queueSize;
 	}
 
 	public void setCodec(MultiTypeCodec<Object> codec) {
@@ -888,7 +854,7 @@ public abstract class MessageBusSupport
 
 		private final Class<T> requiredType;
 
-		private SharedChannelProvider(Class<T> clazz) {
+		protected SharedChannelProvider(Class<T> clazz) {
 			this.requiredType = clazz;
 		}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/LocalMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/LocalMessageBusTests.java
@@ -18,15 +18,21 @@ package org.springframework.xd.dirt.integration.bus;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.interceptor.WireTap;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.utils.IntegrationUtils;
@@ -34,6 +40,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.GenericMessage;
 
 /**
  * @author Gary Russell
@@ -67,6 +74,46 @@ public class LocalMessageBusTests extends AbstractMessageBusTests {
 		verifyPayloadConversion(new TestPayload(), bus);
 	}
 
+	@Test
+	public void testTapDoesntHurtStream() throws Exception {
+		LocalMessageBus bus = (LocalMessageBus) getMessageBus();
+		DirectChannel moduleOutputChannel = new DirectChannel();
+		moduleOutputChannel.setBeanName("bangOut");
+		DirectChannel tapChannel = new DirectChannel();
+		tapChannel.setBeanName("tapChannel");
+		WireTap tap = new WireTap(tapChannel);
+		moduleOutputChannel.addInterceptor(tap);
+		bus.bindProducer("bang.0", moduleOutputChannel, null);
+		final AtomicBoolean messageReceived = new AtomicBoolean();
+		final AtomicReference<Thread> streamThread = new AtomicReference<Thread>();
+		bus.bindConsumer("bang.0", new DirectChannel() {
+
+			@Override
+			protected boolean doSend(Message<?> message, long timeout) {
+				messageReceived.set(true);
+				streamThread.set(Thread.currentThread());
+				return true;
+			}
+		}, null);
+		final CountDownLatch tapped = new CountDownLatch(1);
+		final AtomicReference<Thread> tapThread = new AtomicReference<Thread>();
+		bus.bindPubSubProducer("tap:stream:bang.0", tapChannel, null);
+		bus.bindPubSubConsumer("tap:stream:bang.0", new DirectChannel() {
+
+			@Override
+			protected boolean doSend(Message<?> message, long timeout) {
+				tapped.countDown();
+				tapThread.set(Thread.currentThread());
+				throw new RuntimeException("bang");
+			}
+		}, null);
+		moduleOutputChannel.send(new GenericMessage<String>("Foo"));
+		assertTrue(tapped.await(10, TimeUnit.SECONDS));
+		assertTrue(messageReceived.get());
+		assertSame(Thread.currentThread(), streamThread.get());
+		assertNotNull(tapThread.get());
+		assertNotSame(Thread.currentThread(), tapThread.get());
+	}
 
 	private void verifyPayloadConversion(final Object expectedValue, final LocalMessageBus bus) {
 		DirectChannel myChannel = new DirectChannel();


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2201

When using a `LocalMessageBus`, if a tap throws
an exception, the message is not sent to the next
module in the stream.
- Set `ignoreFailures` on the wire tap's PubSub channel.
- Run taps on the local message bus's `executor`.
- Move fields in `MessageBusSupport` that are only used by `LocalMessageBus` to the `LocalMessageBus`.
