### PR TITLE
[Sprint: 40] XD-2430 Adding a Sqoop tasklet and Sqoop batch job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ ext {
 	springShellVersion = '1.1.0.RELEASE'
 	zookeeperVersion = '3.4.6'
 	sparkVersion = '1.1.0'
+	sqoopVersion = '1.4.5'
 
 	// Also in IO
 	nettyVersion = '3.7.0.Final' // N.B. Reactor depends on Netty 4

--- a/config/modules/job/sqoop/sqoop.properties
+++ b/config/modules/job/sqoop/sqoop.properties
@@ -1,0 +1,9 @@
+#Jdbc Properties
+url = ${spring.datasource.url}
+driverClassName = ${spring.datasource.driverClassName}
+username = ${spring.datasource.username}
+password = ${spring.datasource.password}
+#Hadoop Properties
+fsUri = ${spring.hadoop.fsUri}
+resourceManagerHost = ${spring.hadoop.resourceManagerHost}
+resourceManagerPort = ${spring.hadoop.resourceManagerPort}

--- a/config/servers.yml
+++ b/config/servers.yml
@@ -245,6 +245,8 @@ endpoints:
 #spring:
 #  hadoop:
 #   fsUri: hdfs://localhost:8020
+#   resourceManagerHost: localhost
+#   resourceManagerPort: 8032
 
 ---
 # Zookeeper properties

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopOptionsMetadata.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopOptionsMetadata.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.sqoop;
+
+import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.xd.jdbc.JdbcConnectionMixin;
+import org.springframework.xd.module.options.mixins.HadoopConfigurationMixin;
+import org.springframework.xd.module.options.mixins.MapreduceConfigurationMixin;
+import org.springframework.xd.module.options.spi.Mixin;
+import org.springframework.xd.module.options.spi.ModuleOption;
+
+
+/**
+ * Module options for Sqoop application module.
+ *
+ * @author Thomas Risberg
+ */
+@Mixin({ JdbcConnectionMixin.class, HadoopConfigurationMixin.class, MapreduceConfigurationMixin.class })
+public class SqoopOptionsMetadata {
+
+	private String command = "";
+
+	private String args = "";
+
+	@NotBlank
+	public String getCommand() {
+		return command;
+	}
+
+	@ModuleOption("the Sqoop command to run")
+	public void setCommand(String command) {
+		this.command = command;
+	}
+
+	public String getArgs() {
+		return args;
+	}
+
+	@ModuleOption("the arguments for the Sqoop command")
+	public void setArgs(String args) {
+		this.args = args;
+	}
+}

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.sqoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.sqoop.Sqoop;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class for running Sqoop tool.
+ *
+ * @since 1.1
+ * @author Thomas Risberg
+ */
+public class SqoopRunner {
+
+	private static final Logger logger = LoggerFactory.getLogger(SqoopRunner.class);
+
+	private static final String JDBC_USERNAME_KEY = "jdbc.username";
+	private static final String JDBC_PASSWORD_KEY = "jdbc.password";
+	private static final String JDBC_URL_KEY = "jdbc.url";
+
+	public static void main(String[] args) {
+
+		if (args == null || args.length < 1) {
+			throw new IllegalArgumentException("Missing arguments and/or configuration options for Sqoop");
+		}
+
+		String jarPath = com.cloudera.sqoop.util.Jars.getJarPathForClass(JobConf.class);
+		String hadoopMapredHome = jarPath.substring(0, jarPath.lastIndexOf(File.separator));
+
+		String command = args[0];
+		String[] sqoopArgumentSource = args[1].split(" ");
+
+		List<String> sqoopArguments = new ArrayList<String>();
+		boolean connectProvided = parseSqoopArguments(sqoopArgumentSource, sqoopArguments);
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Sqoop command: " + command);
+			logger.debug("Using args: " + sqoopArguments);
+			logger.debug("Mapreduce home: " + hadoopMapredHome);
+		}
+
+		Map<String, String> configOptions = new HashMap<String, String>();
+		parseConfigOptions(args, configOptions);
+
+		Configuration configuration = createConfiguration(configOptions);
+
+		List<String> finalArguments = new ArrayList<String>();
+		createFinalArguments(hadoopMapredHome, command, sqoopArguments, connectProvided, configOptions, finalArguments);
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("Final args: " + finalArguments);
+		}
+
+		final int ret = Sqoop.runTool(finalArguments.toArray(new String[finalArguments.size()]), configuration);
+
+		if (ret != 0) {
+			throw new RuntimeException("Sqoop failed - return code "
+					+ Integer.toString(ret));
+		}
+	}
+
+	protected static void createFinalArguments(String hadoopMapredHome, String command, List<String> sqoopArguments,
+	                                           boolean connectProvided, Map<String, String> configOptions,
+	                                           List<String> finalArguments) {
+		finalArguments.add(command);
+		if (!connectProvided) {
+			finalArguments.add("--connect=" + configOptions.get(JDBC_URL_KEY));
+			if (configOptions.containsKey(JDBC_USERNAME_KEY) && configOptions.get(JDBC_USERNAME_KEY) != null) {
+				finalArguments.add("--username=" + configOptions.get(JDBC_USERNAME_KEY));
+			}
+			if (configOptions.containsKey(JDBC_PASSWORD_KEY) && configOptions.get(JDBC_PASSWORD_KEY) != null) {
+				finalArguments.add("--password=" + configOptions.get(JDBC_PASSWORD_KEY));
+			}
+		}
+		if ("import".equals(command.toLowerCase()) || "export".equals(command.toLowerCase())) {
+			finalArguments.add("--hadoop-mapred-home=" + hadoopMapredHome);
+		}
+		finalArguments.addAll(sqoopArguments);
+	}
+
+	protected static Configuration createConfiguration(Map<String, String> configOptions) {
+		Configuration configuration = new Configuration();
+		if (configOptions.containsKey(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY) &&
+				configOptions.get(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY) != null) {
+			configuration.set(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY,
+					configOptions.get(CommonConfigurationKeys.FS_DEFAULT_NAME_KEY));
+		}
+		if (configOptions.containsKey(YarnConfiguration.RM_ADDRESS) &&
+				configOptions.get(YarnConfiguration.RM_ADDRESS) != null) {
+			configuration.set(YarnConfiguration.RM_ADDRESS,
+					configOptions.get(YarnConfiguration.RM_ADDRESS));
+		}
+		configuration.set("mapreduce.framework.name", "yarn");
+		return configuration;
+	}
+
+	protected static void parseConfigOptions(String[] args, Map<String, String> configOptions) {
+		for (int i = 2; i < args.length; i++) {
+			String option = args[i];
+			if (!option.contains("=")) {
+				throw new IllegalArgumentException("Invalid config option provided: " + option);
+			}
+			String[] optionParts = option.split("=");
+			configOptions.put(optionParts[0], optionParts.length > 1 ? optionParts[1] : null);
+		}
+		if (logger.isDebugEnabled()) {
+			logger.debug("Config options: " + configOptions);
+		}
+	}
+
+	protected static boolean parseSqoopArguments(String[] sqoopArguments, List<String> runtimeArguments) {
+		boolean connectProvided = false;
+		for (int i = 0; i < sqoopArguments.length; i++) {
+			if (sqoopArguments[i].startsWith("--connect")) {
+				connectProvided = true;
+			}
+			if (sqoopArguments[i].contains("\"")) {
+				StringBuilder quotedArg = new StringBuilder();
+				while(i < sqoopArguments.length) {
+					if (quotedArg.length() > 0) {
+						quotedArg.append(" ");
+					}
+					quotedArg.append(sqoopArguments[i]);
+					if (sqoopArguments[i].endsWith("\"")) {
+						break;
+					}
+					i++;
+				}
+				runtimeArguments.add(quotedArg.toString());
+			}
+			else {
+				runtimeArguments.add(sqoopArguments[i]);
+			}
+		}
+		return connectProvided;
+	}
+
+}

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.sqoop;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.batch.step.tasklet.x.AbstractProcessBuilderTasklet;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tasklet used for running Sqoop tool.
+ *
+ * @since 1.1
+ * @author Thomas Risberg
+ */
+public class SqoopTasklet extends AbstractProcessBuilderTasklet implements InitializingBean {
+
+	private static final String SQOOP_RUNNER_CLASS = "org.springframework.xd.sqoop.SqoopRunner";
+
+	private String[] arguments;
+
+
+	public String[] getArguments() {
+		return arguments;
+	}
+
+	public void setArguments(String[] arguments) {
+		this.arguments = arguments;
+	}
+
+	@Override
+	protected List<String> createCommand() {
+		List<String> command = new ArrayList<String>();
+		command.add("java");
+		command.add(SQOOP_RUNNER_CLASS);
+		command.addAll(Arrays.asList(arguments));
+		return command;
+	}
+
+	@Override
+	protected String getCommandDisplayString() {
+		if (arguments.length > 1) {
+			return arguments[0] + " " + arguments[1];
+		}
+		else {
+			return arguments[0];
+		}
+	}
+
+	@Override
+	protected String getCommandName() {
+		return "Sqoop";
+	}
+
+	@Override
+	protected String getCommandDescription() {
+		return "Sqoop job for '" + arguments[0] + "'";
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		if (arguments == null || arguments.length < 1) {
+			throw new IllegalArgumentException("Missing arguments and/or configuration options for Sqoop");
+		}
+	}
+}

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/package-info.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package for XD sqoop extensions.
+ */
+
+package org.springframework.xd.sqoop;

