### PR TITLE
[Sprint: 41] XD-2606: Add trackHistory Deployment Property

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.xd.dirt.plugins.stream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -26,10 +27,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_STREAM_NAME_KEY;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.After;
 import org.junit.Before;
@@ -42,6 +46,8 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.interceptor.WireTap;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.BridgeHandler;
+import org.springframework.integration.support.DefaultMessageBuilderFactory;
+import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -50,8 +56,9 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.validation.BindException;
-import org.springframework.xd.dirt.integration.bus.local.LocalMessageBus;
+import org.springframework.xd.dirt.integration.bus.BusProperties;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
+import org.springframework.xd.dirt.integration.bus.local.LocalMessageBus;
 import org.springframework.xd.dirt.zookeeper.EmbeddedZooKeeper;
 import org.springframework.xd.dirt.zookeeper.Paths;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
@@ -190,7 +197,7 @@ public class StreamPluginTests {
 				.build());
 		when(module.getType()).thenReturn(moduleDefinition.getType());
 		when(module.getName()).thenReturn(moduleDefinition.getName());
-		final AtomicBoolean messageReceived = new AtomicBoolean();
+		final AtomicReference<Message<?>> messageReceived = new AtomicReference<>();
 		LocalMessageBus bus = new LocalMessageBus() {
 
 			final AtomicBoolean consumerBound = new AtomicBoolean();
@@ -202,7 +209,7 @@ public class StreamPluginTests {
 
 					@Override
 					public void handleMessage(Message<?> message) throws MessagingException {
-						messageReceived.set(true);
+						messageReceived.set(message);
 					}
 
 				};
@@ -244,11 +251,19 @@ public class StreamPluginTests {
 		bridge.start();
 		when(module.getComponent("input", MessageChannel.class)).thenReturn(input);
 		when(module.getComponent("output", MessageChannel.class)).thenReturn(output);
+		ModuleDeploymentProperties props = new ModuleDeploymentProperties();
+		props.put(BusProperties.TRACK_HISTORY, "true");
+		when(module.getDeploymentProperties()).thenReturn(props);
+		when(module.getComponent(MessageBuilderFactory.class)).thenReturn(new DefaultMessageBuilderFactory());
 		StreamPlugin plugin = new StreamPlugin(bus, zkConnection);
 		plugin.preProcessModule(module);
 		plugin.postProcessModule(module);
 		input.send(new GenericMessage<String>("foo"));
-		assertTrue(messageReceived.get());
+		assertNotNull(messageReceived.get());
+		Collection<Map<String, Object>> xdHistory =
+				(Collection<Map<String, Object>>) messageReceived.get().getHeaders().get("xdHistory");
+		assertTrue(xdHistory != null);
+		assertEquals("testing", xdHistory.iterator().next().get("module"));
 	}
 
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
@@ -252,7 +252,7 @@ public class StreamPluginTests {
 		when(module.getComponent("input", MessageChannel.class)).thenReturn(input);
 		when(module.getComponent("output", MessageChannel.class)).thenReturn(output);
 		ModuleDeploymentProperties props = new ModuleDeploymentProperties();
-		props.put(BusProperties.TRACK_HISTORY, "true");
+		props.setTrackHistory(true);
 		when(module.getDeploymentProperties()).thenReturn(props);
 		when(module.getComponent(MessageBuilderFactory.class)).thenReturn(new DefaultMessageBuilderFactory());
 		StreamPlugin plugin = new StreamPlugin(bus, zkConnection);

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
@@ -124,4 +124,9 @@ public interface BusProperties {
 	 */
 	public static final String COMPRESS = "compress";
 
+	/**
+	 * Track history.
+	 */
+	public static final String TRACK_HISTORY = "trackHistory";
+
 }

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
@@ -124,9 +124,4 @@ public interface BusProperties {
 	 */
 	public static final String COMPRESS = "compress";
 
-	/**
-	 * Track history.
-	 */
-	public static final String TRACK_HISTORY = "trackHistory";
-
 }

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDeploymentProperties.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDeploymentProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.Set;
  * Deployment properties for a module.
  *
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public class ModuleDeploymentProperties implements Map<String, String> {
 
@@ -44,6 +45,11 @@ public class ModuleDeploymentProperties implements Map<String, String> {
 	 * Key for the {@code criteria} property. Value should be a SpEL expression.
 	 */
 	public static final String CRITERIA_KEY = "criteria";
+
+	/**
+	 * Key for the {@code trackHistory} property. Value should be a boolean.
+	 */
+	public static final String TRACK_HISTORY_KEY = "trackHistory";
 
 	/**
 	 * The underlying map.
@@ -93,6 +99,23 @@ public class ModuleDeploymentProperties implements Map<String, String> {
 	 */
 	public ModuleDeploymentProperties setCriteria(String criteria) {
 		put(CRITERIA_KEY, criteria);
+		return this;
+	}
+
+	/**
+	 * Return the trackHistory property for this module.
+	 *
+	 * @return true if history should be tracked.
+	 */
+	public boolean getTrackHistory() {
+		return Boolean.valueOf(get(TRACK_HISTORY_KEY));
+	}
+
+	/**
+	 * Specify the trackHistory property for this module.
+	 */
+	public ModuleDeploymentProperties setTrackHistory(boolean trackHistory) {
+		put(TRACK_HISTORY_KEY, String.valueOf(trackHistory));
 		return this;
 	}
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2606
````
xd:>stream create foo --definition "time | transformLabel: transform | log --expression=#root"
Created new stream 'foo'
xd:>stream create bar --definition "tap:stream:foo > transform | log --expression=#root"
Created new stream 'bar'
xd:>stream deploy --name foo --properties "module.*.trackHistory=true"
Deployed stream 'foo'
xd:>stream deploy --name bar --properties "module.*.trackHistory=true"
Deployed stream 'bar'
````
>18:42:48,137  INFO task-scheduler-4 sink.foo - GenericMessage [payload=2015-01-16 18:42:48, headers={xdHistory=[{container.id=aa885943-5df7-4de6-be8a-9f8ccae4bdcf, pid=94203, stream.name=foo, host=myhost, groups=, ip=10.0.0.2, module=time, thread=task-scheduler-4}, {container.id=aa885943-5df7-4de6-be8a-9f8ccae4bdcf, pid=94203, stream.name=foo, host=myhost, groups=, ip=10.0.0.2, module=transformLabel, thread=task-scheduler-4}, {container.id=aa885943-5df7-4de6-be8a-9f8ccae4bdcf, pid=94203, stream.name=foo, host=myhost, groups=, ip=10.0.0.2, module=log, thread=task-scheduler-4}], id=342e64f3-6998-06c7-a14b-bb0d6374931a, timestamp=1421451768137}]

>18:42:48,137  INFO pool-1-thread-1 sink.bar - GenericMessage [payload=2015-01-16 18:42:48, headers={xdHistory=[{container.id=aa885943-5df7-4de6-be8a-9f8ccae4bdcf, pid=94203, stream.name=foo, host=myhost, groups=, ip=10.0.0.2, module=time, thread=task-scheduler-4}, {container.id=aa885943-5df7-4de6-be8a-9f8ccae4bdcf, pid=94203, stream.name=bar, host=myhost, groups=, ip=10.0.0.2, module=tap:stream:foo.time.0>transform, thread=pool-1-thread-1}, {container.id=aa885943-5df7-4de6-be8a-9f8ccae4bdcf, pid=94203, stream.name=bar, host=myhost, groups=, ip=10.0.0.2, module=log, thread=pool-1-thread-1}], id=c88bb73c-354e-6bc1-45f2-2fef4afe0a13, timestamp=1421451768137}]