### PR TITLE
[Sprint: 41]XD-2075 Add binary, charset Options to MQTT Source

### DIFF
--- a/modules/source/mqtt/config/mqtt.xml
+++ b/modules/source/mqtt/config/mqtt.xml
@@ -20,7 +20,15 @@
                 url="${url}"
                 topics="${topics}"
                 client-factory="clientFactory"
-                channel="output"/>
+                channel="output"
+                converter="converter" />
+
+        <bean id="converter" class="org.springframework.integration.mqtt.support.DefaultPahoMessageConverter">
+                <constructor-arg value="0" />  <!-- not used on inbound; need a new ctor INT-3594 -->
+                <constructor-arg value="false" /> <!-- not used on inbound; need a new ctor INT-3594 -->
+                <constructor-arg value="${charset}" />
+                <property name="payloadAsBytes" value="${binary}" />
+        </bean>
 
         <int:channel id="output"/>
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/MqttSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/MqttSourceOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * Describes options to the {@code mqtt} source module.
  * 
  * @author Eric Bottard
+ * @author Gary Russell
  */
 @Mixin(MqttConnectionMixin.class)
 public class MqttSourceOptionsMetadata {
@@ -34,6 +35,10 @@ public class MqttSourceOptionsMetadata {
 	private String clientId = "xd.mqtt.client.id.src";
 
 	private String topics = "xd.mqtt.test";
+
+	private boolean binary = false;
+
+	private String charset = "UTF-8";
 
 
 	@NotBlank
@@ -57,5 +62,22 @@ public class MqttSourceOptionsMetadata {
 		this.topics = topics;
 	}
 
+	public String getCharset() {
+		return charset;
+	}
+
+	@ModuleOption("the charset used to convert bytes to String (when binary is false)")
+	public void setCharset(String charset) {
+		this.charset = charset;
+	}
+
+	public boolean isBinary() {
+		return binary;
+	}
+
+	@ModuleOption("true to leave the payload as bytes")
+	public void setBinary(boolean binary) {
+		this.binary = binary;
+	}
 
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,8 +13,10 @@
 
 package org.springframework.xd.dirt.stream;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.util.MatcherAssertionErrors.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,7 +34,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.xd.dirt.integration.bus.Binding;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.RabbitTestMessageBus;
-import org.springframework.xd.dirt.stream.StreamDefinition;
 import org.springframework.xd.dirt.test.sink.NamedChannelSink;
 import org.springframework.xd.dirt.test.sink.SingleNodeNamedChannelSinkFactory;
 import org.springframework.xd.dirt.test.source.NamedChannelSource;
@@ -72,7 +73,7 @@ public class RabbitSingleNodeStreamDeploymentIntegrationTests extends
 	@Test
 	public void mqttSourceStreamReceivesMqttSinkStreamOutput() throws Exception {
 		StreamDefinition mqtt1 = new StreamDefinition("mqtt1", "queue:mqttsource > mqtt --topic=foo");
-		StreamDefinition mqtt2 = new StreamDefinition("mqtt2", "mqtt --topics=foo > queue:mqttsink");
+		StreamDefinition mqtt2 = new StreamDefinition("mqtt2", "mqtt --topics=foo --charset=UTF-8 > queue:mqttsink");
 		integrationSupport.createAndDeployStream(mqtt1);
 		integrationSupport.createAndDeployStream(mqtt2);
 
@@ -84,6 +85,26 @@ public class RabbitSingleNodeStreamDeploymentIntegrationTests extends
 		Object result = sink.receivePayload(1000);
 
 		assertEquals("hello", result);
+		source.unbind();
+		sink.unbind();
+	}
+
+	@Test
+	public void mqttSourceStreamReceivesMqttSinkStreamOutputBinary() throws Exception {
+		StreamDefinition mqtt3 = new StreamDefinition("mqtt3", "queue:mqttsource2 > mqtt --topic=foo2");
+		StreamDefinition mqtt4 = new StreamDefinition("mqtt4", "mqtt --topics=foo2 --binary=true > queue:mqttsink2");
+		integrationSupport.createAndDeployStream(mqtt3);
+		integrationSupport.createAndDeployStream(mqtt4);
+
+		NamedChannelSource source = new SingleNodeNamedChannelSourceFactory(integrationSupport.messageBus()).createNamedChannelSource("queue:mqttsource2");
+		NamedChannelSink sink = new SingleNodeNamedChannelSinkFactory(integrationSupport.messageBus()).createNamedChannelSink("queue:mqttsink2");
+
+		Thread.sleep(1000);
+		source.sendPayload("hello");
+		Object result = sink.receivePayload(1000);
+
+		assertThat(result, instanceOf(byte[].class));
+		assertEquals("hello", new String((byte[]) result));
 		source.unbind();
 		sink.unbind();
 	}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2075

- `--binary=true` leaves the payload as `byte[]`

- `--charset` allows configuration of the charset used to convert `byte[]` to `String`