### PR TITLE
[Sprint: 41] XD-2606: Fix Track History with Redis/Kafka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -928,6 +928,7 @@ project('spring-xd-messagebus-spi') {
 		compile "org.springframework:spring-messaging"
 		compile "org.springframework.retry:spring-retry"
 		compile "org.springframework.integration:spring-integration-core"
+		compile "com.fasterxml.jackson.core:jackson-databind"
 	}
 }
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -44,6 +44,7 @@ import org.springframework.messaging.support.ChannelInterceptorAdapter;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
+import org.springframework.xd.dirt.integration.bus.XdHeaders;
 import org.springframework.xd.dirt.zookeeper.Paths;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperConnectionListener;
@@ -187,7 +188,7 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 				public Message<?> preSend(Message<?> message, MessageChannel channel) {
 					@SuppressWarnings("unchecked")
 					Collection<Map<String, Object>> history =
-							(Collection<Map<String, Object>>) message.getHeaders().get("xdHistory");
+							(Collection<Map<String, Object>>) message.getHeaders().get(XdHeaders.XD_HISTORY);
 					if (history == null) {
 						history = new ArrayList<Map<String, Object>>(1);
 					}
@@ -200,7 +201,7 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 					history.add(map);
 					Message<?> out = messageBuilderFactory
 										.fromMessage(message)
-										.setHeader("xdHistory", history)
+										.setHeader(XdHeaders.XD_HISTORY, history)
 										.build();
 					return out;
 				}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/AbstractMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/AbstractMessageBusTests.java
