### PR TITLE
[Sprint: 41] XD-2597 Adding new 'admininfo' command to list admins host:port info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -678,6 +678,9 @@ project('spring-xd-yarn:spring-xd-yarn-client') {
 			exclude group: 'log4j', module: 'log4j'
 		}
 		compile "org.springframework.boot:spring-boot-autoconfigure"
+		compile("org.apache.zookeeper:zookeeper:$zookeeperVersion") {
+			exclude group: 'jline', module: 'jline'
+		}
 		runtime "log4j:log4j",
 				"org.slf4j:jcl-over-slf4j",
 				"org.slf4j:slf4j-log4j12"

--- a/spring-xd-yarn/site/scripts/xd-yarn
+++ b/spring-xd-yarn/site/scripts/xd-yarn
@@ -16,7 +16,7 @@ COMMANDS:
     xd-yarn submit [OPTIONS]                 Submit a new application instance
     xd-yarn submitted [OPTIONS]              List status of submitted instances
     xd-yarn kill [OPTIONS]                   Kill an running instance
-    xd-yarn admininfo                        List http host and port info for the admin servers
+    xd-yarn admininfo [OPTIONS]              List http host and port info for the admin servers
     xd-yarn clustersinfo [OPTIONS]           List instance container clusters info
     xd-yarn clustercreate [OPTIONS]          Create a new container cluster
     xd-yarn clusterdestroy [OPTIONS]         Destroy a existing container cluster

--- a/spring-xd-yarn/site/scripts/xd-yarn
+++ b/spring-xd-yarn/site/scripts/xd-yarn
@@ -16,6 +16,7 @@ COMMANDS:
     xd-yarn submit [OPTIONS]                 Submit a new application instance
     xd-yarn submitted [OPTIONS]              List status of submitted instances
     xd-yarn kill [OPTIONS]                   Kill an running instance
+    xd-yarn admininfo                        List http host and port info for the admin servers
     xd-yarn clustersinfo [OPTIONS]           List instance container clusters info
     xd-yarn clustercreate [OPTIONS]          Create a new container cluster
     xd-yarn clusterdestroy [OPTIONS]         Destroy a existing container cluster
@@ -120,7 +121,7 @@ do
         else
             die "No application directory location specified for -d option"
         fi
-    elif [ "$1" = "push" ] || [ "$1" = "shell" ] || [ "$1" = "kill" ] || [ "$1" = "pushed" ] || [ "$1" = "submit" ] || [ "$1" = "submitted" ] || [ "$1" = "clustercreate" ] || [ "$1" = "clusterdestroy" ] || [ "$1" = "clusterinfo" ] || [ "$1" = "clustermodify" ] || [ "$1" = "clustersinfo" ] || [ "$1" = "clusterstart" ] || [ "$1" = "clusterstop" ]; then
+    elif [ "$1" = "push" ] || [ "$1" = "shell" ] || [ "$1" = "kill" ] || [ "$1" = "pushed" ] || [ "$1" = "submit" ] || [ "$1" = "submitted" ] || [ "$1" = "clustercreate" ] || [ "$1" = "clusterdestroy" ] || [ "$1" = "clusterinfo" ] || [ "$1" = "clustermodify" ] || [ "$1" = "clustersinfo" ] || [ "$1" = "clusterstart" ] || [ "$1" = "clusterstop" ] || [ "$1" = "admininfo" ]; then
         PARAMS=("${PARAMS[@]}" "$1")
         if [ "$ACTION" = "" ]; then
             ACTION="$1"

