### PR TITLE
XD-2482: Validate TimeUnit

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/PeriodicTriggerMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/PeriodicTriggerMixin.java
@@ -17,6 +17,7 @@
 package org.springframework.xd.dirt.modules.metadata;
 
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
 
 import org.springframework.xd.module.options.spi.ModuleOption;
 
@@ -44,6 +45,8 @@ public class PeriodicTriggerMixin {
 		this.initialDelay = initialDelay;
 	}
 
+	@Pattern(regexp = "(?i)(NANOSECONDS|MICROSECONDS|MILLISECONDS|SECONDS|MINUTES|HOURS|DAYS)",
+			message = "timeUnit must be one of NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS (case-insensitive)")
 	public String getTimeUnit() {
 		return timeUnit;
 	}


### PR DESCRIPTION
    xd:>stream create foo --definition "time --timeUnit=millis --initialDelay=5000 --fixedDelay=1000 | log" --deploy
    Command failed org.springframework.xd.rest.client.impl.SpringXDException: Error with option(s) for module time of type source:
    timeUnit: timeUnit must be one of NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS (case-insensitive)

    xd:>stream create foo --definition "time --timeUnit=milliseconds --initialDelay=5000 --fixedDelay=1000 | log" --deploy
    Created and deployed new stream 'foo'