@@ -93,7 +93,7 @@ public abstract class AbstractMessageBusTests {
 		Message<?> inbound = moduleInputChannel.receive(5000);
 		assertNotNull(inbound);
 		assertEquals("foo", inbound.getPayload());
-		assertNull(inbound.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+		assertNull(inbound.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 		assertEquals("foo/bar", inbound.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 		messageBus.unbindProducers("foo.0");
 		messageBus.unbindConsumers("foo.0");
@@ -113,7 +113,7 @@ public abstract class AbstractMessageBusTests {
 		Message<?> inbound = moduleInputChannel.receive(5000);
 		assertNotNull(inbound);
 		assertEquals("foo", inbound.getPayload());
-		assertNull(inbound.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+		assertNull(inbound.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 		assertNull(inbound.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 		messageBus.unbindProducers("bar.0");
 		messageBus.unbindConsumers("bar.0");
@@ -144,7 +144,7 @@ public abstract class AbstractMessageBusTests {
 			Message<?> inbound = moduleInputChannel.receive(5000);
 			assertNotNull(inbound);
 			assertEquals("foo", inbound.getPayload());
-			assertNull(inbound.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+			assertNull(inbound.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 			assertEquals("foo/bar", inbound.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 			Message<?> tapped1 = module2InputChannel.receive(5000);
 			Message<?> tapped2 = module3InputChannel.receive(5000);
@@ -156,10 +156,10 @@ public abstract class AbstractMessageBusTests {
 			}
 			success = true;
 			assertEquals("foo", tapped1.getPayload());
-			assertNull(tapped1.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+			assertNull(tapped1.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 			assertEquals("foo/bar", tapped1.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 			assertEquals("foo", tapped2.getPayload());
-			assertNull(tapped2.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+			assertNull(tapped2.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 			assertEquals("foo/bar", tapped2.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 		}
 		// delete one tap stream is deleted
@@ -211,7 +211,7 @@ public abstract class AbstractMessageBusTests {
 			Message<?> inbound = moduleInputChannel.receive(5000);
 			assertNotNull(inbound);
 			assertEquals("foo", inbound.getPayload());
-			assertNull(inbound.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+			assertNull(inbound.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 			assertEquals("foo/bar", inbound.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 			Message<?> tapped1 = module2InputChannel.receive(5000);
 			Message<?> tapped2 = module3InputChannel.receive(5000);
@@ -223,10 +223,10 @@ public abstract class AbstractMessageBusTests {
 			}
 			success = true;
 			assertEquals("foo", tapped1.getPayload());
-			assertNull(tapped1.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+			assertNull(tapped1.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 			assertEquals("foo/bar", tapped1.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 			assertEquals("foo", tapped2.getPayload());
-			assertNull(tapped2.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+			assertNull(tapped2.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 			assertEquals("foo/bar", tapped2.getHeaders().get(MessageHeaders.CONTENT_TYPE));
 		}
 		// delete one tap stream is deleted

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportTests.java
@@ -76,7 +76,7 @@ public class MessageBusSupportTests {
 		Message<?> reconstructed = messageBus.deserializePayloadIfNecessary(converted);
 		payload = (byte[]) reconstructed.getPayload();
 		assertSame(converted.getPayload(), payload);
-		assertNull(reconstructed.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+		assertNull(reconstructed.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 	}
 
 	@Test
@@ -95,7 +95,7 @@ public class MessageBusSupportTests {
 		assertSame(converted.getPayload(), payload);
 		assertEquals(MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE,
 				reconstructed.getHeaders().get(MessageHeaders.CONTENT_TYPE));
-		assertNull(reconstructed.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+		assertNull(reconstructed.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 	}
 
 	@Test
@@ -121,7 +121,7 @@ public class MessageBusSupportTests {
 		assertEquals(MimeTypeUtils.TEXT_PLAIN,
 				contentTypeResolver.resolve(converted.getHeaders()));
 		assertEquals(MimeTypeUtils.APPLICATION_JSON,
-				converted.getHeaders().get(MessageBusSupport.ORIGINAL_CONTENT_TYPE_HEADER));
+				converted.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
 		Message<?> reconstructed = messageBus.deserializePayloadIfNecessary(converted);
 		assertEquals("{\"foo\":\"foo\"}", reconstructed.getPayload());
 		assertEquals(MimeTypeUtils.APPLICATION_JSON, reconstructed.getHeaders().get(MessageHeaders.CONTENT_TYPE));

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
@@ -57,6 +57,7 @@ import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.validation.BindException;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
+import org.springframework.xd.dirt.integration.bus.XdHeaders;
 import org.springframework.xd.dirt.integration.bus.local.LocalMessageBus;
 import org.springframework.xd.dirt.zookeeper.EmbeddedZooKeeper;
 import org.springframework.xd.dirt.zookeeper.Paths;
@@ -259,7 +260,7 @@ public class StreamPluginTests {
 		assertNotNull(messageReceived.get());
 		@SuppressWarnings("unchecked")
 		Collection<Map<String, Object>> xdHistory =
-				(Collection<Map<String, Object>>) messageReceived.get().getHeaders().get("xdHistory");
+				(Collection<Map<String, Object>>) messageReceived.get().getHeaders().get(XdHeaders.XD_HISTORY);
 		assertTrue(xdHistory != null);
 		assertEquals("testing", xdHistory.iterator().next().get("module"));
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
@@ -38,6 +38,7 @@ import org.springframework.xd.dirt.core.DeploymentUnitStatus;
 import org.springframework.xd.dirt.core.ModuleDeploymentsPath;
 import org.springframework.xd.dirt.integration.bus.AbstractTestMessageBus;
 import org.springframework.xd.dirt.integration.bus.Binding;
+import org.springframework.xd.dirt.integration.bus.XdHeaders;
 import org.springframework.xd.dirt.integration.bus.local.LocalMessageBus;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.server.SingleNodeApplication;
@@ -318,13 +319,13 @@ public abstract class AbstractSingleNodeStreamDeploymentIntegrationTests {
 
 		final Message<Object> bar1Message = (Message<Object>) bar1sink.receive(10000);
 		assertNotNull(bar1Message);
-		Object history = bar1Message.getHeaders().get("xdHistory");
+		Object history = bar1Message.getHeaders().get(XdHeaders.XD_HISTORY);
 		assertNotNull(history);
 		assertThat(history, instanceOf(List.class));
 		final Object bar1 = bar1Message.getPayload();
 		final Message<Object> bar2Message = (Message<Object>) bar2sink.receive(10000);
 		assertNotNull(bar2Message);
-		assertNull(bar2Message.getHeaders().get("xdHistory"));
+		assertNull(bar2Message.getHeaders().get(XdHeaders.XD_HISTORY));
 		final Object bar2 = bar2Message.getPayload();
 		assertEquals("hello", bar1);
 		assertEquals("hello", bar2);

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
@@ -46,7 +46,7 @@ import org.springframework.xd.test.rabbit.RabbitTestSupport;
  * @author Gary Russell
  */
 public class RabbitSingleNodeStreamDeploymentIntegrationTests extends
-AbstractDistributedTransportSingleNodeStreamDeploymentIntegrationTests {
+		AbstractDistributedTransportSingleNodeStreamDeploymentIntegrationTests {
 
 	@ClassRule
 	public static RabbitTestSupport rabbitAvailableRule = new RabbitTestSupport();

--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -44,9 +44,11 @@ import kafka.serializer.Decoder;
 import kafka.serializer.DefaultDecoder;
 import kafka.serializer.DefaultEncoder;
 import kafka.utils.ZkUtils;
+
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkMarshallingError;
 import org.I0Itec.zkclient.serialize.ZkSerializer;
+
 import scala.collection.Seq;
 
 import org.springframework.context.Lifecycle;
@@ -89,6 +91,7 @@ import org.springframework.xd.dirt.integration.bus.Binding;
 import org.springframework.xd.dirt.integration.bus.BusProperties;
 import org.springframework.xd.dirt.integration.bus.EmbeddedHeadersMessageConverter;
 import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
+import org.springframework.xd.dirt.integration.bus.XdHeaders;
 import org.springframework.xd.dirt.integration.bus.serializer.MultiTypeCodec;
 
 /**
@@ -181,28 +184,11 @@ public class KafkaMessageBus extends MessageBusSupport {
 					KafkaMessageBus.COMPRESSION_CODEC,
 			}));
 
-	private static final String XD_REPLY_CHANNEL = "xdReplyChannel";
-
-	private static final String XD_HISTORY = "xdHistory";
-
 	/**
 	 * The consumer group to use when achieving point to point semantics (that
 	 * consumer group name is static and hence shared by all containers).
 	 */
 	private static final String POINT_TO_POINT_SEMANTICS_CONSUMER_GROUP = "springXD";
-
-	/**
-	 * The headers that will be propagated, by default.
-	 */
-	private static final String[] STANDARD_HEADERS = new String[] {
-			IntegrationMessageHeaderAccessor.CORRELATION_ID,
-			IntegrationMessageHeaderAccessor.SEQUENCE_SIZE,
-			IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER,
-			MessageHeaders.CONTENT_TYPE,
-			ORIGINAL_CONTENT_TYPE_HEADER,
-			XD_REPLY_CHANNEL,
-			XD_HISTORY
-	};
 
 	/**
 	 * Basic + concurrency + partitioning.
@@ -269,12 +255,14 @@ public class KafkaMessageBus extends MessageBusSupport {
 		setCodec(codec);
 		if (headersToMap.length > 0) {
 			String[] combinedHeadersToMap =
-					Arrays.copyOfRange(STANDARD_HEADERS, 0, STANDARD_HEADERS.length + headersToMap.length);
-			System.arraycopy(headersToMap, 0, combinedHeadersToMap, STANDARD_HEADERS.length, headersToMap.length);
+					Arrays.copyOfRange(XdHeaders.STANDARD_HEADERS, 0, XdHeaders.STANDARD_HEADERS.length + headersToMap
+							.length);
+			System.arraycopy(headersToMap, 0, combinedHeadersToMap, XdHeaders.STANDARD_HEADERS.length, headersToMap
+					.length);
 			this.headersToMap = combinedHeadersToMap;
 		}
 		else {
-			this.headersToMap = STANDARD_HEADERS;
+			this.headersToMap = XdHeaders.STANDARD_HEADERS;
 		}
 
 	}
@@ -700,7 +688,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 				theRequestMessage = embeddedHeadersMessageConverter.extractHeaders((Message<byte[]>) requestMessage);
 			}
 			catch (Exception e) {
-				logger.error("Could not convert message", e);
+				logger.error(EmbeddedHeadersMessageConverter.decodeExceptionMessage(requestMessage), e);
 			}
 			return deserializePayloadIfNecessary(theRequestMessage);
 		}

--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -183,6 +183,8 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 	private static final String XD_REPLY_CHANNEL = "xdReplyChannel";
 
+	private static final String XD_HISTORY = "xdHistory";
+
 	/**
 	 * The consumer group to use when achieving point to point semantics (that
 	 * consumer group name is static and hence shared by all containers).
@@ -198,7 +200,8 @@ public class KafkaMessageBus extends MessageBusSupport {
 			IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER,
 			MessageHeaders.CONTENT_TYPE,
 			ORIGINAL_CONTENT_TYPE_HEADER,
-			XD_REPLY_CHANNEL
+			XD_REPLY_CHANNEL,
+			XD_HISTORY
 	};
 
 	/**
@@ -696,7 +699,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 			try {
 				theRequestMessage = embeddedHeadersMessageConverter.extractHeaders((Message<byte[]>) requestMessage);
 			}
-			catch (UnsupportedEncodingException e) {
+			catch (Exception e) {
 				logger.error("Could not convert message", e);
 			}
 			return deserializePayloadIfNecessary(theRequestMessage);

--- a/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,8 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 
 	private static final String REPLY_TO = "replyTo";
 
+	private static final String XD_HISTORY = "xdHistory";
+
 	/**
 	 * The headers that will be propagated, by default.
 	 */
@@ -85,7 +87,8 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		XD_REPLY_CHANNEL,
 		MessageHeaders.CONTENT_TYPE,
 		ORIGINAL_CONTENT_TYPE_HEADER,
-		REPLY_TO
+		REPLY_TO,
+		XD_HISTORY
 	};
 
 	private static final SpelExpressionParser parser = new SpelExpressionParser();
@@ -478,7 +481,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 			try {
 				theRequestMessage = embeddedHeadersMessageConverter.extractHeaders((Message<byte[]>) requestMessage);
 			}
-			catch (UnsupportedEncodingException e) {
+			catch (Exception e) {
 				logger.error("Could not convert message", e);
 			}
 			return deserializePayloadIfNecessary(theRequestMessage);

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/EmbeddedHeadersMessageConverter.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/EmbeddedHeadersMessageConverter.java
@@ -21,6 +21,8 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.xml.bind.DatatypeConverter;
+
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.json.Jackson2JsonObjectMapper;
@@ -42,6 +44,11 @@ import org.springframework.messaging.Message;
 public class EmbeddedHeadersMessageConverter {
 
 	private final Jackson2JsonObjectMapper objectMapper = new Jackson2JsonObjectMapper();
+
+	public static String decodeExceptionMessage(Message<?> requestMessage) {
+		return "Could not convert message: " + DatatypeConverter.printHexBinary((byte[]) requestMessage.getPayload());
+	}
+
 
 	/**
 	 * Return a new message where some of the original headers of {@code original}

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -13,7 +13,11 @@
 
 package org.springframework.xd.dirt.integration.bus;
 
-import static org.springframework.util.MimeTypeUtils.*;
+import static org.springframework.util.MimeTypeUtils.ALL;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_OCTET_STREAM;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE;
+import static org.springframework.util.MimeTypeUtils.TEXT_PLAIN;
+import static org.springframework.util.MimeTypeUtils.TEXT_PLAIN_VALUE;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -88,8 +92,6 @@ public abstract class MessageBusSupport
 	private final ContentTypeResolver contentTypeResolver = new StringConvertingContentTypeResolver();
 
 	private final ThreadLocal<Boolean> revertingDirectBinding = new ThreadLocal<Boolean>();
-
-	protected static final String ORIGINAL_CONTENT_TYPE_HEADER = "originalContentType";
 
 	protected static final List<MimeType> MEDIATYPES_MEDIATYPE_ALL = Collections.singletonList(ALL);
 
@@ -518,7 +520,7 @@ public abstract class MessageBusSupport
 					.copyHeaders(message.getHeaders())
 					.setHeader(MessageHeaders.CONTENT_TYPE, contentType);
 			if (originalContentType != null) {
-				messageBuilder.setHeader(ORIGINAL_CONTENT_TYPE_HEADER, originalContentType);
+				messageBuilder.setHeader(XdHeaders.XD_ORIGINAL_CONTENT_TYPE, originalContentType);
 			}
 			return messageBuilder.build();
 		}
@@ -554,9 +556,9 @@ public abstract class MessageBusSupport
 		Object payload = deserializePayload(originalPayload, contentType);
 		if (payload != null) {
 			MessageBuilder<Object> transformed = MessageBuilder.withPayload(payload).copyHeaders(message.getHeaders());
-			Object originalContentType = message.getHeaders().get(ORIGINAL_CONTENT_TYPE_HEADER);
+			Object originalContentType = message.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE);
 			transformed.setHeader(MessageHeaders.CONTENT_TYPE, originalContentType);
-			transformed.setHeader(ORIGINAL_CONTENT_TYPE_HEADER, null);
+			transformed.setHeader(XdHeaders.XD_ORIGINAL_CONTENT_TYPE, null);
 			messageToSend = transformed.build();
 		}
 		return messageToSend;

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/XdHeaders.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/XdHeaders.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus;
+
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.messaging.MessageHeaders;
+
+
+/**
+ * Spring Integration message headers for XD.
+ *
+ * @author Gary Russell
+ */
+public final class XdHeaders {
+
+	public static final String XD_REPLY_CHANNEL = "xdReplyChannel";
+
+	public static final String XD_HISTORY = "xdHistory";
+
+	/*
+	 * no xd prefix for backwards compatibility
+	 */
+	public static final String XD_ORIGINAL_CONTENT_TYPE = "originalContentType";
+
+	/*
+	 * no xd prefix for backwards compatibility
+	 */
+	public static final String REPLY_TO = "replyTo";
+
+	/**
+	 * The headers that will be propagated, by default, by message bus implementations
+	 * that have no inherent header support (by embedding the headers in the payload).
+	 */
+	public static final String[] STANDARD_HEADERS = new String[] {
+		IntegrationMessageHeaderAccessor.CORRELATION_ID,
+		IntegrationMessageHeaderAccessor.SEQUENCE_SIZE,
+		IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER,
+		XD_REPLY_CHANNEL,
+		MessageHeaders.CONTENT_TYPE,
+		XD_ORIGINAL_CONTENT_TYPE,
+		REPLY_TO,
+		XD_HISTORY
+	};
+
+	private XdHeaders() {
+	}
+
+}


### PR DESCRIPTION
Add `xdHistory` to the standard list of headers passed by the bus,

Fix `EmbeddedHeaderMessageConverter` to handle non-string headers and
increase the size of the header value to `Integer.MAX_VALUE` (from 255).

Store the header values as JSON; eliminates the need to interpret
specific headers, allows transport of the `xdHistory` collection.

The converter will continue to decode "old" messages that might still
be in the bus before upgrading.