### PR TITLE
[Sprint: 39] XD-2429 [master + backport] Bind Producer Before Consumer

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -117,16 +117,13 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 
 	/**
 	 * Bind input/output channel of the module's message consumer/producers to {@link MessageBus}'s message
-	 * source/target entities.
+	 * source/target entities. The producer must be bound first so that messages can immediately
+	 * start flowing from the consumer.
 	 *
 	 * @param module the module whose consumer and producers to bind to the {@link MessageBus}.
 	 */
 	protected final void bindConsumerAndProducers(Module module) {
 		Properties[] properties = extractConsumerProducerProperties(module);
-		MessageChannel inputChannel = module.getComponent(MODULE_INPUT_CHANNEL, MessageChannel.class);
-		if (inputChannel != null) {
-			bindMessageConsumer(inputChannel, getInputChannelName(module), properties[0]);
-		}
 		MessageChannel outputChannel = module.getComponent(MODULE_OUTPUT_CHANNEL, MessageChannel.class);
 		if (outputChannel != null) {
 			bindMessageProducer(outputChannel, getOutputChannelName(module), properties[1]);
@@ -135,6 +132,10 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 			if (isTapActive(tapChannelName)) {
 				createAndBindTapChannel(tapChannelName, outputChannel);
 			}
+		}
+		MessageChannel inputChannel = module.getComponent(MODULE_INPUT_CHANNEL, MessageChannel.class);
+		if (inputChannel != null) {
+			bindMessageConsumer(inputChannel, getInputChannelName(module), properties[0]);
 		}
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
@@ -16,15 +16,20 @@
 
 package org.springframework.xd.dirt.plugins.stream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.same;
-import static org.mockito.Mockito.*;
-import static org.springframework.xd.module.options.spi.ModulePlaceholders.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_STREAM_NAME_KEY;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.After;
 import org.junit.Before;
@@ -35,9 +40,17 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.interceptor.WireTap;
+import org.springframework.integration.endpoint.EventDrivenConsumer;
+import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.validation.BindException;
+import org.springframework.xd.dirt.integration.bus.LocalMessageBus;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.zookeeper.EmbeddedZooKeeper;
 import org.springframework.xd.dirt.zookeeper.Paths;
@@ -164,4 +177,78 @@ public class StreamPluginTests {
 		assertEquals(1, interceptors.size());
 		assertTrue(interceptors.get(0) instanceof WireTap);
 	}
+
+	@Test
+	// XD 2429
+	public void testBindOrder() {
+		ModuleDefinition moduleDefinition = ModuleDefinitions.dummy("testing", ModuleType.processor);
+		Module module = mock(Module.class);
+		when(module.getDescriptor()).thenReturn(new ModuleDescriptor.Builder()
+				.setGroup("foo")
+				.setIndex(1)
+				.setModuleDefinition(moduleDefinition)
+				.build());
+		when(module.getType()).thenReturn(moduleDefinition.getType());
+		when(module.getName()).thenReturn(moduleDefinition.getName());
+		final AtomicBoolean messageReceived = new AtomicBoolean();
+		LocalMessageBus bus = new LocalMessageBus() {
+
+			final AtomicBoolean consumerBound = new AtomicBoolean();
+
+			@Override
+			public void bindProducer(String name, final MessageChannel moduleOutputChannel, Properties properties) {
+
+				final MessageHandler handler = new MessageHandler() {
+
+					@Override
+					public void handleMessage(Message<?> message) throws MessagingException {
+						messageReceived.set(true);
+					}
+
+				};
+
+				if (consumerBound.get()) {
+					Executors.newSingleThreadExecutor().execute(new Runnable() {
+
+						@Override
+						public void run() {
+							try {
+								Thread.sleep(1000); //delay the bind to exhibit the XD-2429 behavior
+							}
+							catch (InterruptedException e) {
+								Thread.currentThread().interrupt();
+							}
+							((SubscribableChannel) moduleOutputChannel).subscribe(handler);
+						}
+					});
+				}
+				else {
+					((SubscribableChannel) moduleOutputChannel).subscribe(handler);
+				}
+			}
+
+			@Override
+			public void bindConsumer(String name, MessageChannel moduleInputChannel, Properties properties) {
+				this.consumerBound.set(true);
+			}
+
+		};
+		when(module.getComponent(MessageBus.class)).thenReturn(bus);
+		DirectChannel input = new DirectChannel();
+		input.setBeanName("test.input.channel");
+		DirectChannel output = new DirectChannel();
+		output.setBeanName("test.output.channel");
+		BridgeHandler handler = new BridgeHandler();
+		handler.setOutputChannel(output);
+		EventDrivenConsumer bridge = new EventDrivenConsumer(input, handler);
+		bridge.start();
+		when(module.getComponent("input", MessageChannel.class)).thenReturn(input);
+		when(module.getComponent("output", MessageChannel.class)).thenReturn(output);
+		StreamPlugin plugin = new StreamPlugin(bus, zkConnection);
+		plugin.preProcessModule(module);
+		plugin.postProcessModule(module);
+		input.send(new GenericMessage<String>("foo"));
+		assertTrue(messageReceived.get());
+	}
+
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractDistributedTransportSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractDistributedTransportSingleNodeStreamDeploymentIntegrationTests.java
@@ -16,21 +16,23 @@
 
 package org.springframework.xd.dirt.stream;
 
-import org.junit.Test;
-import org.springframework.integration.test.util.SocketUtils;
-import org.springframework.xd.dirt.integration.bus.Binding;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import org.springframework.integration.test.util.SocketUtils;
+import org.springframework.xd.dirt.integration.bus.Binding;
 
 /**
  * Base class for testing non-local transports, such as RabbitMQ and Redis.
  *
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentIntegrationTests extends
 		AbstractSingleNodeStreamDeploymentIntegrationTests {
@@ -93,7 +95,7 @@ public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentInte
 		Map<String, String> props = new HashMap<String, String>();
 		props.put("module.http.count", "0");
 		props.put("module.log.count", "3");
-		integrationSupport.deployStream(sd, props,/*allowIncomplete*/ true);
+		integrationSupport.deployStream(sd, props,/*allowIncomplete*/true);
 		List<Binding> bindings = getMessageBusBindingsForStream(streamName);
 		assertEquals(2, bindings.size());
 		Binding consumerBinding = bindings.get(0);
