### PR TITLE
XD-2408 Fix tap re-deploy issue

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -246,7 +246,9 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 		MessageChannel outputChannel = module.getComponent(MODULE_OUTPUT_CHANNEL, MessageChannel.class);
 		if (outputChannel != null) {
 			messageBus.unbindProducer(getOutputChannelName(module), outputChannel);
-			unbindTapChannel(buildTapChannelName(module));
+			String tapChannelName = buildTapChannelName(module);
+			unbindTapChannel(tapChannelName);
+			tappableChannels.remove(tapChannelName);
 			if (logger.isDebugEnabled()) {
 				logger.debug("Unbound producer(s) for " + module.toString());
 			}
@@ -255,7 +257,7 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 
 	private void unbindTapChannel(String tapChannelName) {
 		// Should this be unbindProducer() as there won't be multiple producers on the tap channel.
-		MessageChannel tappedChannel = tappableChannels.remove(tapChannelName);
+		MessageChannel tappedChannel = tappableChannels.get(tapChannelName);
 		if (tappedChannel instanceof ChannelInterceptorAware) {
 			ChannelInterceptorAware interceptorAware = ((ChannelInterceptorAware) tappedChannel);
 			List<ChannelInterceptor> interceptors = new ArrayList<ChannelInterceptor>();


### PR DESCRIPTION
- When a tap is undeployed, the associated tappable module output channel entry was
  removed from plugin. We should remove the entry only if the main stream is
  undeployed.
  - This way when a tap is re-deployed, the corresponding tap channel
    is bound to the module output channel.
