### PR TITLE
[Sprint: 39] XD-2331: Single node recovery on disconnect / XD-2373: Distributed test should verify container shutdown

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
@@ -403,7 +403,7 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 		 */
 		@Override
 		public void onResume(CuratorFramework client) {
-			logger.info("Admin {} connection resumed", getId());
+			logger.info("Admin {} connection resumed, client state: {}", getId(), client.getState());
 			registerWithZooKeeper(client);
 			requestLeadership(client);
 		}

--- a/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/DefaultDistributedTestSupport.java
+++ b/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/DefaultDistributedTestSupport.java
@@ -222,19 +222,21 @@ public class DefaultDistributedTestSupport implements DistributedTestSupport {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void shutdownContainers() {
+	public void shutdownContainers() throws InterruptedException {
 		for (Iterator<Map.Entry<Long, JavaApplication<SimpleJavaApplication>>> iterator =
 					mapPidContainers.entrySet().iterator(); iterator.hasNext();) {
 			iterator.next().getValue().close();
 			iterator.remove();
 		}
+		waitForContainers();
+		logger.info("All containers shutdown");
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void shutdownAll() {
+	public void shutdownAll() throws InterruptedException {
 		shutdownContainers();
 		if (adminServer != null) {
 			try {

--- a/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/DistributedTestSupport.java
+++ b/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/DistributedTestSupport.java
@@ -88,14 +88,20 @@ public interface DistributedTestSupport {
 
 	/**
 	 * Shut down all containers started via {@link #startContainer}.
+	 * This method will block the executing thread until the
+	 * admin server indicates that there are no containers running.
+	 *
+	 * @throws InterruptedException
 	 */
-	void shutdownContainers();
+	void shutdownContainers() throws InterruptedException;
 
 	/**
 	 * Shut down all servers started, including those started via
 	 * {@link #startup} and all containers started via
 	 * {@link #startContainer}.
+	 *
+	 * @throws java.lang.InterruptedException
 	 */
-	void shutdownAll();
+	void shutdownAll() throws InterruptedException;
 }
 

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/DistributedTestSuite.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/DistributedTestSuite.java
@@ -67,7 +67,7 @@ public class DistributedTestSuite {
 	 * @see DistributedTestSupport#shutdownAll
 	 */
 	@AfterClass
-	public static void afterClass() {
+	public static void afterClass() throws InterruptedException {
 		distributedTestSupport.shutdownAll();
 	}
 


### PR DESCRIPTION
When a single node server disconnects and reconnects to ZK (for instance when running on a laptop that goes to sleep) the leader election routine was failing an assert because the `CuratorFramework` was not in `STARTED` state. This was happening because the container listener forces a client shutdown and reconnect to guarantee that all its ephemeral nodes are cleaned up. This connection is the same one being passed to the leader election routine.

The fix is to only force the container to recreate the `CuratorFramework` if it is not in the `STARTED` state. The state transition of `SUSPENDED` -> `LOST` -> `RECONNECTED` where the framework has restarted seems to happen consistently when the machine running the process goes to sleep and wakes up.

XD-2373: Distributed test should verify container shutdown

After each test, block execution until admin indicates that all containers have been unregistered from ZK.

Destroy streams before container shutdown

Increased state transition timeout

Some tests require deployment to a container after it joins the cluster. Since there is a mandatory waiting period before new containers are assigned deployments (15 seconds by default) the wait period for the verify stream/job state methods has been increased.
