### PR TITLE
[Sprint 41] XD-2572 Set fixed NPM version for Grunt Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,11 @@ buildscript {
 	dependencies {
 		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.0.RELEASE")
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
-		classpath 'com.moowork.gradle:gradle-grunt-plugin:0.5'
+		classpath 'com.moowork.gradle:gradle-grunt-plugin:0.6'
+		classpath 'com.moowork.gradle:gradle-node-plugin:0.7'
 		classpath 'me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1'
 		classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.10.0'
+		classpath 'org.codehaus.groovy:groovy-backports-compat23:2.3.5'
 	}
 }
 
@@ -937,6 +939,7 @@ project('spring-xd-ui') {
 	node {
 		version = '0.10.33'
 		download = true
+		npmVersion = '2.1.18'
 	}
 
 	task cleanDist(type: Delete) {
@@ -956,7 +959,7 @@ project('spring-xd-ui') {
 		delete 'app/lib'
 	}
 
-	tasks['grunt_build'].dependsOn(['npmInstall', 'installGrunt']);
+	tasks['grunt_build'].dependsOn(['npmSetup', 'npmInstall', 'installGrunt']);
 	tasks['grunt_teste2e'].dependsOn(['grunt_build']);
 
 	task ui_test(dependsOn: ['grunt_teste2e', ':spring-xd-dirt:backgroundAdminServer']) {


### PR DESCRIPTION
Looks like `groovy-backports-compat23` is needed so everything with with Gradle `<2.0`. The UI build also works with Windows.