### PR TITLE
[Sprint: 41] XD-2477 Adding stoppable logic to AbstractProcessBuilderTasklet

### DIFF
--- a/config/xd-container-logger.properties
+++ b/config/xd-container-logger.properties
@@ -17,6 +17,7 @@ log4j.logger.org.springframework.xd=WARN
 log4j.logger.org.springframework.xd.dirt.server=INFO
 log4j.logger.org.springframework.xd.dirt.util.XdConfigLoggingInitializer=INFO
 log4j.logger.xd.sink=INFO
+log4j.logger.org.springframework.xd.sqoop=INFO
 
 log4j.logger.org.springframework=WARN
 log4j.logger.org.springframework.boot=WARN

--- a/config/xd-singlenode-logger.properties
+++ b/config/xd-singlenode-logger.properties
@@ -17,6 +17,7 @@ log4j.logger.org.springframework.xd=WARN
 log4j.logger.org.springframework.xd.dirt.server=INFO
 log4j.logger.org.springframework.xd.dirt.util.XdConfigLoggingInitializer=INFO
 log4j.logger.xd.sink=INFO
+log4j.logger.org.springframework.xd.sqoop=INFO
 
 log4j.logger.org.springframework=WARN
 log4j.logger.org.springframework.boot=WARN

--- a/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/AbstractProcessBuilderTasklet.java
+++ b/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/AbstractProcessBuilderTasklet.java
@@ -46,6 +46,8 @@ import java.util.Map;
  * Abstract tasklet for running code in a separate process and capturing the log output. The step execution
  * context will be updated with some runtime information as well as with the log output.
  *
+ * Note: This this class is not thread-safe.
+ *
  * @since 1.1
  * @author Thomas Rrisberg
  */

--- a/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/AbstractProcessBuilderTasklet.java
+++ b/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/AbstractProcessBuilderTasklet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@ package org.springframework.batch.step.tasklet.x;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.SimpleSystemProcessExitCodeMapper;
 import org.springframework.batch.core.step.tasklet.SystemProcessExitCodeMapper;
@@ -29,8 +31,10 @@ import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -54,6 +58,18 @@ public abstract class AbstractProcessBuilderTasklet implements Tasklet, StepExec
 	 */
 	protected int exitCode = -1;
 
+	private String exitMessage;
+
+	private boolean complete = false;
+
+	private boolean stopped = false;
+
+	private boolean stoppable = false;
+
+	private long checkInterval = 1000;
+
+	private JobExplorer jobExplorer;
+
 	private SystemProcessExitCodeMapper systemProcessExitCodeMapper = new SimpleSystemProcessExitCodeMapper();
 
 
@@ -61,7 +77,6 @@ public abstract class AbstractProcessBuilderTasklet implements Tasklet, StepExec
 	public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
 
 		StepExecution stepExecution = chunkContext.getStepContext().getStepExecution();
-		ExitStatus exitStatus = stepExecution.getExitStatus();
 
 		String commandDescription = getCommandDescription();
 
@@ -73,25 +88,71 @@ public abstract class AbstractProcessBuilderTasklet implements Tasklet, StepExec
 
 		String commandClassPath = createClassPath(this.getClass());
 
-		ProcessBuilder pb = new ProcessBuilder(command).redirectErrorStream(true);
+		File out = File.createTempFile(commandName + "-", ".out");
+		stepExecution.getExecutionContext().putString(commandName.toLowerCase() + ".system.out", out.getAbsolutePath());
+		logger.info(commandName + " system.out: " + out.getAbsolutePath());
+		File err = File.createTempFile(commandName + "-", ".err");
+		stepExecution.getExecutionContext().putString(commandName.toLowerCase() + ".system.err", err.getAbsolutePath());
+		ProcessBuilder pb = new ProcessBuilder(command).redirectOutput(out).redirectError(err);
 		Map<String, String> env = pb.environment();
 		env.put("CLASSPATH", commandClassPath);
 		String msg = commandDescription + " is being launched";
 		stepExecution.getExecutionContext().putString(commandName.toLowerCase() + ".command", commandDisplayString.trim());