--- a/extensions/spring-xd-extension-sqoop/src/main/resources/log4j.xml
+++ b/extensions/spring-xd-extension-sqoop/src/main/resources/log4j.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<!-- Appenders -->
+	<appender name="console" class="org.apache.log4j.ConsoleAppender">
+		<param name="Target" value="System.out" />
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%d{ABSOLUTE} %5p %t %c{2} - %m%n" />
+		</layout>
+	</appender>
+
+	<!-- Application Loggers -->
+	<logger name="org.springframework.xd.sqoop">
+		<level value="info" />
+	</logger>
+
+	<logger name="org.apache.sqoop">
+		<level value="info" />
+	</logger>
+
+	<logger name="org.springframework">
+		<level value="info" />
+	</logger>
+
+	<!-- Root Logger -->
+	<root>
+		<priority value="info" />
+		<appender-ref ref="console" />
+	</root>
+
+</log4j:configuration>
+
+

--- a/gradle/build-extensions.gradle
+++ b/gradle/build-extensions.gradle
@@ -1,6 +1,6 @@
 /*
  * Spring XD Extension projects, supporting module definitions.
-*/
+ */
 
 project('spring-xd-extension-mail') {
     description = 'Spring XD Mail'
@@ -187,8 +187,21 @@ project('spring-xd-extension-script') {
 project('spring-xd-extension-spark') {
     description = 'Spring XD spark extensions'
     dependencies {
-	compile "org.apache.spark:spark-core_2.10:$sparkVersion"
+        compile "org.apache.spark:spark-core_2.10:$sparkVersion"
         provided "org.springframework.batch:spring-batch-core"
         compile project(":spring-xd-module-spi")
 	}
+}
+
+project('spring-xd-extension-sqoop') {
+    description = 'Spring XD Sqoop extensions'
+    dependencies {
+        compile project(':spring-xd-module-spi')
+        compile project(':spring-xd-extension-batch')
+        compile project(':spring-xd-extension-jdbc')
+        compile "org.apache.sqoop:sqoop:${sqoopVersion}:hadoop200"
+        provided "org.springframework.batch:spring-batch-core"
+        provided "org.springframework.data:spring-data-hadoop-core:${springDataHadoopBase}"
+        provided "org.springframework.data:spring-data-hadoop-batch:${springDataHadoopBase}"
+    }
 }

--- a/gradle/build-modules.gradle
+++ b/gradle/build-modules.gradle
@@ -383,3 +383,9 @@ project('modules.job.timestampfile') {
         runtime project(":spring-xd-extension-batch")
     }
 }
+
+project('modules.job.sqoop') {
+    dependencies {
+        runtime(project(":spring-xd-extension-sqoop"))
+    }
+}

--- a/modules/job/sqoop/config/sqoop.properties
+++ b/modules/job/sqoop/config/sqoop.properties
@@ -1,0 +1,1 @@
+options_class=org.springframework.xd.sqoop.SqoopOptionsMetadata

--- a/modules/job/sqoop/config/sqoop.xml
+++ b/modules/job/sqoop/config/sqoop.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:hdp="http://www.springframework.org/schema/hadoop"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:batch="http://www.springframework.org/schema/batch"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/hadoop
+		http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
+		http://www.springframework.org/schema/batch
+		http://www.springframework.org/schema/batch/spring-batch.xsd">
+
+	<batch:job id="sqoopJob">
+		<batch:step id="tasklet">
+			<batch:tasklet ref="sqoopTasklet" />
+		</batch:step>
+	</batch:job>
+
+	<bean id="sqoopTasklet" class="org.springframework.xd.sqoop.SqoopTasklet">
+		<property name="arguments">
+			<list>
+				<value>${command}</value>
+				<value>${args}</value>
+				<value>jdbc.url=${url}</value>
+				<value>jdbc.username=${username}</value>
+				<value>jdbc.password=${password}</value>
+				<value>fs.defaultFS=${fsUri}</value>
+				<value>yarn.resourcemanager.address=${resourceManagerHost}:${resourceManagerPort}</value>
+			</list>
+		</property>
+	</bean>
+
+	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
+		fs.defaultFS=${fsUri}
+	</hdp:configuration>
+
+</beans>

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -54,7 +54,10 @@ spring:
     alternateUsernameAllowed: false
 # Hadoop properties
   hadoop:
-   fsUri: hdfs://localhost:8020
+    fsUri: hdfs://localhost:8020
+    resourceManagerHost: localhost
+    resourceManagerPort: 8032
+
 endpoints:
   jolokia:
     enabled: ${XD_JMX_ENABLED:true}

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MapreduceConfigurationMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MapreduceConfigurationMixin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.module.options.mixins;
+
+import org.hibernate.validator.constraints.NotBlank;
+import org.springframework.xd.module.options.spi.ModuleOption;
+
+/**
+ * Factors out common configuration options for Hadoop MapReduce.
+ * 
+ * @author Thomas Risberg
+ */
+public class MapreduceConfigurationMixin {
+
+	private String resourceManagerHost = "${spring.hadoop.resourceManagerHost}";
+	private String resourceManagerPort = "${spring.hadoop.resourceManagerPort}";
+
+
+	@NotBlank
+	public String getResourceManagerHost() {
+		return resourceManagerHost;
+	}
+
+	@ModuleOption("the Host for Hadoop's ResourceManager")
+	public void setResourceManagerHost(String resourceManagerHost) {
+		this.resourceManagerHost = resourceManagerHost;
+	}
+
+	@NotBlank
+	public String getResourceManagerPort() {
+		return resourceManagerPort;
+	}
+
+	@ModuleOption("the Port for Hadoop's ResourceManager")
+	public void setResourceManagerPort(String resourceManagerPort) {
+		this.resourceManagerPort = resourceManagerPort;
+	}
+}


### PR DESCRIPTION
- ported the Sqoop job POC over and added a Sqoop tasklet to handle capturing logs to be stored in the step execution context
- added an AbstractProcessBuilderTasklet that provides support for running this type of jobs in a separate process. This could be used by the Spark tasklet as well.
