### PR TITLE
[Sprint 40 ]XD-2510 Add spring-integration-amqp as a dependency for both Rabbit sink...

### DIFF
--- a/gradle/build-modules.gradle
+++ b/gradle/build-modules.gradle
@@ -197,6 +197,11 @@ project('modules.source.sftp') {
     dependencies { runtime      "org.springframework.integration:spring-integration-sftp" }
 }
 
+project('modules.source.rabbit') {
+    dependencies { runtime "org.springframework.integration:spring-integration-amqp" }
+}
+
+
 // ================ M O D U L E S : P R O C E S S O R S ================
 
 
@@ -316,6 +321,10 @@ project('modules.sink.kafka') {
         dependencies {
                 runtime(project(":spring-xd-extension-kafka"))
         }
+}
+
+project('modules.sink.rabbit') {
+    dependencies { runtime "org.springframework.integration:spring-integration-amqp" }
 }
 
 


### PR DESCRIPTION
This is necessary, as the two aren't on system classpath anymore, after the message bus refactoring.
