### PR TITLE
[Sprint: 40] XD-2496 - Refactor use of getContainerHostForSource in integration tests

### DIFF
--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ContainerResolver.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ContainerResolver.java
@@ -1,0 +1,155 @@
+package org.springframework.xd.integration.fixtures;
+
+import org.springframework.util.Assert;
+import org.springframework.xd.integration.util.StreamUtils;
+import org.springframework.xd.rest.domain.ModuleMetadataResource;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Resolve runtime hosts for modules.
+ *
+ * @author Mark Pollack
+ */
+public class ContainerResolver {
+
+    private final URL adminServer;
+    private final Map<String, String> containers;
+    private final String defaultStreamName;
+
+
+    public ContainerResolver(URL adminServer, Map<String, String> containers, String defaultStreamName) {
+        this.adminServer = adminServer;
+        this.containers = containers;
+        Assert.hasText(defaultStreamName, "stream name can not be empty nor null");
+        this.defaultStreamName = defaultStreamName;
+    }
+
+    /**
+     * Gets the URL of the container for the source being tested.
+     *
+     * @return The URL that contains the source.
+     */
+    public URL getContainerUrlForSource() {
+        return getContainerUrlForSource(defaultStreamName);
+    }
+
+    /**
+     * Gets the URL of the container where the source was deployed using default XD Port.
+     *
+     * @param streamName Used to find the container that contains the source.
+     * @return The URL that contains the source.
+     */
+    public URL getContainerUrlForSource(String streamName) {
+        return getContainerHostForURL(streamName, ModuleType.source);
+    }
+
+    /**
+     * Gets the URL of the container for the sink being tested.
+     *
+     * @return The URL that contains the sink.
+     */
+    public URL getContainerUrlForSink() {
+        return getContainerUrlForSink(defaultStreamName);
+    }
+
+    /**
+     * Gets the URL of the container where the sink was deployed using default XD Port.
+     *
+     * @param streamName Used to find the container that contains the sink.
+     * @return The URL that contains the sink.
+     */
+    public URL getContainerUrlForSink(String streamName) {
+        return getContainerHostForURL(streamName, ModuleType.sink);
+    }
+
+    /**
+     * Gets the URL of the container where the processor was deployed
+     *
+     * @return The URL that contains the sink.
+     */
+
+    public URL getContainerUrlForProcessor() {
+        return getContainerUrlForProcessor(defaultStreamName);
+    }
+
+
+    /**
+     * Gets the URL of the container where the processor was deployed
+     *
+     * @param streamName Used to find the container that contains the processor.
+     * @return The URL that contains the processor.
+     */
+    public URL getContainerUrlForProcessor(String streamName) {
+
+        return getContainerHostForURL(streamName, ModuleType.processor);
+    }
+
+    /**
+     * Gets the host of the container where the source was deployed
+     *
+     * @return The host that contains the source.
+     */
+    public String getContainerHostForSource() {
+        return getContainerHostForSource(defaultStreamName);
+    }
+
+    /**
+     * Gets the host of the container where the source was deployed
+     *
+     * @param streamName Used to find the container that contains the source.
+     * @return The host that contains the source.
+     */
+    public String getContainerHostForSource(String streamName) {
+        return getContainerHostForModulePrefix(streamName, ModuleType.source);
+    }
+
+    /**
+     * Finds the container URL where the module is deployed with the stream name & module type
+     *
+     * @param streamName The name of the stream that the module is deployed
+     * @param moduleType The type of module that we are seeking
+     * @return the container url.
+     */
+    private URL getContainerHostForURL(String streamName, ModuleType moduleType) {
+        URL result = null;
+        try {
+            result = new URL("http://"
+                    + getContainerHostForModulePrefix(streamName, moduleType) + ":" + adminServer.getPort());
+        }
+        catch (MalformedURLException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+        return result;
+    }
+
+
+    /**
+     * Gets the URL of the container where the module
+     *
+     * @param streamName Used construct the module id prefix.
+     * @return The URL that contains the module.
+     */
+    public String getContainerHostForModulePrefix(String streamName, ModuleType moduleType) {
+        Assert.hasText(streamName, "stream name can not be empty nor null");
+        String moduleIdPrefix = streamName + "." + moduleType + ".";
+        Iterator<ModuleMetadataResource> resourceIter = StreamUtils.getRuntimeModules(adminServer).iterator();
+        ArrayList<String> containerIds = new ArrayList<String>();
+        while (resourceIter.hasNext()) {
+            ModuleMetadataResource resource = resourceIter.next();
+            if (resource.getModuleId().startsWith(moduleIdPrefix)) {
+                containerIds.add(resource.getContainerId());
+            }
+        }
+        Assert.isTrue(
+                containerIds.size() == 1,
+                "Test require that module to be deployed to only one container. It was deployed to "
+                        + containerIds.size() + " containers");
+        return containers.get(containerIds.get(0));
+    }
+
+}

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ModuleFixture.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ModuleFixture.java
@@ -1,0 +1,26 @@
+package org.springframework.xd.integration.fixtures;
+
+/**
+ * Created by mpollack on 12/11/14.
+ */
+public class ModuleFixture {
+
+
+    private ContainerResolver containerResolver;
+
+    /**
+     * Set the container resolver to back sources that depend on runtime container information, e.g. httpSource
+     * @param containerResolver resolves stream and module names to runtime host and ports
+     */
+    public void setContainerResolver(ContainerResolver containerResolver) {
+        this.containerResolver = containerResolver;
+    }
+
+    /**
+     * Get the container resolver
+     * @return container resolver
+     */
+    public ContainerResolver getContainerResolver() {
+        return containerResolver;
+    }
+}

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ModuleType.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ModuleType.java
@@ -1,0 +1,10 @@
+package org.springframework.xd.integration.fixtures;
+
+/**
+ * Enumeration of different module types
+ *
+ * @author Mark Pollack
+ */
+public enum ModuleType {
+    sink, source, processor, job
+}

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sinks.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sinks.java
@@ -35,7 +35,7 @@ import org.springframework.xd.test.fixtures.KafkaSink;
  *
  * @author Glenn Renfro
  */
-public class Sinks {
+public class Sinks extends ModuleFixture {
 
 	private TcpSink tcpSink;
 
@@ -73,6 +73,15 @@ public class Sinks {
 	 */
 	public TcpSink tcp(String host) {
 		return TcpSink.withDefaults(host);
+	}
+
+	/**
+	 * Construct a new TcpSink with the target host resolved at runtime from the default stream name.
+	 *
+	 * @return an instance of TcpSource configured with host and port of http module deployed at runtime.
+	 */
+	public TcpSink tcpSink() {
+		return tcp(getContainerResolver().getContainerHostForSource());
 	}
 
 

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
@@ -34,6 +34,8 @@ import org.springframework.xd.test.fixtures.TwitterSearchSource;
 import org.springframework.xd.test.fixtures.TwitterStreamSource;
 import org.springframework.xd.test.fixtures.KafkaSource;
 
+import java.util.Map;
+
 
 /**
  * A convenience class for creating instances of sources to be used for integration testing.
@@ -43,9 +45,12 @@ import org.springframework.xd.test.fixtures.KafkaSource;
  * @author Glenn Renfro
  * @author Mark Pollack
  */
-public class Sources {
+public class Sources extends ModuleFixture {
 
 	private final XdEnvironment xdEnvironment;
+	
+	private Map<String, String> containers;
+
 
 	/**
 	 * Construct a new Sources instance using the provided environment.
@@ -88,6 +93,23 @@ public class Sources {
 		return new SimpleHttpSource(host, port);
 	}
 
+	/**
+	 * Create an instance of the http source with the target host resolved at runtime from the stream name.
+	 *
+	 * @param streamName the name of the stream that has an http source module deployed
+	 * @return an instance of HttpSource configured with host and port of http module deployed at runtime.
+	 */
+	public SimpleHttpSource httpSource(String streamName) {
+		return http(getContainerResolver().getContainerHostForSource(streamName));
+	}
+
+	/**
+	 * Create an instance of the http source with the target host resolved at runtime from the default stream name.
+	 * @return an instance of HttpSource configured with host and port of http module deployed at runtime.
+	 */
+	public SimpleHttpSource httpSource() {
+		return http(getContainerResolver().getContainerHostForSource());
+	}
 
 	/**
 	 * Construct a new TcpSource with the default target host localhost and port (1234)
@@ -117,6 +139,26 @@ public class Sources {
 	 */
 	public TcpSource tcp(String host, int port) {
 		return new TcpSource(host, port);
+	}
+
+
+	/**
+	 * Construct a new TcpSource with the target host resolved at runtime from the default stream name.
+	 *
+	 * @return an instance of TcpSource configured with host and port of tcp module deployed at runtime.
+	 */
+	public TcpSource tcpSource() {
+		return new TcpSource(getContainerResolver().getContainerHostForSource());
+	}
+
+	/**
+	 * Construct a new TcpSource with the target host resolved at runtime from the stream name.
+	 *
+	 * @param streamName the name of the stream that has an tcp source module deployed
+	 * @return an instance of TcpSource configured with host and port of http module deployed at runtime.
+	 */
+	public TcpSource tcpSource(String streamName) {
+		return new TcpSource(getContainerResolver().getContainerHostForSource(streamName));
 	}
 
 	/**
@@ -202,7 +244,7 @@ public class Sources {
 	 * @param host the ip of the machine where simulated syslog traffic will be sent.
 	 * @return an instance of SyslogTcpSource.
 	 */
-	public SyslogTcpSource syslogTcpSource(String host) {
+	public SyslogTcpSource syslogTcp(String host) {
 		return SyslogTcpSource.withDefaults(host);
 	}
 
@@ -211,8 +253,17 @@ public class Sources {
 	 *
 	 * @return an instance of SyslogTcpSource.
 	 */
-	public SyslogTcpSource syslogTcpSource() {
+	public SyslogTcpSource syslogTcp() {
 		return SyslogTcpSource.withDefaults();
+	}
+
+	/**
+	 * Construct a new SyslogTcpSource with the target host resolved at runtime from the default stream name.
+	 *
+	 * @return an instance of SyslogTcpSource configured with host and port of syslogtcp source deployed at runtime.
+	 */
+	public SyslogTcpSource syslogTcpSource() {
+		return syslogTcp(getContainerResolver().getContainerHostForSource());
 	}
 
 	/**
@@ -221,7 +272,7 @@ public class Sources {
 	 * @param host the ip of the machine where simulated syslog traffic will be sent.
 	 * @return an instance of SyslogUdpSource.
 	 */
-	public SyslogUdpSource syslogUdpSource(String host) {
+	public SyslogUdpSource syslogUdp(String host) {
 		return SyslogUdpSource.withDefaults(host);
 	}
 
@@ -230,8 +281,17 @@ public class Sources {
 	 *
 	 * @return an instance of SyslogUdpSource.
 	 */
-	public SyslogUdpSource syslogUdpSource() {
+	public SyslogUdpSource syslogUdp() {
 		return SyslogUdpSource.withDefaults();
+	}
+
+	/**
+	 * Construct a new SyslogUdpSource with the target host resolved at runtime from the default stream name.
+	 *
+	 * @return an instance of SyslogTcpSource configured with host and port of syslogudp source deployed at runtime.
+	 */
+	public SyslogUdpSource syslogUdpSource() {
+		return syslogUdp(getContainerResolver().getContainerHostForSource());
 	}
 
 
@@ -272,5 +332,6 @@ public class Sources {
 	public KafkaSource kafkaSource(){
 		return new KafkaSource(xdEnvironment.getKafkaZkConnect());
 	}
+
 
 }

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractJobTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractJobTest.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.util.Assert;
 import org.springframework.xd.integration.fixtures.Jobs;
+import org.springframework.xd.integration.fixtures.ModuleType;
 import org.springframework.xd.integration.util.StreamUtils;
 import org.springframework.xd.rest.client.impl.SpringXDTemplate;
 import org.springframework.xd.rest.domain.JobDefinitionResource;
@@ -119,7 +120,7 @@ public abstract class AbstractJobTest extends AbstractIntegrationTest {
 	 * @return The host that contains the job.
 	 */
 	public String getContainerHostForJob(String jobName) {
-		return getContainerHostForModulePrefix(jobName, ModuleType.job);
+		return this.getContainerResolver().getContainerHostForModulePrefix(jobName, ModuleType.job);
 	}
 
 	/*

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/CountTests.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/CountTests.java
@@ -59,7 +59,7 @@ public class CountTests extends AbstractIntegrationTest {
 		stream(sources.tap(streamName).label(labelName) + XD_TAP_DELIMITER +
 				sinks.counterSink(counterName));
 
-		sources.http(getContainerHostForSource(streamName)).postData(GOOD_TEXT);
+		sources.httpSource(streamName).postData(GOOD_TEXT);
 		waitForMetric(counterName);
 
 		assertEquals("The value expected for this counter was 1", 1, getCount(counterName));
@@ -91,9 +91,9 @@ public class CountTests extends AbstractIntegrationTest {
 				label(goodAndBadLabelName) + XD_TAP_DELIMITER +
 				sinks.counterSink(goodAndBadCounterName));
 
-		sources.http(getContainerHostForSource(streamName)).postData(GOOD_TEXT);
-		sources.http(getContainerHostForSource(streamName)).postData(GOOD_BAD_TEXT);
-		sources.http(getContainerHostForSource(streamName)).postData(BAD_TEXT);
+		sources.httpSource(streamName).postData(GOOD_TEXT);
+		sources.httpSource(streamName).postData(GOOD_BAD_TEXT);
+		sources.httpSource(streamName).postData(BAD_TEXT);
 
 		waitForMetric(afterGoodCounterName);
 		waitForMetric(goodAndBadCounterName);

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FileJdbcTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FileJdbcTest.java
@@ -70,7 +70,8 @@ public class FileJdbcTest extends AbstractJobTest {
 			// Create a stream that writes to a file. This file will be used by the job.
 			stream("dataSender" + i, sources.http("foobar", 9000 + i) + XD_DELIMITER
 					+ sinks.file(FileJdbcJob.DEFAULT_DIRECTORY, DEFAULT_FILE_NAME + "partition" + i).toDSL());
-			sources.http(getContainerHostForSource("dataSender" + i), 9000 + i).postData(data);
+			String host = getContainerResolver().getContainerHostForSource("dataSender" + i);
+			sources.http(host, 9000 + i).postData(data);
 		}
 		waitForXD();
 		job(job.toDSL());
@@ -103,7 +104,7 @@ public class FileJdbcTest extends AbstractJobTest {
 		// Create a stream that writes to a file. This file will be used by the job.
 		stream("dataSender", sources.http() + XD_DELIMITER
 				+ sinks.file(FileJdbcJob.DEFAULT_DIRECTORY, DEFAULT_FILE_NAME).toDSL());
-		sources.http(getContainerHostForSource("dataSender")).postData(data);
+		sources.httpSource("dataSender").postData(data);
 		job(job.toDSL());
 		waitForXD();
 		jobLaunch();

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/GemfireTests.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/GemfireTests.java
@@ -57,7 +57,7 @@ public class GemfireTests extends AbstractIntegrationTest {
 	public void testBasicGemfireSink()  {
 		stream(streamName, sources.http() + XD_DELIMITER + sinks.gemfireServer("Stocks"));
 		String data = "foo";
-		sources.http(getContainerHostForSource(streamName)).postData(data);
+		sources.httpSource(streamName).postData(data);
 		waitForCacheUpdate(streamName);
 		String cachedData = (String) stocks.get(streamName);
 		assertEquals(data, cachedData);
@@ -67,7 +67,7 @@ public class GemfireTests extends AbstractIntegrationTest {
 	public void testGemfireJsonSink()  {
 		stream(streamName, sources.http() + XD_DELIMITER + sinks.gemfireServer("Stocks").json(true));
 		String data = "{\"foo\":\"foo\"}";
-		sources.http(getContainerHostForSource(streamName)).postData(data);
+		sources.httpSource(streamName).postData(data);
 		waitForCacheUpdate(streamName);
 		Object cachedData = stocks.get(streamName);
 

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsJdbcTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsJdbcTest.java
@@ -65,7 +65,7 @@ public class HdfsJdbcTest extends AbstractJobTest {
 		// Create a stream that writes to a hdfs file. This file will be used by the job.
 		stream("dataSender", sources.http() + XD_DELIMITER + sinks.hdfs()
 				.directoryName(HdfsJdbcJob.DEFAULT_DIRECTORY).fileName(DEFAULT_FILE_NAME).toDSL());
-		sources.http(getContainerHostForSource("dataSender")).postData(data);
+		sources.httpSource("dataSender").postData(data);
 		job(job.toDSL());
 		waitForXD();
 		//Undeploy the dataSender stream to force XD to close the file.

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsMongoDbTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsMongoDbTest.java
@@ -59,7 +59,7 @@ public class HdfsMongoDbTest extends AbstractJobTest {
 		// Create a stream that writes to a hdfs file. This file will be used by the job.
 		stream("dataSender", sources.http() + XD_DELIMITER + sinks.hdfs()
 				.directoryName(HdfsMongoDbJob.DEFAULT_DIRECTORY).fileName(HdfsMongoDbJob.DEFAULT_FILE_NAME).toDSL());
-		sources.http(getContainerHostForSource("dataSender")).postData(data);
+		sources.httpSource("dataSender").postData(data);
 		job(job.toDSL());
 		waitForXD();
 		//Undeploy the dataSender stream to force XD to close the file.

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HttpTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HttpTest.java
@@ -53,7 +53,7 @@ public class HttpTest extends AbstractIntegrationTest {
 	private void genericTest(AbstractModuleFixture<?> sink) {
 		String data = UUID.randomUUID().toString();
 		stream(sources.http() + XD_DELIMITER + sink);
-		sources.http(getContainerHostForSource()).postData(data);
+		sources.httpSource().postData(data);
 		assertValid(data, sink);
 		assertReceived(1);
 

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JdbcHdfsTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JdbcHdfsTest.java
@@ -75,7 +75,7 @@ public class JdbcHdfsTest extends AbstractJobTest {
 		// Use a trigger to send data to JDBC
 		stream("dataSender", sources.http() + XD_DELIMITER
 				+ jdbcSink);
-		sources.http(getContainerHostForSource("dataSender")).postData(data);
+		sources.httpSource("dataSender").postData(data);
 
 		job(job.toDSL());
 		waitForXD();
@@ -109,9 +109,9 @@ public class JdbcHdfsTest extends AbstractJobTest {
 		// Use a trigger to send data to JDBC
 		stream("dataSender", sources.http() + XD_DELIMITER
 				+ jdbcSink);
-		sources.http(getContainerHostForSource("dataSender")).postData(data0);
-		sources.http(getContainerHostForSource("dataSender")).postData(data1);
-		sources.http(getContainerHostForSource("dataSender")).postData(data2);
+		sources.httpSource("dataSender").postData(data0);
+		sources.httpSource("dataSender").postData(data1);
+		sources.httpSource("dataSender").postData(data2);
 
 		job(job.toDSL());
 		waitForXD();

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JobCommandTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JobCommandTest.java
@@ -159,7 +159,7 @@ public class JobCommandTest extends AbstractJobTest {
 		// Create a stream that writes to a file. This file will be used by the job.
 		stream("dataSender", sources.http() + XD_DELIMITER
 				+ sinks.file(FileJdbcJob.DEFAULT_DIRECTORY, DEFAULT_FILE_NAME).toDSL());
-		sources.http(getContainerHostForSource("dataSender")).postData(data);
+		sources.httpSource("dataSender").postData(data);
 		job(jobName, job.toDSL(),true);
 		jobLaunch(jobName);
 		String query = String.format("SELECT data FROM %s", tableName);

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/KafkaTests.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/KafkaTests.java
@@ -42,8 +42,7 @@ public class KafkaTests extends AbstractIntegrationTest {
 
 		stream(source + XD_DELIMITER + sinks.file());
 		stream(sinkStreamName, sources.http() + XD_DELIMITER + sink);
-		sources.http(getContainerHostForSource(sinkStreamName)).postData(data);
-
+		sources.httpSource(sinkStreamName).postData(data);
 		assertFileContains(data);
 		assertReceived(1);
 	}

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/ProcessorTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/ProcessorTest.java
@@ -50,13 +50,13 @@ public class ProcessorTest extends AbstractIntegrationTest {
 		String filterContent = "BAD";
 		stream(sources.http() + XD_DELIMITER + " filter --expression=payload=='good' " + XD_DELIMITER
 				+ sinks.file());
-		sources.http(getContainerHostForSource()).postData(filterContent);
+		sources.httpSource().postData(filterContent);
 		waitForXD();
-		assertReceived(getContainerUrlForProcessor(), FILTER_MODULE_NAME, INPUT_CHANNEL_NAME, 1);
-		assertReceived(getContainerUrlForProcessor(), FILTER_MODULE_NAME, OUTPUT_CHANNEL_NAME, 0);
-		assertReceived(getContainerUrlForProcessor(), FILTER_MODULE_NAME, TO_SPEL_CHANNEL_NAME, 1);
-		assertReceived(getContainerUrlForProcessor(), FILTER_MODULE_NAME, TO_SCRIPT_CHANNEL_NAME, 0);
-		assertReceived(getContainerUrlForSink(), HTTP_MODULE_NAME, OUTPUT_CHANNEL_NAME, 1);
+		assertReceivedByProcessor(FILTER_MODULE_NAME, INPUT_CHANNEL_NAME, 1);
+		assertReceivedByProcessor(FILTER_MODULE_NAME, OUTPUT_CHANNEL_NAME, 0);
+		assertReceivedByProcessor(FILTER_MODULE_NAME, TO_SPEL_CHANNEL_NAME, 1);
+		assertReceivedByProcessor(FILTER_MODULE_NAME, TO_SCRIPT_CHANNEL_NAME, 0);
+		assertReceivedBySource(HTTP_MODULE_NAME, OUTPUT_CHANNEL_NAME, 1);
 
 	}
 
@@ -69,7 +69,7 @@ public class ProcessorTest extends AbstractIntegrationTest {
 		String filterContent = "good";
 		stream(sources.http() + XD_DELIMITER + " filter --expression=payload=='" + filterContent + "' " + XD_DELIMITER
 				+ sinks.file());
-		sources.http(getContainerHostForSource()).postData(filterContent);
+		sources.httpSource().postData(filterContent);
 		assertValid(filterContent, sinks.file());
 		assertReceived(1);
 	}
@@ -88,8 +88,8 @@ public class ProcessorTest extends AbstractIntegrationTest {
 				+ "good') " + XD_DELIMITER
 				+ sinks.file());
 
-		sources.http(getContainerHostForSource()).postData(goodData);
-		sources.http(getContainerHostForSource()).postData(badData);
+		sources.httpSource().postData(goodData);
+		sources.httpSource().postData(badData);
 
 		assertValid(goodData, sinks.file());
 		assertReceived(1);
@@ -121,9 +121,9 @@ public class ProcessorTest extends AbstractIntegrationTest {
 				+ " goodandbad: splitter --expression=#jsonPath(payload,'$.id') "
 				+ XD_DELIMITER + sinks.file());
 
-		sources.http(getContainerHostForSource()).postData(goodBadText);
-		sources.http(getContainerHostForSource()).postData(goodGoodText);
-		sources.http(getContainerHostForSource()).postData(badBadText);
+		sources.httpSource().postData(goodBadText);
+		sources.httpSource().postData(goodGoodText);
+		sources.httpSource().postData(badBadText);
 
 		assertValid("A" + idBase, sinks.file());
 		assertReceived(1);

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SyslogTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SyslogTest.java
@@ -36,9 +36,9 @@ public class SyslogTest extends AbstractIntegrationTest {
 	@Test
 	public void testSyslogTcp() {
 		String data = UUID.randomUUID().toString();
-		stream(sources.syslogTcpSource() + XD_DELIMITER
+		stream(sources.syslogTcp() + XD_DELIMITER
 				+ "file");
-		sources.syslogTcpSource(getContainerHostForSource()).sendBytes((data + "\r\n").getBytes());
+		sources.syslogTcpSource().sendBytes((data + "\r\n").getBytes());
 		assertReceived(1);
 		assertFileContains(data);
 	}
@@ -50,9 +50,9 @@ public class SyslogTest extends AbstractIntegrationTest {
 	@Test
 	public void testSyslogUdp() {
 		String data = UUID.randomUUID().toString();
-		stream(sources.syslogUdpSource() + XD_DELIMITER
+		stream(sources.syslogUdp() + XD_DELIMITER
 				+ "file");
-		sources.syslogUdpSource(getContainerHostForSource()).sendBytes((data + "\r\n").getBytes());
+		sources.syslogUdpSource().sendBytes((data + "\r\n").getBytes());
 		assertReceived(1);
 		this.assertFileContains(data);
 	}

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TapTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TapTest.java
@@ -41,7 +41,7 @@ public class TapTest extends AbstractIntegrationTest {
 		stream(sources.tap("dataSender") + XD_TAP_DELIMITER
 				+ sinks.file());
 
-		sources.http(getContainerHostForSource("dataSender")).postData(data);
+		sources.httpSource("dataSender").postData(data);
 		assertValid(data, sinks.file());
 	}
 
@@ -61,7 +61,7 @@ public class TapTest extends AbstractIntegrationTest {
 		stream(sources.tap("dataSender").label("label2") + XD_TAP_DELIMITER
 				+ sinks.file());
 
-		sources.http(getContainerHostForSource("dataSender")).postData(data);
+		sources.httpSource("dataSender").postData(data);
 		assertValid(data.toUpperCase().substring(3), sinks.file());
 	}
 
@@ -79,7 +79,7 @@ public class TapTest extends AbstractIntegrationTest {
 		stream(sources.tap("dataSender").label("ds1") + XD_TAP_DELIMITER
 				+ sinks.file());
 
-		sources.http(getContainerHostForSource("dataSender")).postData(data);
+		sources.httpSource("dataSender").postData(data);
 		assertValid(data.toUpperCase(), sinks.file());
 	}
 

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TcpTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TcpTest.java
@@ -36,7 +36,7 @@ public class TcpTest extends AbstractIntegrationTest {
 	public void testTCPSourceCRLF() {
 		String data = UUID.randomUUID().toString();
 		stream(sources.tcp() + XD_DELIMITER + sinks.file());
-		sources.tcp(getContainerHostForSource()).sendBytes((data + "\r\n").getBytes());
+		sources.tcpSource().sendBytes((data + "\r\n").getBytes());
 		assertValid(data, sinks.file());
 		assertReceived(1);
 	}
@@ -50,7 +50,7 @@ public class TcpTest extends AbstractIntegrationTest {
 		String data = UUID.randomUUID().toString();
 		stream(sources.tcp() + XD_DELIMITER + sinks.file());
 		stream("dataSender",
-				"trigger --payload='" + data + "'" + XD_DELIMITER + sinks.tcp(getContainerHostForSource()));
+				"trigger --payload='" + data + "'" + XD_DELIMITER + sinks.tcpSink());
 		assertValid(data, sinks.file());
 		assertReceived(1);
 	}


### PR DESCRIPTION
- Created ContainerResolver for looking up runtime location of a module.
- Added httpSource and other xyzSource methods that take a stream name.
- Updated assertReceived to assertReceivedBySink/Source/Processor.
