### PR TITLE
[Sprint: 41] XD-2416: Handle escaped quotes according to outer quotes

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
@@ -451,7 +451,8 @@ public class StreamConfigParser implements StreamLookupEnvironment {
 			argValue = t.data;
 		}
 		else if (t.getKind() == TokenKind.LITERAL_STRING) {
-			argValue = t.data.substring(1, t.data.length() - 1).replaceAll("''", "'").replaceAll("\"\"", "\"");
+			String quotesUsed = t.data.substring(0, 1);
+			argValue = t.data.substring(1, t.data.length() - 1).replace(quotesUsed+quotesUsed, quotesUsed);
 		}
 		else {
 			raiseException(t.startpos, XDDSLMessages.EXPECTED_ARGUMENT_VALUE, t.data);

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.springframework.xd.dirt.stream.ParsingContext.stream;
@@ -355,7 +356,7 @@ public class StreamConfigParserTests {
 		assertEquals("'hi'", ast.getModule("transform").getArguments()[0].getValue());
 
 		ast = parse("http | transform --expression=\"''''hi''''\" | log");
-		assertEquals("''hi''", ast.getModule("transform").getArguments()[0].getValue());
+		assertEquals("''''hi''''", ast.getModule("transform").getArguments()[0].getValue());
 	}
 
 	@Test
@@ -603,6 +604,16 @@ public class StreamConfigParserTests {
 		checkForParseError("foo --name .sub=value", XDDSLMessages.NO_WHITESPACE_IN_DOTTED_NAME, 11);
 		checkForParseError("foo --name. sub=value", XDDSLMessages.NO_WHITESPACE_IN_DOTTED_NAME, 12);
 	}
+
+	@Test
+	public void testXD2416() {
+		StreamNode ast = parse("http | transform --expression='payload.replace(\"abc\", \"\")' | log");
+		assertThat((String)ast.getModuleNodes().get(1).getArgumentsAsProperties().get("expression"), equalTo("payload.replace(\"abc\", \"\")"));
+
+		ast = parse("http | transform --expression='payload.replace(\"abc\", '''')' | log");
+		assertThat((String)ast.getModuleNodes().get(1).getArgumentsAsProperties().get("expression"), equalTo("payload.replace(\"abc\", '')"));
+	}
+
 
 	@After
 	public void reset() {


### PR DESCRIPTION
Had a discussion with @aclement about this. Finally decided not to handle escapes at the Tokenizer level because
1. less regression risks
2. one could even argue if we do that, then the token payload should not contain the outer quotes IMO. So even more regression risks.

