### PR TITLE
[Sprint: 40] XD-2409 Changing correlation-strategy-expression

### DIFF
--- a/modules/sink/hdfs-dataset/config/hdfs-dataset.xml
+++ b/modules/sink/hdfs-dataset/config/hdfs-dataset.xml
@@ -17,7 +17,7 @@
 
 	<int:aggregator
 			input-channel="input"
-			correlation-strategy-expression="payload.getClass().getName()"
+			correlation-strategy-expression="payload.class.name"
 			release-strategy-expression="size() == ${batchSize}"
 			expire-groups-upon-completion="true"
 			send-partial-result-on-expiry="true"


### PR DESCRIPTION
- this will avoid some issues ecountered with SpEL (SPR-12502)
- using "payload.class.name" seems to work in all cases
