### PR TITLE
XD-2203 Make sure Spring XD's PDF reference doc has right release revision references

### DIFF
--- a/gradle/build-docs.gradle
+++ b/gradle/build-docs.gradle
@@ -14,12 +14,6 @@ buildscript {
 
 }
 
-ext {
-	// Drives the Asciidoctor version used
-	//asciidoctorjVersion =  '1.5.0.preview.7'
-}
-
-
 import org.ajoberstar.grgit.*
 import org.ajoberstar.grgit.auth.AuthConfig
 import org.apache.tools.ant.filters.TokenFilter


### PR DESCRIPTION
- Add `appversion` attribute under the `asciidoctorDocbook` Gradle task
- Update `asciidoctor-gradle-plugin` to `1.5.0`
- Update `docbook-reference-plugin` to `0.3.0`
- Add `compat-mode` attribute under the `asciidoctorDocbook` Gradle task
- Add `compat-mode` attribute under the `asciidoctorHtml` Gradle task

Jira: https://jira.spring.io/browse/XD-2203
