### PR TITLE
XD-2344 UI should quote parameters containing a space

### DIFF
--- a/spring-xd-ui/app/scripts/job/controllers/module-create-definition.js
+++ b/spring-xd-ui/app/scripts/job/controllers/module-create-definition.js
@@ -83,8 +83,17 @@ define([], function () {
           for (var i = 0; i < arrayLength; i++) {
             var parameter = jobDefinition.parameters[i];
             if (parameter.value) {
-              $scope.calculatedDefinition = $scope.calculatedDefinition + ' --' + parameter.name + '=' + parameter.value;
+              var parameterValueToUse = escapeStringIfNecessary(parameter.value);
+              $scope.calculatedDefinition = $scope.calculatedDefinition + ' --' + parameter.name + '=' + parameterValueToUse;
             }
+          }
+        }
+        function escapeStringIfNecessary(string) {
+          if (string && /\s/g.test(string)) {
+            return '"' + string + '"';
+          }
+          else {
+            return string;
           }
         }
       });


### PR DESCRIPTION
- Added a check that wraps the parameter value into quotes ONLY IF the string contains a whitespace (incl. tab charater)