--- a/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/ClientApplication.java
+++ b/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/ClientApplication.java
@@ -53,6 +53,7 @@ public class ClientApplication extends AbstractCli {
 		cmdCommands.add(new YarnSubmitCommand());
 		cmdCommands.add(new YarnSubmittedCommand(new SubmittedOptionHandler("XD")));
 		cmdCommands.add(new YarnKillCommand());
+		cmdCommands.add(new XdYarnAdminInfoCommand());
 		cmdCommands.add(new YarnClustersInfoCommand());
 		cmdCommands.add(new YarnClusterInfoCommand());
 		cmdCommands.add(new XdYarnClusterCreateCommand());
@@ -62,7 +63,7 @@ public class ClientApplication extends AbstractCli {
 		cmdCommands.add(new YarnClusterDestroyCommand());		
 		app.registerCommands(cmdCommands);
 
-		// shell commands, push not supported in shell
+		// shell commands, push and admininfo not supported in shell
 		List<Command> shellCommands = new ArrayList<Command>();
 		shellCommands.add(new YarnPushedCommand());
 		shellCommands.add(new YarnSubmitCommand());

--- a/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/ClientApplication.java
+++ b/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/ClientApplication.java
@@ -63,12 +63,13 @@ public class ClientApplication extends AbstractCli {
 		cmdCommands.add(new YarnClusterDestroyCommand());		
 		app.registerCommands(cmdCommands);
 
-		// shell commands, push and admininfo not supported in shell
+		// shell commands, push not supported in shell
 		List<Command> shellCommands = new ArrayList<Command>();
 		shellCommands.add(new YarnPushedCommand());
 		shellCommands.add(new YarnSubmitCommand());
 		shellCommands.add(new YarnSubmittedCommand(new SubmittedOptionHandler("XD")));
 		shellCommands.add(new YarnKillCommand());
+		shellCommands.add(new XdYarnAdminInfoCommand());
 		shellCommands.add(new YarnClustersInfoCommand());
 		shellCommands.add(new YarnClusterInfoCommand());
 		shellCommands.add(new XdYarnClusterCreateCommand());

--- a/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/XdYarnAdminInfoCommand.java
+++ b/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/XdYarnAdminInfoCommand.java
@@ -111,13 +111,14 @@ public class XdYarnAdminInfoCommand extends AbstractCommand {
 			if (stat != null) {
 				List<String> admins = zk.getChildren(adminsPath, false);
 				for (String admin : admins) {
-					Stat dataStat = new Stat();
-					byte[] data = zk.getData(adminsPath + "/" + admin, false, dataStat);
+					byte[] data = zk.getData(adminsPath + "/" + admin, false, null);
 					try {
 						HashMap<String,Object> dataValues =
 								new ObjectMapper().readValue(new String(data), HashMap.class);
 						results.add("http://" + dataValues.get("host") + ":" + dataValues.get("port"));
-					} catch (IOException e) {}
+					} catch (IOException e) {
+						Log.error("IOException while retrieving data for " + admin + ": " + e.getMessage());
+					}
 				}
 			}
 		} catch (InterruptedException ignore) {}

--- a/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/XdYarnAdminInfoCommand.java
+++ b/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/XdYarnAdminInfoCommand.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.yarn;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.boot.cli.command.AbstractCommand;
+import org.springframework.boot.cli.command.status.ExitStatus;
+import org.springframework.boot.cli.util.Log;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * A custom command for listing the http ports used by admin servers.
+ *
+ * @author Thomas Risberg
+ */
+public class XdYarnAdminInfoCommand extends AbstractCommand {
+
+	private static final String XD_YARN_ADMIN_INFO_COMMAND_NAME = "admininfo";
+	private static final String XD_YARN_ADMIN_INFO_COMMAND_DESC = "List http host and port info for the admin servers";
+
+	public static final String ZK_NAMESPACE = "zk.namespace";
+	public static final String ZK_CLIENT_CONNECT = "zk.client.connect";
+
+	public static final String XD_ADMINS = "admins";
+
+	private String zkNamespace = "xd";
+	private String zkClientConnect = "localhost:2181";
+
+	private ZooKeeper zk;
+
+	/**
+	 * Call super constructor for new {@link org.springframework.boot.cli.command.AbstractCommand} instance.
+	 */
+	public XdYarnAdminInfoCommand() {
+		super(XD_YARN_ADMIN_INFO_COMMAND_NAME, XD_YARN_ADMIN_INFO_COMMAND_DESC);
+	}
+
+	@Override
+	public ExitStatus run(String... args) throws InterruptedException {
+		try {
+			init();
+			Log.info("Admins: " + getAdmins());
+		}
+		catch (IOException e) {
+			Log.error("IOException accessing admin info: " + e.getMessage());
+		}
+		catch (KeeperException e) {
+			Log.error("KeeperException accessing admin info: " + e.getMessage());
+		}
+		finally {
+			close();
+		}
+		return ExitStatus.OK;
+	}
+
+	private void init() throws IOException {
+		YamlPropertiesFactoryBean ypfb = new YamlPropertiesFactoryBean();
+		ypfb.setResources(new FileSystemResource(System.getProperty("spring.config.location")));
+		Properties conf = ypfb.getObject();
+		if (conf.containsKey(ZK_NAMESPACE)) {
+			zkNamespace = (String) conf.get(ZK_NAMESPACE);
+		}
+		if (conf.containsKey(ZK_CLIENT_CONNECT)) {
+			zkClientConnect = (String) conf.get(ZK_CLIENT_CONNECT);
+		}
+		zk = new ZooKeeper(zkClientConnect, 5000,
+				new Watcher() {
+					@Override
+					public void process(WatchedEvent event) {
+					}
+				});
+	}
+
+	private void close() throws InterruptedException {
+		if (zk != null) {
+			zk.close();
+		}
+	}
+
+	private List<String> getAdmins() throws KeeperException {
+		String adminsPath = "/" + zkNamespace + "/" + XD_ADMINS;
+		List<String> results = new ArrayList<String>();
+		try {
+			Stat stat = zk.exists(adminsPath, false);
+			if (stat != null) {
+				List<String> admins = zk.getChildren(adminsPath, false);
+				for (String admin : admins) {
+					Stat dataStat = new Stat();
+					byte[] data = zk.getData(adminsPath + "/" + admin, false, dataStat);
+					try {
+						HashMap<String,Object> dataValues =
+								new ObjectMapper().readValue(new String(data), HashMap.class);
+						results.add("http://" + dataValues.get("host") + ":" + dataValues.get("port"));
+					} catch (IOException e) {}
+				}
+			}
+		} catch (InterruptedException ignore) {}
+		return results;
+	}
+}


### PR DESCRIPTION
- using ZooKeeper APIs directly since we only do reads

- we don't monitor for live changes since if data is not there we just show empty list

- user would have to run command again to pick up any changes