### PR TITLE
XD-2482: Add `initialDelay` and `TimeUnit`

### DIFF
--- a/modules/source/time/config/time.xml
+++ b/modules/source/time/config/time.xml
@@ -10,7 +10,13 @@
 	<inbound-channel-adapter channel="output"
 			auto-startup="false"
 			expression="new java.text.SimpleDateFormat('${format}').format(new java.util.Date())">
-		<poller fixed-delay="${fixedDelay}" time-unit="SECONDS"/>
+		<poller trigger="fixedDelayTrigger" />
 	</inbound-channel-adapter>
+
+	<beans:bean id="fixedDelayTrigger" class="org.springframework.scheduling.support.PeriodicTrigger">
+		<beans:constructor-arg value="${fixedDelay}" />
+		<beans:constructor-arg value="${timeUnit}" />
+		<beans:property name="initialDelay" value="${initialDelay} "/>
+	</beans:bean>
 
 </beans:beans>

--- a/modules/source/trigger/config/trigger.xml
+++ b/modules/source/trigger/config/trigger.xml
@@ -6,15 +6,16 @@
 
 	<int:channel id="output" />
 
+	<int:inbound-channel-adapter channel="output"
+		auto-startup="false" expression="'${payload}'">
+		<int:poller trigger="trigger" />
+	</int:inbound-channel-adapter>
+
 	<beans profile="use-date">
-		<int:inbound-channel-adapter channel="output"
-			auto-startup="false" expression="'${payload}'">
-			<int:poller trigger="dateTrigger" />
-		</int:inbound-channel-adapter>
         <bean id="df" class="java.text.SimpleDateFormat">
             <constructor-arg value="${dateFormat}" />
         </bean>
-        <bean id="dateTrigger" class="org.springframework.xd.module.support.DateTrigger">
+        <bean id="trigger" class="org.springframework.xd.module.support.DateTrigger">
             <constructor-arg>
                 <bean factory-bean="df" factory-method="parse">
                     <constructor-arg value="${date}" />
@@ -24,17 +25,17 @@
 	</beans>
 
 	<beans profile="use-cron">
-		<int:inbound-channel-adapter channel="output"
-			auto-startup="false" expression="'${payload}'">
-			<int:poller cron="${cron}" />
-		</int:inbound-channel-adapter>
+		<bean id="trigger" class="org.springframework.scheduling.support.CronTrigger">
+			<constructor-arg value="${cron}" />
+		</bean>
 	</beans>
 
 	<beans profile="use-delay">
-		<int:inbound-channel-adapter channel="output"
-			auto-startup="false" expression="'${payload}'">
-			<int:poller fixed-delay="${fixedDelay}" time-unit="SECONDS" />
-		</int:inbound-channel-adapter>
+		<bean id="trigger" class="org.springframework.scheduling.support.PeriodicTrigger">
+			<constructor-arg value="${fixedDelay}" />
+			<constructor-arg value="${timeUnit}" />
+			<property name="initialDelay" value="${initialDelay} "/>
+		</bean>
 	</beans>
 
 </beans>

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/PeriodicTriggerMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/PeriodicTriggerMixin.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.modules.metadata;
+
+import javax.validation.constraints.Min;
+
+import org.springframework.xd.module.options.spi.ModuleOption;
+
+
+/**
+ * Mixin for options that include a periodic fixed-delay trigger.
+ * fixedDelay remains in annotated classes to avoid breaking changes
+ * due to differing defaults.
+ *
+ * @author Gary Russell
+ */
+public class PeriodicTriggerMixin {
+
+	private Integer initialDelay = 0;
+
+	private String timeUnit = "SECONDS";
+
+	@Min(0)
+	public Integer getInitialDelay() {
+		return initialDelay;
+	}
+
+	@ModuleOption("an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)")
+	public void setInitialDelay(Integer initialDelay) {
+		this.initialDelay = initialDelay;
+	}
+
+	public String getTimeUnit() {
+		return timeUnit;
+	}
+
+	@ModuleOption("the time unit for the fixed delay")
+	public void setTimeUnit(String timeUnit) {
+		this.timeUnit = timeUnit;
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TimeSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TimeSourceOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,16 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
+import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
 
 /**
  * Describes options to the {@code time} source module.
- * 
+ *
  * @author Eric Bottard
+ * @author Gary Russell
  */
+@Mixin(PeriodicTriggerMixin.class)
 public class TimeSourceOptionsMetadata {
 
 	private String format = "yyyy-MM-dd HH:mm:ss";

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TriggerSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TriggerSourceOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,27 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
-import org.hibernate.validator.constraints.NotBlank;
-import org.springframework.xd.module.options.spi.ModuleOption;
-import org.springframework.xd.module.options.spi.ProfileNamesProvider;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import org.springframework.xd.module.options.spi.Mixin;
+import org.springframework.xd.module.options.spi.ModuleOption;
+import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 
 /**
  * Describes options to the {@code trigger} source module.
- * 
+ *
  * @author Eric Bottard
  * @author Florent Biville
+ * @author Gary Russell
  */
+@Mixin(PeriodicTriggerMixin.class)
 public class TriggerSourceOptionsMetadata implements ProfileNamesProvider {
 
 	private Integer fixedDelay;
@@ -40,9 +45,9 @@ public class TriggerSourceOptionsMetadata implements ProfileNamesProvider {
 
 	private String payload = "";
 
-    private String date;
+	private String date;
 
-    private String dateFormat = "MM/dd/yy HH:mm:ss";
+	private String dateFormat = "MM/dd/yy HH:mm:ss";
 
 	@Override
 	public String[] profilesToActivate() {
@@ -67,7 +72,7 @@ public class TriggerSourceOptionsMetadata implements ProfileNamesProvider {
 		return !(fixedDelay != null && cron != null);
 	}
 
-	@ModuleOption("number of seconds between executions")
+	@ModuleOption("number of seconds between executions, expressed in TimeUnits (seconds by default)")
 	public void setFixedDelay(Integer fixedDelay) {
 		this.fixedDelay = fixedDelay;
 	}
@@ -92,26 +97,26 @@ public class TriggerSourceOptionsMetadata implements ProfileNamesProvider {
 		this.payload = payload;
 	}
 
-    @NotNull
-    public String getDate() {
-        if (date == null) {
-            return new SimpleDateFormat(dateFormat).format(new Date());
-        }
-        return date;
-    }
+	@NotNull
+	public String getDate() {
+		if (date == null) {
+			return new SimpleDateFormat(dateFormat).format(new Date());
+		}
+		return date;
+	}
 
-    @ModuleOption("the date when the trigger should fire")
-    public void setDate(String date) {
-        this.date = date;
-    }
+	@ModuleOption("the date when the trigger should fire")
+	public void setDate(String date) {
+		this.date = date;
+	}
 
-    @NotBlank
-    public String getDateFormat() {
-        return dateFormat;
-    }
+	@NotBlank
+	public String getDateFormat() {
+		return dateFormat;
+	}
 
-    @ModuleOption("the format specifying how the date should be parsed")
-    public void setDateFormat(String dateFormat) {
-        this.dateFormat = dateFormat;
-    }
+	@ModuleOption("the format specifying how the date should be parsed")
+	public void setDateFormat(String dateFormat) {
+		this.dateFormat = dateFormat;
+	}
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2482

Support `initialDelay` and `timeUnit` properties for the `time` and `trigger` sources.

Create a new `Mixin` but the `fixedDelay` property has to remain in the existing
options metadata because of different defaults.