### PR TITLE
[Sprint: 41] XD-2590: Handle Large Messages in HTTP Source

### DIFF
--- a/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyInboundMessageConverter.java
+++ b/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyInboundMessageConverter.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.x.http;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+
+import org.springframework.http.MediaType;
+import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
+import org.springframework.integration.support.DefaultMessageBuilderFactory;
+import org.springframework.integration.support.MessageBuilderFactory;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.util.Assert;
+
+
+/**
+ * Message converter (inbound only) to convert a Netty Http MessageEvent to
+ * a Message. Returns null if the content is not readable.
+ *
+ * @author Mark Fisher
+ * @author Jennifer Hickey
+ * @author Gary Russell
+ * @author Marius Bogoevici
+ * @author Peter Rietzler
+ */
+public class NettyInboundMessageConverter implements MessageConverter {
+
+	private final MessageBuilderFactory messageBuilderFactory;
+
+	public NettyInboundMessageConverter() {
+		this(new DefaultMessageBuilderFactory());
+	}
+
+	public NettyInboundMessageConverter(MessageBuilderFactory messageBuilderFactory) {
+		this.messageBuilderFactory = messageBuilderFactory;
+	}
+
+	@Override
+	public Object fromMessage(Message<?> message, Class<?> targetClass) {
+		throw new UnsupportedOperationException("This converter is for inbound messages only.");
+	}
+
+	@Override
+	public Message<?> toMessage(Object payload, MessageHeaders header) {
+		Assert.isInstanceOf(HttpRequest.class, payload);
+		HttpRequest request = (HttpRequest) payload;
+		ChannelBuffer content = request.getContent();
+		Charset charsetToUse = null;
+		boolean binary = false;
+		if (content.readable()) {
+			Map<String, String> messageHeaders = new HashMap<String, String>();
+			for (Entry<String, String> entry : request.getHeaders()) {
+				if (entry.getKey().equalsIgnoreCase("Content-Type")) {
+					MediaType contentType = MediaType.parseMediaType(entry.getValue());
+					charsetToUse = contentType.getCharSet();
+					messageHeaders.put(MessageHeaders.CONTENT_TYPE, entry.getValue());
+					binary = MediaType.APPLICATION_OCTET_STREAM.equals(contentType);
+				}
+				else if (!entry.getKey().toUpperCase().startsWith("ACCEPT")
+						&& !entry.getKey().toUpperCase().equals("CONNECTION")) {
+					messageHeaders.put(entry.getKey(), entry.getValue());
+				}
+			}
+			messageHeaders.put("requestPath", request.getUri());
+			messageHeaders.put("requestMethod", request.getMethod().toString());
+			addHeaders(messageHeaders, request);
+			try {
+				AbstractIntegrationMessageBuilder<?> builder;
+				if (binary) {
+					builder = this.messageBuilderFactory.withPayload(toByteArray(content));
+				}
+				else {
+					// ISO-8859-1 is the default http charset when not set
+					charsetToUse = charsetToUse == null ? Charset.forName("ISO-8859-1") : charsetToUse;
+					builder = this.messageBuilderFactory.withPayload(content.toString(charsetToUse));
+				}
+				builder.copyHeaders(messageHeaders);
+				return builder.build();
+			}
+			catch (Exception ex) {
+				throw new MessageConversionException("Failed to convert netty event to a Message", ex);
+			}
+		}
+		else {
+			return null;
+		}
+	}
+
+	private byte[] toByteArray(ChannelBuffer content) {
+		if (content.hasArray()) {
+			return content.array();
+		}
+		else {
+			byte[] bytes = new byte[content.readableBytes()];
+			content.getBytes(0, bytes);
+			return bytes;
+		}
+	}
+
+	/**
+	 * Add additional headers. Default implementation adds none.
+	 * @param messageHeaders The headers that will be added to the message.
+	 * @param request The HttpRequest
+	 */
+	protected void addHeaders(Map<String, String> messageHeaders, HttpRequest request) {
+	}
+
+}

--- a/modules/source/http/config/http.xml
+++ b/modules/source/http/config/http.xml
@@ -13,8 +13,16 @@
 		<beans:property name="autoStartup" value="false"/>
 		<beans:property name="outputChannel" ref="output"/>
 		<beans:property name="sslPropertiesLocation" value="${sslPropertiesLocation}"/>
+		<beans:property name="maxContentLength" value="${maxContentLength}"/>
+		<beans:property name="messageConverter" ref="converter"/>
 	</beans:bean>
 
+	<beans:bean id="converter" class="org.springframework.integration.x.http.NettyInboundMessageConverter"/>
+
 	<channel id="output"/>
+
+	<beans:beans profile="customConverter">
+		<beans:bean id="converter" class="${messageConverterClass}"/>
+	</beans:beans>
 
 </beans:beans>

