### PR TITLE
[Sprint: 41] XD-2638 Update spring-data-hadoop version to 2.1.0.RC1

### DIFF
--- a/gradle/build-dist.gradle
+++ b/gradle/build-dist.gradle
@@ -189,10 +189,10 @@ task distShellZip(type: Zip, dependsOn: [copyInstall], overwrite: true) {
         }
         // copy hadoop distro jars
         [
-                'hadoop24',
                 'hadoop25',
+                'hadoop26',
                 'cdh5',
-                'hdp21',
+                'hdp22',
                 'phd21'
         ].each { distro ->
                         from("$buildDir/dist/spring-xd/xd/lib/$distro") {


### PR DESCRIPTION
- missed some distros for Spring Shell zip distribution in XD-2594

- adding hadoop26 and hdp22 to distShellZip task