### PR TITLE
XD-2643 Kafka test creates Topic prior to tests

### DIFF
--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
@@ -16,6 +16,8 @@
 
 package org.springframework.xd.integration.fixtures;
 
+import kafka.utils.ZKStringSerializer$;
+import org.I0Itec.zkclient.ZkClient;
 import org.springframework.util.Assert;
 import org.springframework.xd.integration.util.XdEnvironment;
 import org.springframework.xd.test.fixtures.GemFireCQSource;
@@ -341,6 +343,16 @@ public class Sources extends ModuleFixture {
 	 */
 	public TcpClientSource tcpClientSource() {
 		return new TcpClientSource(xdEnvironment.getTcpClientHost(), xdEnvironment.getTcpClientPort());
+	}
+
+	/**
+	 * Creates a ZkClient connected to the Zookeeper that the kafka is associated.
+	 * @return zkClient instance that is connected to the kafka's zookeeper
+	 */
+	public ZkClient getKafkaZkClient(){
+		int zkConnectionTimeout = 6000;
+		int zkSessionTimeout = 6000;
+		return new ZkClient(xdEnvironment.getKafkaZkConnect(), 6000, 6000, ZKStringSerializer$.MODULE$);
 	}
 
 }

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/KafkaTests.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/KafkaTests.java
@@ -16,10 +16,13 @@
 
 package org.springframework.xd.integration.test;
 
+import kafka.admin.AdminUtils;
+import org.I0Itec.zkclient.ZkClient;
 import org.junit.Test;
 import org.springframework.xd.test.fixtures.KafkaSink;
 import org.springframework.xd.test.fixtures.KafkaSource;
 
+import java.util.Properties;
 import java.util.UUID;
 
 /**
@@ -35,10 +38,13 @@ public class KafkaTests extends AbstractIntegrationTest {
 	@Test
 	public void kafkaSourceSinkTest() {
 		String data = UUID.randomUUID().toString();
-		String topic = UUID.randomUUID().toString();
+		String topicToUse = UUID.randomUUID().toString();
+		ZkClient zkClient = sources.getKafkaZkClient();
+		AdminUtils.createTopic(zkClient, topicToUse, 1, 1, new Properties());
+
 		String sinkStreamName = "ks" + UUID.randomUUID().toString();
-		KafkaSource source = sources.kafkaSource().topic(topic).ensureReady();
-		KafkaSink sink = sinks.kafkaSink().topic(topic).ensureReady();
+		KafkaSource source = sources.kafkaSource().topic(topicToUse).ensureReady();
+		KafkaSink sink = sinks.kafkaSink().topic(topicToUse).ensureReady();
 
 		stream(source + XD_DELIMITER + sinks.file());
 		stream(sinkStreamName, sources.http() + XD_DELIMITER + sink);
@@ -46,4 +52,5 @@ public class KafkaTests extends AbstractIntegrationTest {
 		assertFileContains(data);
 		assertReceived(1);
 	}
+
 }


### PR DESCRIPTION
Kafka source and sink require a topic to be present before execution.  This code creates the topic at the beginning of the test.