### PR TITLE
[Sprint 41] XD 2542 - Create MessageHandler for RxJava based processor modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ ext {
 		'spring-xd-analytics',
 		'spring-xd-analytics-ml',
 		'spring-xd-reactor',
+		'spring-xd-rxjava',
 		'spring-xd-tuple',
 		'spring-xd-module',
 		'spring-xd-rest-client',
@@ -344,6 +345,14 @@ project('spring-xd-reactor') {
 	description = 'Spring XD Reactor'
 	dependencies {
 		compile "io.projectreactor:reactor-core"
+		compile "org.springframework.integration:spring-integration-core"
+	}
+}
+
+project('spring-xd-rxjava') {
+	description = 'Spring XD RxJava'
+	dependencies {
+		compile "io.reactivex:rxjava"
 		compile "org.springframework.integration:spring-integration-core"
 	}
 }

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -99,6 +99,7 @@ jaxen\:jaxen=1.1.6
 jline\:jline=2.11
 joda-time\:joda-time=2.5
 junit\:junit=4.12
+io.reactivex\:rxjava=1.0.0
 ldapsdk\:ldapsdk=4.1
 log4j\:log4j=1.2.17
 mysql\:mysql-connector-java=5.1.34

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ include 'spring-xd-analytics'
 include 'spring-xd-analytics-ml'
 
 include 'spring-xd-reactor'
+include 'spring-xd-rxjava'
 
 include 'spring-xd-messagebus-spi'
 include 'spring-xd-messagebus-local'

--- a/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/Processor.java
+++ b/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/Processor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.rxjava;
+
+import rx.Observable;
+
+/**
+ *  Contract for performing stream processing using RxJava within an XD processor module
+ * @author Mark Pollack
+ */
+public interface Processor<I,O> {
+
+    /**
+     * Process a stream of messages and return an output stream.  The input
+     * and output stream will be mapped onto receive/send operations on the message bus.
+     *
+     * @param inputStream Input stream the receives messages from the message bus
+     * @return Output stream of messages sent to the message bus
+     */
+    Observable<O> process(Observable<I> inputStream);
+}

--- a/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/SubjectMessageHandler.java
+++ b/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/SubjectMessageHandler.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.rxjava;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.ResolvableType;
+import org.springframework.integration.handler.AbstractMessageProducingHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+import rx.Observable;
+import rx.Subscription;
+import rx.functions.Action1;
+import rx.subjects.BehaviorSubject;
+import rx.subjects.Subject;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ *
+ * @author Mark Pollack
+ */
+public class SubjectMessageHandler extends AbstractMessageProducingHandler {
+
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    private final ConcurrentMap<Long, BehaviorSubject<Object>> subjectMap =
+            new ConcurrentHashMap<Long, BehaviorSubject<Object>>();
+
+    private final Object monitor = new Object();
+
+    @SuppressWarnings("rawtypes")
+    private final Processor processor;
+
+    private final ResolvableType inputType;
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public SubjectMessageHandler(Processor processor) {
+        Assert.notNull(processor, "processor cannot be null.");
+        this.processor = processor;
+        Method method = ReflectionUtils.findMethod(this.processor.getClass(), "process", Observable.class);
+        this.inputType = ResolvableType.forMethodParameter(method, 0).getNested(2);
+    }
+
+
+    @Override
+    protected void handleMessageInternal(Message<?> message) throws Exception {
+        Subject subjectToUse = getSubject();
+        if (ClassUtils.isAssignable(inputType.getRawClass(), message.getClass())) {
+            subjectToUse.onNext(message);
+        } else if (ClassUtils.isAssignable(inputType.getRawClass(), message.getPayload().getClass())) {
+            //TODO handle type conversion of payload to input type if possible
+            System.out.println(Thread.currentThread().getName() +
+                    "> Inside handleMessageInternal, sending to subject data = " + message.getPayload());
+            subjectToUse.onNext(message.getPayload());
+        }
+        //TODO else log error.
+    }
+
+    private Subject getSubject() {
+        long idToUse = Thread.currentThread().getId();
+        Subject subject = subjectMap.get(idToUse);
+        if (subject == null) {
+            BehaviorSubject existingSubject = subjectMap.putIfAbsent(idToUse, BehaviorSubject.create());
+            if (existingSubject == null)
+                subject = subjectMap.get(idToUse);
+            synchronized (this.monitor) {
+                if (!subject.hasObservers()) {
+                    //user defined stream processing
+                    Observable<?> outputStream = processor.process(subject);
+
+                    //TODO Error handling
+
+                    final Subscription subscription = outputStream.subscribe(new Action1<Object>() {
+                        @Override
+                        public void call(Object outputObject) {
+                            if (ClassUtils.isAssignable(Message.class, outputObject.getClass())) {
+                                getOutputChannel().send((Message) outputObject);
+                            } else {
+                                getOutputChannel().send(MessageBuilder.withPayload(outputObject).build());
+                            }
+                            //System.out.println(Thread.currentThread().getName() + "> Going to send to message bus " + o);
+                        }
+                    });
+
+                    //TODO keep track of subscriptions to unsubscribe cleanly...
+                }
+            }
+        }
+        return subject;
+
+    }
+}

--- a/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/SubjectMessageHandler.java
+++ b/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/SubjectMessageHandler.java
@@ -17,36 +17,42 @@ package org.springframework.xd.rxjava;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.core.ResolvableType;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
-
 import rx.Observable;
 import rx.Subscription;
+import rx.functions.Action0;
 import rx.functions.Action1;
-import rx.subjects.BehaviorSubject;
+import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
 
 import java.lang.reflect.Method;
+import java.util.Hashtable;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
+ * A handler that adapts the item at a time delivery in a {@link org.springframework.messaging.MessageHandler}
+ * and delegates processing to an RxJava Observable.  A
  *
  * @author Mark Pollack
  */
-public class SubjectMessageHandler extends AbstractMessageProducingHandler {
+public class SubjectMessageHandler extends AbstractMessageProducingHandler implements DisposableBean {
 
     protected final Log logger = LogFactory.getLog(getClass());
 
-    private final ConcurrentMap<Long, BehaviorSubject<Object>> subjectMap =
-            new ConcurrentHashMap<Long, BehaviorSubject<Object>>();
+    private final ConcurrentMap<Long, PublishSubject<Object>> subjectMap =
+            new ConcurrentHashMap<Long, PublishSubject<Object>>();
 
-    private final Object monitor = new Object();
+    private final Map<Long, Subscription> subscriptionMap = new Hashtable<Long, Subscription>();
 
     @SuppressWarnings("rawtypes")
     private final Processor processor;
@@ -68,45 +74,56 @@ public class SubjectMessageHandler extends AbstractMessageProducingHandler {
         if (ClassUtils.isAssignable(inputType.getRawClass(), message.getClass())) {
             subjectToUse.onNext(message);
         } else if (ClassUtils.isAssignable(inputType.getRawClass(), message.getPayload().getClass())) {
-            //TODO handle type conversion of payload to input type if possible
-            System.out.println(Thread.currentThread().getName() +
-                    "> Inside handleMessageInternal, sending to subject data = " + message.getPayload());
             subjectToUse.onNext(message.getPayload());
+        } else {
+            throw new MessageHandlingException(message, "Processor signature does not match [" + message.getClass()
+                    + "] or [" + message.getPayload().getClass() + "]");
         }
-        //TODO else log error.
     }
 
     private Subject getSubject() {
         long idToUse = Thread.currentThread().getId();
         Subject subject = subjectMap.get(idToUse);
         if (subject == null) {
-            BehaviorSubject existingSubject = subjectMap.putIfAbsent(idToUse, BehaviorSubject.create());
+            PublishSubject existingSubject = subjectMap.putIfAbsent(idToUse, PublishSubject.create());
             if (existingSubject == null)
                 subject = subjectMap.get(idToUse);
-            synchronized (this.monitor) {
-                if (!subject.hasObservers()) {
-                    //user defined stream processing
-                    Observable<?> outputStream = processor.process(subject);
+            //user defined stream processing
+            Observable<?> outputStream = processor.process(subject);
 
-                    //TODO Error handling
-
-                    final Subscription subscription = outputStream.subscribe(new Action1<Object>() {
-                        @Override
-                        public void call(Object outputObject) {
-                            if (ClassUtils.isAssignable(Message.class, outputObject.getClass())) {
-                                getOutputChannel().send((Message) outputObject);
-                            } else {
-                                getOutputChannel().send(MessageBuilder.withPayload(outputObject).build());
-                            }
-                            //System.out.println(Thread.currentThread().getName() + "> Going to send to message bus " + o);
-                        }
-                    });
-
-                    //TODO keep track of subscriptions to unsubscribe cleanly...
+            final Subscription subscription = outputStream.subscribe(new Action1<Object>() {
+                @Override
+                public void call(Object outputObject) {
+                    if (ClassUtils.isAssignable(Message.class, outputObject.getClass())) {
+                        getOutputChannel().send((Message) outputObject);
+                    } else {
+                        getOutputChannel().send(MessageBuilder.withPayload(outputObject).build());
+                    }
                 }
-            }
+            }, new Action1<Throwable>() {
+                @Override
+                public void call(Throwable throwable) {
+                    logger.error(throwable);
+                }
+            }, new Action0() {
+                @Override
+                public void call() {
+                    subjectMap.remove(Thread.currentThread().getId());
+                }
+            });
+
+            subscriptionMap.put(idToUse, subscription);
+
+
         }
         return subject;
 
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        for (Subscription subscription : subscriptionMap.values()) {
+            subscription.unsubscribe();
+        }
     }
 }

--- a/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/PongMessageProcessor.java
+++ b/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/PongMessageProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.rxjava;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+import rx.Observable;
+import rx.functions.Func1;
+
+/**
+ *
+ *  A simple stream processor that transforms messages by adding "-pong" to the payload.
+ *
+ * @author Mark Pollack
+ */
+public class PongMessageProcessor implements Processor<Message, Message> {
+
+    @Override
+    public Observable<Message> process(Observable<Message> inputStream) {
+        return inputStream.map(new Func1<Message, Message>() {
+            @Override
+            public Message call(Message message) {
+                return new GenericMessage<String>(message.getPayload() + "-pojopong");
+            }
+        });
+    }
+}

--- a/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/PongStringProcessor.java
+++ b/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/PongStringProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.rxjava;
+
+import rx.Observable;
+import rx.functions.Func1;
+
+/**
+ *
+ * A simple stream processor that transforms Strings by adding "-pong" to the string.
+ *
+ * @author Mark Pollack
+ */
+public class PongStringProcessor implements Processor<String, String> {
+
+    @Override
+    public Observable<String> process(Observable<String> inputStream) {
+        return inputStream.map(new Func1<String, String>() {
+            @Override
+            public String call(String s) {
+                return s + "-stringpong";
+            }
+        });
+    }
+}

--- a/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/SubjectMessageHandlerTests.java
+++ b/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/SubjectMessageHandlerTests.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.rxjava;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test the {@link org.springframework.xd.rxjava.SubjectMessageHandler} by using two types of
+ * {@link org.springframework.xd.rxjava.Processor}. The first is parameterized by
+ * {@link org.springframework.messaging.Message} and the second by String to test extracting payload types and
+ * wrapping return types in a Message.
+ *
+ * @author Mark Pollack
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/rxjava.xml")
+@DirtiesContext
+public class SubjectMessageHandlerTests {
+
+    private final int numMessages = 10;
+
+    @Autowired
+    @Qualifier("outputChannel1")
+    PollableChannel outputChannel1;
+
+    @Autowired
+    @Qualifier("outputChannel2")
+    PollableChannel outputChannel2;
+
+    @Autowired
+    @Qualifier("toMessageHandlerChannel")
+    MessageChannel toMessageHandlerChannel;
+
+    @Autowired
+    @Qualifier("toStringHandlerChannel")
+    MessageChannel toStringHandlerChannel;
+
+    @Test
+    public void pojoBasedProcessor() throws IOException {
+        sendPojoMessages();
+        for (int i = 0; i < numMessages; i++) {
+            Message<?> outputMessage = outputChannel1.receive(500);
+            assertEquals("ping-pojopong", outputMessage.getPayload());
+        }
+    }
+
+    @Test
+    public void stringBasedProcessor() throws IOException {
+
+        sendStringMessages();
+        for (int i = 0; i < numMessages; i++) {
+            Message<?> outputMessage = outputChannel2.receive(500);
+            assertEquals("ping-stringpong", outputMessage.getPayload());
+        }
+    }
+
+    private void sendPojoMessages() {
+        Message<?> message = new GenericMessage<String>("ping");
+        for (int i = 0; i < numMessages; i++) {
+            toMessageHandlerChannel.send(message);
+        }
+    }
+
+    private void sendStringMessages() {
+        Message<?> message = new GenericMessage<String>("ping");
+        for (int i = 0; i < numMessages; i++) {
+            toStringHandlerChannel.send(message);
+        }
+    }
+}

--- a/spring-xd-rxjava/src/test/resources/rxjava.xml
+++ b/spring-xd-rxjava/src/test/resources/rxjava.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:int="http://www.springframework.org/schema/integration"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+
+    <int:channel id="outputChannel1">
+        <int:queue capacity="20"/>
+    </int:channel>
+
+    <int:channel id="outputChannel2">
+        <int:queue capacity="20"/>
+    </int:channel>
+
+
+    <int:channel id="toMessageHandlerChannel"/>
+
+    <int:channel id="toStringHandlerChannel"/>
+
+    <bean id="messageProcessor" class="org.springframework.xd.rxjava.PongMessageProcessor"/>
+
+    <bean name="reactorMessageHandler" class="org.springframework.xd.rxjava.SubjectMessageHandler">
+        <constructor-arg ref="messageProcessor"/>
+    </bean>
+
+    <int:service-activator input-channel="toMessageHandlerChannel" ref="reactorMessageHandler"
+                           output-channel="outputChannel1"/>
+
+    <bean id="stringProcessor" class="org.springframework.xd.rxjava.PongStringProcessor"/>
+
+    <bean name="reactorStringHandler" class="org.springframework.xd.rxjava.SubjectMessageHandler">
+        <constructor-arg ref="stringProcessor"/>
+    </bean>
+
+    <int:service-activator input-channel="toStringHandlerChannel" ref="reactorStringHandler"
+                           output-channel="outputChannel2"/>
+
+
+</beans>


### PR DESCRIPTION
Based off 2d59676ccbe20ff2e86cb5e737ea71b25e973e57

* Changed to use PublishSubject
* Remove check for existing observers
* Throw exception if can't dispatch message to a Subject
* Keep track of Subscriptions, unsubscribe on app context destory
* Remove Subject from map when it completes, will be created again on 
  next message for a given dispatcher thread.