### PR TITLE
[Sprint: 38] XD-2123 Support for kerberized hdfs

### DIFF
--- a/modules/sink/hdfs-dataset/config/hdfs-dataset.xml
+++ b/modules/sink/hdfs-dataset/config/hdfs-dataset.xml
@@ -4,11 +4,13 @@
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-hadoop="http://www.springframework.org/schema/integration/hadoop"
 	xmlns:task="http://www.springframework.org/schema/task"
+	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/hadoop http://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<int:channel id="input"/>
@@ -58,8 +60,18 @@
 		<property name="writerCacheSize" value="${writerCacheSize:null}"/>
 	</bean>
 
-	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
+	<context:property-placeholder location="${xd.config.home}/hadoop.properties"/>
+
+	<hdp:configuration
+		register-url-handler="false"
+		properties-location="${xd.config.home}/hadoop.properties"
+		security-method="${hadoop.security.authentication:}"
+		user-keytab="${spring.hadoop.userKeytab:}"
+		user-principal="${spring.hadoop.userPrincipal:}"
+		namenode-principal="${dfs.namenode.kerberos.principal:}"
+		rm-manager-principal="${yarn.resourcemanager.principal:}">
 		fs.defaultFS=${fsUri}
 	</hdp:configuration>
+
 
 </beans>

--- a/modules/sink/hdfs/config/hdfs.xml
+++ b/modules/sink/hdfs/config/hdfs.xml
@@ -2,6 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:task="http://www.springframework.org/schema/task"
+	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-hadoop="http://www.springframework.org/schema/integration/hadoop"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
@@ -9,13 +10,23 @@
 		http://www.springframework.org/schema/integration/hadoop http://www.springframework.org/schema/integration/hadoop/spring-integration-hadoop.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd">
 
 	<!-- TODO: these should be defined globally -->
 	<task:executor id="taskExecutor" pool-size="1"/>
 	<task:scheduler id="taskScheduler" pool-size="1"/>
 
-	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
+	<context:property-placeholder location="${xd.config.home}/hadoop.properties"/>
+
+	<hdp:configuration
+		register-url-handler="false"
+		properties-location="${xd.config.home}/hadoop.properties"
+		security-method="${hadoop.security.authentication:}"
+		user-keytab="${spring.hadoop.userKeytab:}"
+		user-principal="${spring.hadoop.userPrincipal:}"
+		namenode-principal="${dfs.namenode.kerberos.principal:}"
+		rm-manager-principal="${yarn.resourcemanager.principal:}">
 		fs.defaultFS=${fsUri}
 	</hdp:configuration>
 

--- a/spring-xd-shell/config/hadoop.properties
+++ b/spring-xd-shell/config/hadoop.properties
@@ -1,0 +1,2 @@
+# Use servers.yml to change URI for namenode
+# You can add additional properties in this file

--- a/spring-xd-shell/src/main/resources/META-INF/spring/spring-shell-plugin.xml
+++ b/spring-xd-shell/src/main/resources/META-INF/spring/spring-shell-plugin.xml
@@ -9,7 +9,15 @@
 
 	<context:component-scan base-package="org.springframework.xd.shell" />
 
-	<hadoop:configuration>
+	<context:property-placeholder location="hadoop.properties"/>
+
+	<hadoop:configuration
+		properties-location="hadoop.properties"
+		security-method="${hadoop.security.authentication:}"
+		user-keytab="${spring.hadoop.userKeytab:}"
+		user-principal="${spring.hadoop.userPrincipal:}"
+		namenode-principal="${dfs.namenode.kerberos.principal:}"
+		rm-manager-principal="${yarn.resourcemanager.principal:}">
 		fs.defaultFS=
 	</hadoop:configuration>
 


### PR DESCRIPTION
There is no specific tests for kerberos other than I tested singlenode against
kerberized and non-kerberized hadoop instance.
- Modify hdfs.xml and hdfs-dataset.xml to read values
  via from hadoop.properties via property placeholder.
  This is needed for security config to kick in because
  reading properties properties-location in hadoop namespace
  is not enough. Default values for these are empty which
  gets normal hadoop configuration.
- Added same tweaks to shell's shdp namespace usage and
  added empty hadoop.properties file.
- Kerberized config is then enabled i.e. using below
  propertys in hadoop.properties:
  hadoop.security.authorization=true
  hadoop.security.authentication=kerberos
  dfs.namenode.kerberos.principal=hdfs/neo@LOCALDOMAIN
  yarn.resourcemanager.principal=yarn/neo@LOCALDOMAIN
  spring.hadoop.userKeytab=/usr/local/hadoops/janne.keytab
  spring.hadoop.userPrincipal=janne/neo
- Use of userKeytab and userPrincipal enables
  automatic login using kerberos keytab file.