--- a/modules/source/http/config/http.xml
+++ b/modules/source/http/config/http.xml
@@ -17,12 +17,10 @@
 		<beans:property name="messageConverter" ref="converter"/>
 	</beans:bean>
 
-	<beans:bean id="converter" class="org.springframework.integration.x.http.NettyInboundMessageConverter"/>
-
 	<channel id="output"/>
 
-	<beans:beans profile="customConverter">
-		<beans:bean id="converter" class="${messageConverterClass}"/>
-	</beans:beans>
+	<beans:bean id="converter" class="${messageConverterClass}">
+		<beans:constructor-arg ref="#{T(org.springframework.integration.support.utils.IntegrationUtils).INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME}"/>
+	</beans:bean>
 
 </beans:beans>

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
@@ -17,14 +17,13 @@
 package org.springframework.xd.dirt.modules.metadata;
 
 import org.springframework.xd.module.options.spi.ModuleOption;
-import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 
 /**
  * Describes options to the {@code http} source module.
  *
  * @author Gary Russell
  */
-public class HttpSourceOptionsMetadata implements ProfileNamesProvider {
+public class HttpSourceOptionsMetadata {
 
 	private int port = 9000;
 
@@ -34,7 +33,7 @@ public class HttpSourceOptionsMetadata implements ProfileNamesProvider {
 
 	private int maxContentLength = 1048576;
 
-	private String messageConverterClass = null;
+	private String messageConverterClass = "org.springframework.integration.x.http.NettyInboundMessageConverter";
 
 	public int getPort() {
 		return port;
@@ -76,19 +75,9 @@ public class HttpSourceOptionsMetadata implements ProfileNamesProvider {
 		return messageConverterClass;
 	}
 
-	@ModuleOption("the name of a custom MessageConverter class, to convert HttpRequest to Message")
+	@ModuleOption("the name of a custom MessageConverter class, to convert HttpRequest to Message; must have a constructor with a 'MessageBuilderFactory' parameter")
 	public void setMessageConverterClass(String messageConverterClass) {
 		this.messageConverterClass = messageConverterClass;
-	}
-
-	@Override
-	public String[] profilesToActivate() {
-		if (this.messageConverterClass != null) {
-			return new String[] { "customConverter" };
-		}
-		else {
-			return new String[0];
-		}
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@
 package org.springframework.xd.dirt.modules.metadata;
 
 import org.springframework.xd.module.options.spi.ModuleOption;
+import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 
 /**
  * Describes options to the {@code http} source module.
- * 
+ *
  * @author Gary Russell
  */
-public class HttpSourceOptionsMetadata {
+public class HttpSourceOptionsMetadata implements ProfileNamesProvider {
 
 	private int port = 9000;
 
@@ -31,6 +32,9 @@ public class HttpSourceOptionsMetadata {
 
 	private String sslPropertiesLocation = "classpath:httpSSL.properties";
 
+	private int maxContentLength = 1048576;
+
+	private String messageConverterClass = null;
 
 	public int getPort() {
 		return port;
@@ -57,6 +61,34 @@ public class HttpSourceOptionsMetadata {
 	@ModuleOption("location (resource) of properties containing the location of the pkcs12 keyStore and pass phrase")
 	public void setSslPropertiesLocation(String sslProperties) {
 		this.sslPropertiesLocation = sslProperties;
+	}
+
+	public int getMaxContentLength() {
+		return maxContentLength;
+	}
+
+	@ModuleOption("the maximum allowed content length")
+	public void setMaxContentLength(int maxContentLength) {
+		this.maxContentLength = maxContentLength;
+	}
+
+	public String getMessageConverterClass() {
+		return messageConverterClass;
+	}
+
+	@ModuleOption("the name of a custom MessageConverter class, to convert HttpRequest to Message")
+	public void setMessageConverterClass(String messageConverterClass) {
+		this.messageConverterClass = messageConverterClass;
+	}
+
+	@Override
+	public String[] profilesToActivate() {
+		if (this.messageConverterClass != null) {
+			return new String[] { "customConverter" };
+		}
+		else {
+			return new String[0];
+		}
 	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2590

Based on original work by Peter Rietzler:

http source now accepts binary content larger that a few KB

The problem was the assumption that the ChannerBuffer is always backed
by an array - which is not the case if you send e.g. binary data that
is larger than around 10KB. The solution is to check the availability
of a backing byte[] with the hasArray() method.

- move the decoding work to a `MessageConverter`
- allow the message converter to be configured
- add a setter for the max content length; add error handling when the content length is exceeded
  - previously, the client hung waiting for a reply.
  - close the channel in the catch all `exceptionCaught` method and log the error.
- add properties to the http source (maxContentLength, messageConverterClass)

__replaces #1367 __