### PR TITLE
[Sprint: 38] Fix classpath for SparkTasklet

### DIFF
--- a/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/tasklet/SparkTasklet.java
+++ b/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/tasklet/SparkTasklet.java
@@ -229,13 +229,13 @@ public class SparkTasklet implements Tasklet, EnvironmentAware, StepExecutionLis
 		}
 		List<String> classPath = new ArrayList<String>();
 		for (URL url : thisClassLoader.getURLs()) {
-			String file = url.getFile().split("\\!", 2)[0];
+			String file = url.getFile().split("\\!/", 2)[0];
 			if (file.endsWith(".jar")) {
 				classPath.add(file);
 			}
 		}
 		for (URL url : contextClassLoader.getURLs()) {
-			String file = url.getFile().split("\\!", 2)[0];
+			String file = url.getFile().split("\\!/", 2)[0];
 			if (file.endsWith(".jar") && !classPath.contains(file)) {
 				classPath.add(file);
 			}


### PR DESCRIPTION
- If classloader url.getFile() contains `!` in the path, it gets appended to the spark classpath.
  - Split file path by removing the exclamation character
