### PR TITLE
Improve SimpleDateFormat instantiation in TupleBuilder

### DIFF
--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleBuilder.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleBuilder.java
@@ -53,17 +53,24 @@ public class TupleBuilder {
 
 	private static Converter<String, Tuple> stringToTupleConverter = new JsonStringToTupleConverter();
 
-	private DateFormat dateFormat = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
-	{
-		dateFormat.setLenient(false);
+	private static ThreadLocal<DateFormat> dateFormat = new ThreadLocal<DateFormat>() {
+
+		@Override
+		protected DateFormat initialValue() {
+			SimpleDateFormat format = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
+			format.setLenient(false);
+			return format;
+		}
+	};
+
+	private static DateFormat getDateFormat() {
+		return dateFormat.get();
 	}
 
 	public static TupleBuilder tuple() {
 		TupleBuilder tb = new TupleBuilder();
 		tb.setNumberFormatFromLocale(DEFAULT_LOCALE);
-		DateFormat dateFormat = new SimpleDateFormat(DEFAULT_DATE_PATTERN);
-		dateFormat.setLenient(false);
-		tb.setDateFormat(dateFormat);
+		tb.setDateFormat(getDateFormat());
 		return tb;
 	}
 


### PR DESCRIPTION
The `TupleBuilder.tuple()` call is very expensive. 
It can affect Spring Integration flow throughput if called for each message.
This pull request replaces the `SimpleDateFormat` instantiation with static `ThreadLocal` variable.