-		List<String> commandLog = new ArrayList<String>();
+		List<String> commandOut = new ArrayList<String>();
+		List<String> commandErr = new ArrayList<String>();
+		Process p = null;
 		try {
-			Process p = pb.start();
-			p.waitFor();
-			exitCode = p.exitValue();
-			msg = commandDescription + " finished with exit code: " + exitCode;
-			if (exitCode == 0) {
+			p = pb.start();
+
+			while (!complete) {
+
+				try {
+					exitCode = p.exitValue();
+					complete = true;
+				} catch (IllegalThreadStateException e) {
+					if (stopped) {
+						p.destroy();
+						p = null;
+						break;
+					}
+				}
+
+				if (!complete) {
+
+					if (stoppable) {
+						JobExecution jobExecution =
+								jobExplorer.getJobExecution(stepExecution.getJobExecutionId());
+
+						if (jobExecution.isStopping()) {
+							stopped = true;
+						} else if (chunkContext.getStepContext().getStepExecution().isTerminateOnly()) {
+							stopped = true;
+						}
+					}
+
+					Thread.sleep(checkInterval);
+
+				}
+
+			}
+
+			if (complete) {
+				msg = commandDescription + " finished with exit code: " + exitCode;
+			}
+			else {
+				msg = commandDescription + " was aborted due to a stop request";
+			}
+			if (complete && exitCode == 0) {
 				logger.info(msg);
 			}
 			else {
-				logger.error(msg);
+				if (stopped) {
+					logger.warn(msg);
+				}
+				else {
+					logger.error(msg);
+				}
 			}
-			commandLog = getProcessOutput(p);
-			p.destroy();
 		}
 		catch (IOException e) {
 			msg = commandDescription + " job failed with: " + e;
@@ -102,34 +163,37 @@ public abstract class AbstractProcessBuilderTasklet implements Tasklet, StepExec
 			logger.error(msg);
 		}
 		finally {
-			printLog(commandName, commandLog, exitCode);
-			StringBuilder firstException = new StringBuilder();
-			if (exitCode != 0) {
-				for (String line : commandLog) {
-					if (firstException.length() == 0) {
-						if (line.contains("Exception")) {
-							firstException.append(line).append("\n");
-						}
-					}
-					else {
-						if (line.startsWith("\t")) {
-							firstException.append(line).append("\n");
-						}
-						else {
-							break;
-						}
-					}
+			if (p != null) {
+				p.destroy();
+			}
+			commandOut = getProcessOutput(out);
+			commandErr = getProcessOutput(err);
+			printLog(commandName, commandOut, commandErr);
+			String firstException = getFirstExceptionMessage(commandOut, commandErr);
+			if (firstException.length() > 0) {
+				msg = msg + " - " + firstException;
+			}
+			if (commandErr.size() > 0) {
+				StringBuilder commandLogErr = new StringBuilder();
+				for (String line : commandErr) {
+					commandLogErr.append(line).append("</br>");
 				}
+				stepExecution.getExecutionContext().putString(commandName.toLowerCase() + ".errors", commandLogErr.toString());
+			}
+			StringBuilder commandLogOut = new StringBuilder();
+			for (String line : commandOut) {
+				commandLogOut.append(line).append("</br>");
+			}
+			stepExecution.getExecutionContext().putString(commandName.toLowerCase() + ".log", commandLogOut.toString());
+			exitMessage = msg;
+			if (complete && exitCode != 0 || (!complete && !stopped)) {
 				if (firstException.length() > 0) {
-					msg = msg + "\n" + firstException.toString();
+					throw new IllegalStateException("Step execution failed - " + firstException);
+				}
+				else {
+					throw new IllegalStateException("Step execution failed - " + msg);
 				}
 			}
-			StringBuilder commandLogMessages = new StringBuilder();
-			for (String line : commandLog) {
-				commandLogMessages.append(line).append("</br>");
-			}
-			stepExecution.getExecutionContext().putString(commandName.toLowerCase() + ".log", commandLogMessages.toString());
-			stepExecution.setExitStatus(exitStatus.addExitDescription(msg));
 		}
 
 		return RepeatStatus.FINISHED;
@@ -138,12 +202,28 @@ public abstract class AbstractProcessBuilderTasklet implements Tasklet, StepExec
 
 	@Override
 	public void beforeStep(StepExecution stepExecution) {
+		exitCode = -1;
+		complete = false;
+		stopped = false;
+		if (jobExplorer == null) {
+			stoppable = false;
+		}
+		else {
+			stoppable = isStoppable();
+		}
 	}
 
 	@Override
 	public ExitStatus afterStep(StepExecution stepExecution) {
-		return systemProcessExitCodeMapper.getExitStatus(exitCode);
+		if (complete) {
+			return systemProcessExitCodeMapper.getExitStatus(exitCode).addExitDescription(exitMessage);
+		}
+		else {
+			return ExitStatus.STOPPED.addExitDescription(exitMessage);
+		}
 	}
+
+	protected abstract boolean isStoppable();
 
 	protected abstract List<String> createCommand();
 
@@ -193,15 +273,22 @@ public abstract class AbstractProcessBuilderTasklet implements Tasklet, StepExec
 		return classPathBuilder.toString();
 	}
 
-	protected List<String> getProcessOutput(Process p) {
+	protected List<String> getProcessOutput(File f) {
 		List<String> lines = new ArrayList<String>();
-		if (p == null) {
+		if (f == null) {
 			return lines;
 		}
-		InputStream in = p.getInputStream();
-		BufferedReader reader = new BufferedReader(new InputStreamReader(in));
-		String line;
+		FileInputStream in;
 		try {
+			in = new FileInputStream(f);
+		} catch (FileNotFoundException e) {
+			lines.add("Failed to read log output due to " + e.getClass().getName());
+			lines.add(e.getMessage());
+			return lines;
+		}
+		BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+		try {
+			String line;
 			while ((line = reader.readLine()) != null) {
 				if (lines.size() < 10000) {
 					lines.add(line);
@@ -224,19 +311,39 @@ public abstract class AbstractProcessBuilderTasklet implements Tasklet, StepExec
 		return lines;
 	}
 
-	protected void printLog(String commandName, List<String> lines, int exitCode) {
-		if (exitCode != 0) {
-			for (String line : lines) {
-				logger.error(commandName + " log: " + line);
+	protected void printLog(String commandName, List<String> out, List<String> err) {
+		if ((complete && exitCode != 0) || (!complete && !stopped)) {
+			for (String line : err) {
+				logger.error(commandName + " err: " + line);
 			}
 		}
-		else {
-			if (logger.isDebugEnabled()) {
-				for (String line : lines) {
+		for (String line : out) {
+			if (!complete && !stopped) {
+				logger.warn(commandName + " log: " + line);
+			}
+			else {
+				if (logger.isDebugEnabled()) {
 					logger.debug(commandName + " log: " + line);
 				}
 			}
 		}
+	}
+
+	protected String getFirstExceptionMessage(List<String> out, List<String> err) {
+		String firstException = "";
+		List<String> log = new ArrayList<String>(out);
+		log.addAll(err);
+		for (String line : log) {
+			if (line.contains("Exception")) {
+				firstException = line;
+				break;
+			}
+		}
+		return firstException;
+	}
+
+	public void setJobExplorer(JobExplorer jobExplorer) {
+		this.jobExplorer = jobExplorer;
 	}
 
 	/**
@@ -246,6 +353,16 @@ public abstract class AbstractProcessBuilderTasklet implements Tasklet, StepExec
 	 */
 	public void setSystemProcessExitCodeMapper(SystemProcessExitCodeMapper systemProcessExitCodeMapper) {
 		this.systemProcessExitCodeMapper = systemProcessExitCodeMapper;
+	}
+
+	/**
+	 * The time interval how often the tasklet will check for termination
+	 * status.
+	 *
+	 * @param checkInterval time interval in milliseconds (1 second by default).
+	 */
+	public void setTerminationCheckInterval(long checkInterval) {
+		this.checkInterval = checkInterval;
 	}
 
 }

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
@@ -45,6 +45,11 @@ public class SqoopTasklet extends AbstractProcessBuilderTasklet implements Initi
 	}
 
 	@Override
+	protected boolean isStoppable() {
+		return false;
+	}
+
+	@Override
 	protected List<String> createCommand() {
 		List<String> command = new ArrayList<String>();
 		command.add("java");

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
@@ -26,6 +26,8 @@ import java.util.List;
 /**
  * Tasklet used for running Sqoop tool.
  *
+ * Note: This this class is not thread-safe.
+ *
  * @since 1.1
  * @author Thomas Risberg
  */


### PR DESCRIPTION
- improving log management using temp files

- improving exit status handling

- improving step execution status management when job fails

- still can't make Sqoop job stoppable due to the fact that the Sqoop mapreduce job keeps running even if launching process is destroyed

- adding INFO logging for Sqoop tasklet so user can tail Sqoop log for long running jobs