@@ -110,7 +112,7 @@ public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentInte
 		Map<String, String> props = new HashMap<String, String>();
 		props.put("module.*.count", "0");
 		props.put("module.log.count", "3");
-		integrationSupport.deployStream(sd, props,/*allowIncomplete*/ true);
+		integrationSupport.deployStream(sd, props,/*allowIncomplete*/true);
 		List<Binding> bindings = getMessageBusBindingsForStream(streamName);
 		assertEquals(2, bindings.size());
 		Binding consumerBinding = bindings.get(0);
@@ -152,8 +154,8 @@ public abstract class AbstractDistributedTransportSingleNodeStreamDeploymentInte
 		List<Binding> bindings = getMessageBusBindingsForStream(streamName);
 		assertEquals(4, bindings.size());
 		Binding logConsumerBinding = bindings.get(0);
-		Binding filterConsumerBinding = bindings.get(1);
-		Binding filterProducerBinding = bindings.get(2);
+		Binding filterProducerBinding = bindings.get(1);
+		Binding filterConsumerBinding = bindings.get(2);
 		Binding httpProducerBinding = bindings.get(3);
 		assertEquals("inbound." + streamName + ".1", logConsumerBinding.getEndpoint().getComponentName());
 		assertEquals("consumer", logConsumerBinding.getType());


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2429

When tapping a fire hose, it was possible to get `Dispatcher has no subscriber`
errors on the first module's `output` channel.

This was because the `AbstractMessageBusBinderPlugin` bound the consumer (`input`)
first and messages start flowing before the producer (`output` is bound.
If the output channel is a `SubscribableChannel`, `Dispatcher has no subscribers`
resulted.

Change the bind order so that the output channel is bound first, then the
inbound channel. Similar to the way we bind modules right-to-left when using
a `LocalMessageBus`, we need to bind the module itself right-to-left.

This is only a problem when a stream starts with a tap because, with a "normal" stream,
the last module to be bound is the source, and we don't start it until the source itself
is bound; hence no messages flow to the downstream processors so it doesn't matter what
order their channels are bound.

With a tap, messages can start flowing from the tap as soon as the input channel is bound to the bus.
