### PR TITLE
[Sprint 41] XD-2361-2649 Switch to simple consumer for the Kafka Message Bus

### DIFF
--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaPartitionAllocator.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaPartitionAllocator.java
@@ -17,7 +17,7 @@
 
 package org.springframework.integration.x.kafka;
 
-import static org.apache.curator.framework.imps.CuratorFrameworkState.*;
+import static org.apache.curator.framework.imps.CuratorFrameworkState.STARTED;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/extensions/spring-xd-extension-kafka/src/test/java/org/springframework/integration/x/kafka/KafkaTopicMetadataStoreTest.java
+++ b/extensions/spring-xd-extension-kafka/src/test/java/org/springframework/integration/x/kafka/KafkaTopicMetadataStoreTest.java
@@ -89,7 +89,7 @@ public class KafkaTopicMetadataStoreTest {
 
 	private KafkaTopicMetadataStore createKafkaTopicMetadataStore() throws Exception {
 		ZookeeperConnect zookeeperConnect = new ZookeeperConnect();
-		zookeeperConnect.setZkConnect(kafkaTestSupport.getZkconnectstring());
+		zookeeperConnect.setZkConnect(kafkaTestSupport.getZkConnectString());
 		DefaultConnectionFactory connectionFactory =
 				new DefaultConnectionFactory(new ZookeeperConfiguration(zookeeperConnect));
 		connectionFactory.afterPropertiesSet();

--- a/gradle/build-extensions.gradle
+++ b/gradle/build-extensions.gradle
@@ -31,16 +31,21 @@ project('spring-xd-extension-gemfire') {
 }
 
 project('spring-xd-extension-kafka') {
-	description = 'Spring XD Kafka'
-	dependencies {
-		compile ("org.springframework.integration:spring-integration-kafka:$springIntegrationKafkaVersion") {
-           exclude module: "zookeeper"
+    description = 'Spring XD Kafka'
+    dependencies {
+        compile("org.springframework.integration:spring-integration-kafka:$springIntegrationKafkaVersion") {
+            exclude module: "zookeeper"
         }
-        provided project(':spring-xd-dirt')
-		compile project(':spring-xd-module-spi')
+        provided("org.apache.curator:curator-recipes:$curatorVersion") {
+            exclude module: 'zookeeper'
+            exclude module: 'netty'
+        }
+        provided( "com.fasterxml.jackson.core:jackson-databind")
+        provided("org.apache.zookeeper:zookeeper:$zookeeperVersion")
+        compile project(':spring-xd-module-spi')
         testCompile project(':spring-xd-test')
-		compile "javax.validation:validation-api"
-	}
+        compile "javax.validation:validation-api"
+    }
 }
 
 project('spring-xd-extension-batch') {

--- a/gradle/build-messagebuses.gradle
+++ b/gradle/build-messagebuses.gradle
@@ -29,4 +29,8 @@ configure(messagebusProjects) { busProject ->
 }
 
 
-
+project('spring-xd-messagebus-kafka') {
+    dependencies {
+        compile project(":spring-xd-extension-kafka")
+    }
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamRuntimePropertiesProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamRuntimePropertiesProvider.java
@@ -36,6 +36,7 @@ import org.springframework.xd.module.RuntimeModuleDeploymentProperties;
  * @author Patrick Peralta
  * @author Mark Fisher
  * @author Ilayaperumal Gopinathan
+ * @author Marius Bogoevici
  */
 public class StreamRuntimePropertiesProvider extends RuntimeModuleDeploymentPropertiesProvider {
 
@@ -75,6 +76,8 @@ public class StreamRuntimePropertiesProvider extends RuntimeModuleDeploymentProp
 		if (moduleIndex > 0) {
 			ModuleDescriptor previous = streamModules.get(moduleIndex - 1);
 			ModuleDeploymentProperties previousProperties = deploymentPropertiesProvider.propertiesForDescriptor(previous);
+			properties.put("consumer." + BusProperties.SEQUENCE, String.valueOf(moduleSequence));
+			properties.put("consumer." + BusProperties.COUNT, String.valueOf(properties.getCount()));
 			if (hasPartitionKeyProperty(previousProperties)) {
 				properties.put("consumer." + BusProperties.PARTITION_INDEX, String.valueOf(moduleSequence - 1));
 			}

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -138,6 +138,7 @@ xd:
       brokers:                                 localhost:9092
       zkAddress:                               localhost:2181
       numOfKafkaPartitionsForCountEqualsZero:  10
+      offsetStoreTopic:                        SpringXdOffsets
       default:
         batchingEnabled:           false
         batchSize:                 200

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionCapableBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionCapableBusTests.java
@@ -105,6 +105,7 @@ abstract public class PartitionCapableBusTests extends BrokerBusTests {
 		properties.clear();
 		properties.put("concurrency", "2");
 		properties.put("partitionIndex", "0");
+		properties.put("count","3");
 		QueueChannel input0 = new QueueChannel();
 		input0.setBeanName("test.input0S");
 		bus.bindConsumer("part.0", input0, properties);
@@ -200,6 +201,7 @@ abstract public class PartitionCapableBusTests extends BrokerBusTests {
 
 		properties.clear();
 		properties.put("concurrency", "2");
+		properties.put("count","3");
 		properties.put("partitionIndex", "0");
 		QueueChannel input0 = new QueueChannel();
 		input0.setBeanName("test.input0J");

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBusTests.java
@@ -136,18 +136,6 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 	}
 
 	@Test
-	@Ignore("XD-2293 Revisit later")
-	public void testPartitionedModuleSpEL() throws Exception {
-
-	}
-
-	@Test
-	@Ignore("XD-2293 Revisit later")
-	public void testPartitionedModuleJava() throws Exception {
-
-	}
-
-	@Test
 	@Ignore("Kafka message bus does not support direct binding")
 	@Override
 	public void testDirectBinding() throws Exception {

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBusTests.java
@@ -16,7 +16,8 @@
 
 package org.springframework.xd.dirt.integration.kafka;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 import java.util.Properties;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBusTests.java
@@ -83,7 +83,8 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 		// Rewind offset, as tests will have typically already sent the messages we're trying to consume
 
 		KafkaMessageListenerContainer messageListenerContainer =
-				busWrapper.getCoreMessageBus().createMessageListenerContainer(UUID.randomUUID().toString(), 1, topic);
+				busWrapper.getCoreMessageBus().createMessageListenerContainer(UUID.randomUUID().toString(), 1, topic,
+						OffsetRequest.EarliestTime());
 
 		final BlockingQueue<KafkaMessage> messages = new ArrayBlockingQueue<KafkaMessage>(10);
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBusTests.java
@@ -16,53 +16,44 @@
 
 package org.springframework.xd.dirt.integration.kafka;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import kafka.consumer.ConsumerIterator;
-import kafka.consumer.KafkaStream;
-import kafka.javaapi.consumer.ConsumerConnector;
-import kafka.serializer.Decoder;
-import kafka.serializer.DefaultDecoder;
+import kafka.api.OffsetRequest;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.kafka.core.KafkaMessage;
+import org.springframework.integration.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.integration.kafka.listener.MessageListener;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.xd.dirt.integration.bus.EmbeddedHeadersMessageConverter;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
-import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
 import org.springframework.xd.dirt.integration.bus.PartitionCapableBusTests;
+import org.springframework.xd.test.kafka.KafkaTestSupport;
 
 
 /**
  * Integration tests for the {@link KafkaMessageBus}.
  *
  * @author Eric Bottard
+ * @author Marius Bogoevici
  */
 public class KafkaMessageBusTests extends PartitionCapableBusTests {
 
 	private final EmbeddedHeadersMessageConverter embeddedHeadersMessageConverter = new EmbeddedHeadersMessageConverter();
 
-	private static ExecutorService executorService = Executors.newCachedThreadPool();
+	@Rule
+	public KafkaTestSupport kafkaTestSupport = new KafkaTestSupport();
 
 	private KafkaTestMessageBus messageBus;
 
@@ -74,7 +65,7 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 	@Override
 	protected MessageBus getMessageBus() {
 		if (messageBus == null) {
-			messageBus = new KafkaTestMessageBus(getCodec());
+			messageBus = new KafkaTestMessageBus(kafkaTestSupport, getCodec());
 		}
 		return messageBus;
 	}
@@ -88,48 +79,26 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 	public Spy spyOn(final String name) {
 		String topic = KafkaMessageBus.escapeTopicName(name);
 
-		Map<String, Integer> topicCountMap = new HashMap<String, Integer>();
-		int numThreads = 1;
-		topicCountMap.put(topic, numThreads);
-
-
-		Decoder<byte[]> valueDecoder = new DefaultDecoder(null);
-		Decoder<Integer> keyDecoder = new IntegerEncoderDecoder();
-
 		KafkaTestMessageBus busWrapper = (KafkaTestMessageBus) getMessageBus();
 		// Rewind offset, as tests will have typically already sent the messages we're trying to consume
-		ConsumerConnector connector = busWrapper.getCoreMessageBus().createConsumerConnector(
-				UUID.randomUUID().toString(), "auto.offset.reset", "smallest");
 
-		Map<String, List<KafkaStream<Integer, byte[]>>> map = connector.createMessageStreams(
-				topicCountMap, keyDecoder, valueDecoder);
+		KafkaMessageListenerContainer messageListenerContainer =
+				busWrapper.getCoreMessageBus().createMessageListenerContainer(UUID.randomUUID().toString(), 1, topic);
 
-		final ConsumerIterator<Integer, byte[]> iterator = map.get(topic).iterator().next().iterator();
+		final BlockingQueue<KafkaMessage> messages = new ArrayBlockingQueue<KafkaMessage>(10);
+
+		messageListenerContainer.setMessageListener(new MessageListener() {
+			@Override
+			public void onMessage(KafkaMessage message) {
+				messages.offer(message);
+			}
+		});
 
 
 		return new Spy() {
-
 			@Override
 			public Object receive(boolean expectNull) throws Exception {
-				final Future<String> submit = executorService.submit(new Callable<String>() {
-
-					@Override
-					public String call() throws Exception {
-						iterator.hasNext();
-						byte[] raw = iterator.next().message();
-						Message<byte[]> theRequestMessage = embeddedHeadersMessageConverter.extractHeaders(MessageBuilder.withPayload(
-								raw).build());
-
-						return new String(theRequestMessage.getPayload(), "UTF-8");
-					}
-
-				});
-				try {
-					return submit.get(expectNull ? 50 : 5000, TimeUnit.MILLISECONDS);
-				}
-				catch (TimeoutException e) {
-					return null;
-				}
+				return messages.poll(expectNull ? 50 : 5000, TimeUnit.MILLISECONDS);
 			}
 		};
 
@@ -159,8 +128,8 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 			Message<?> inbound = moduleInputChannel.receive(2000);
 			assertNotNull(inbound);
 			assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
-			messageBus.unbindProducers("foo.0");
-			messageBus.unbindConsumers("foo.0");
+			messageBus.unbindProducers("fooCompression"+codec+".0");
+			messageBus.unbindConsumers("fooCompression"+codec+".0");
 		}
 	}
 
@@ -176,6 +145,10 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 
 	}
 
-
+	@Test
+	@Ignore("Kafka message bus does not support direct binding")
+	@Override
+	public void testDirectBinding() throws Exception {
 
 	}
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/KafkaTestMessageBus.java
@@ -49,10 +49,10 @@ public class KafkaTestMessageBus extends AbstractTestMessageBus<KafkaMessageBus>
 
 		try {
 			ZookeeperConnect zookeeperConnect = new ZookeeperConnect();
-			zookeeperConnect.setZkConnect(kafkaTestSupport.getZkconnectstring());
+			zookeeperConnect.setZkConnect(kafkaTestSupport.getZkConnectString());
 			KafkaMessageBus messageBus = new KafkaMessageBus(zookeeperConnect,
 					kafkaTestSupport.getBrokerAddress(),
-					kafkaTestSupport.getZkconnectstring(), codec);
+					kafkaTestSupport.getZkConnectString(), codec);
 			messageBus.afterPropertiesSet();
 			GenericApplicationContext context = new GenericApplicationContext();
 			context.refresh();

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.stream;
+
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.ExternalResource;
+
+import org.springframework.integration.kafka.core.DefaultConnectionFactory;
+import org.springframework.integration.kafka.core.FetchRequest;
+import org.springframework.integration.kafka.core.KafkaMessageBatch;
+import org.springframework.integration.kafka.core.KafkaTemplate;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.core.Result;
+import org.springframework.integration.kafka.core.ZookeeperConfiguration;
+import org.springframework.integration.kafka.serializer.common.StringDecoder;
+import org.springframework.integration.kafka.support.ZookeeperConnect;
+import org.springframework.integration.kafka.util.MessageUtils;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.xd.dirt.integration.bus.RedisTestMessageBus;
+import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
+import org.springframework.xd.dirt.integration.kafka.KafkaTestMessageBus;
+import org.springframework.xd.test.kafka.KafkaTestSupport;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class KafkaSingleNodeStreamDeploymentIntegrationTests extends
+		AbstractSingleNodeStreamDeploymentIntegrationTests {
+
+	@ClassRule
+	public static KafkaTestSupport kafkaTestSupport = new KafkaTestSupport();
+
+	@ClassRule
+	public static ExternalResource initializeKafkaMessageBus = new ExternalResource() {
+		@Override
+		protected void before() {
+			if (testMessageBus == null || !(testMessageBus instanceof RedisTestMessageBus)) {
+				testMessageBus = new KafkaTestMessageBus(kafkaTestSupport);
+			}
+		}
+	};
+
+	@BeforeClass
+	public static void setUpAll() {
+		System.setProperty("xd.messagebus.kafka.zkAddress", kafkaTestSupport.getZkconnectstring());
+		System.setProperty("xd.messagebus.kafka.brokers", kafkaTestSupport.getBrokerAddress());
+		setUp("kafka");
+	}
+
+	@AfterClass
+	public static void clearAll() {
+		System.clearProperty("xd.messagebus.kafka.zkAddress");
+		System.clearProperty("xd.messagebus.kafka.brokers");
+	}
+
+	@Override
+	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3) {
+		ZookeeperConnect zookeeperConnect = new ZookeeperConnect();
+		zookeeperConnect.setZkConnect(kafkaTestSupport.getZkconnectstring());
+		ZookeeperConfiguration configuration = new ZookeeperConfiguration(zookeeperConnect);
+		DefaultConnectionFactory connectionFactory = new DefaultConnectionFactory(configuration);
+		try {
+			connectionFactory.afterPropertiesSet();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		KafkaTemplate template = new KafkaTemplate(connectionFactory);
+		String y = receiveFromTopicForQueue(template, "queue:y");
+		assertTrue(y.endsWith("y")); // bus headers
+		String z = receiveFromTopicForQueue(template, "queue:z");
+		assertNotNull(z);
+		assertTrue(z.endsWith("z")); // bus headers
+	}
+
+	private String receiveFromTopicForQueue(KafkaTemplate template, String topicName) {
+		Partition partition = new Partition(KafkaMessageBus.escapeTopicName(topicName), 0);
+		Result<KafkaMessageBatch> receive = template.receive(Collections.singleton(new FetchRequest(partition, 0, 1000)));
+		return MessageUtils.decodePayload(receive.getResult(partition).getMessages().get(0), new StringDecoder());
+	}
+
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
@@ -16,7 +16,8 @@
 
 package org.springframework.xd.dirt.stream;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 
@@ -36,7 +37,6 @@ import org.springframework.integration.kafka.serializer.common.StringDecoder;
 import org.springframework.integration.kafka.support.ZookeeperConnect;
 import org.springframework.integration.kafka.util.MessageUtils;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.xd.dirt.integration.bus.RedisTestMessageBus;
 import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
 import org.springframework.xd.dirt.integration.kafka.KafkaTestMessageBus;
 import org.springframework.xd.test.kafka.KafkaTestSupport;
@@ -54,7 +54,7 @@ public class KafkaSingleNodeStreamDeploymentIntegrationTests extends
 	public static ExternalResource initializeKafkaMessageBus = new ExternalResource() {
 		@Override
 		protected void before() {
-			if (testMessageBus == null || !(testMessageBus instanceof RedisTestMessageBus)) {
+			if (testMessageBus == null || !(testMessageBus instanceof KafkaTestMessageBus)) {
 				testMessageBus = new KafkaTestMessageBus(kafkaTestSupport);
 			}
 		}
@@ -62,7 +62,7 @@ public class KafkaSingleNodeStreamDeploymentIntegrationTests extends
 
 	@BeforeClass
 	public static void setUpAll() {
-		System.setProperty("xd.messagebus.kafka.zkAddress", kafkaTestSupport.getZkconnectstring());
+		System.setProperty("xd.messagebus.kafka.zkAddress", kafkaTestSupport.getZkConnectString());
 		System.setProperty("xd.messagebus.kafka.brokers", kafkaTestSupport.getBrokerAddress());
 		setUp("kafka");
 	}
@@ -76,7 +76,7 @@ public class KafkaSingleNodeStreamDeploymentIntegrationTests extends
 	@Override
 	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3) {
 		ZookeeperConnect zookeeperConnect = new ZookeeperConnect();
-		zookeeperConnect.setZkConnect(kafkaTestSupport.getZkconnectstring());
+		zookeeperConnect.setZkConnect(kafkaTestSupport.getZkConnectString());
 		ZookeeperConfiguration configuration = new ZookeeperConfiguration(zookeeperConnect);
 		DefaultConnectionFactory connectionFactory = new DefaultConnectionFactory(configuration);
 		try {

--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -17,12 +17,16 @@
 package org.springframework.xd.dirt.integration.kafka;
 
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -30,13 +34,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import kafka.admin.AdminUtils;
+import kafka.api.OffsetRequest;
 import kafka.api.TopicMetadata;
 import kafka.common.ErrorMapping;
-import kafka.consumer.Consumer;
-import kafka.consumer.ConsumerConfig;
-import kafka.consumer.ConsumerIterator;
-import kafka.consumer.KafkaStream;
-import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.javaapi.PartitionMetadata;
 import kafka.javaapi.producer.Producer;
 import kafka.producer.DefaultPartitioner;
 import kafka.serializer.Decoder;
@@ -54,15 +55,23 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.kafka.core.ConnectionFactory;
+import org.springframework.integration.kafka.core.DefaultConnectionFactory;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.core.ZookeeperConfiguration;
+import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter;
+import org.springframework.integration.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.integration.kafka.listener.MetadataStoreOffsetManager;
 import org.springframework.integration.kafka.support.ProducerConfiguration;
 import org.springframework.integration.kafka.support.ProducerFactoryBean;
 import org.springframework.integration.kafka.support.ProducerMetadata;
+import org.springframework.integration.kafka.support.ZookeeperConnect;
+import org.springframework.integration.x.kafka.KafkaTopicMetadataStore;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.SubscribableChannel;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryPolicy;
@@ -72,7 +81,9 @@ import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.policy.TimeoutRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.xd.dirt.integration.bus.AbstractBusPropertiesAccessor;
 import org.springframework.xd.dirt.integration.bus.Binding;
 import org.springframework.xd.dirt.integration.bus.BusProperties;
@@ -108,6 +119,8 @@ import org.springframework.xd.dirt.integration.bus.serializer.MultiTypeCodec;
  * @author Marius Bogoevici
  */
 public class KafkaMessageBus extends MessageBusSupport {
+
+	private final AtomicInteger correlationIdCounter = new AtomicInteger(new Random().nextInt());
 
 	public static final int METADATA_VERIFICATION_TIMEOUT = 5000;
 
@@ -192,6 +205,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 	 * Basic + concurrency + partitioning.
 	 */
 	private static final Set<Object> SUPPORTED_CONSUMER_PROPERTIES = new SetBuilder()
+			.addAll(CONSUMER_STANDARD_PROPERTIES)
 			.add(BusProperties.PARTITION_INDEX) // Not actually used
 			.add(BusProperties.CONCURRENCY)
 			.build();
@@ -200,6 +214,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 	 * Basic + concurrency.
 	 */
 	private static final Set<Object> SUPPORTED_NAMED_CONSUMER_PROPERTIES = new SetBuilder()
+			.addAll(CONSUMER_STANDARD_PROPERTIES)
 			.build();
 
 	private static final Set<Object> SUPPORTED_NAMED_PRODUCER_PROPERTIES = new SetBuilder()
@@ -220,6 +235,8 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 	private final EmbeddedHeadersMessageConverter embeddedHeadersMessageConverter = new EmbeddedHeadersMessageConverter();
 
+	private final ZookeeperConnect zookeeperConnect;
+
 	private String brokers;
 
 	private ExecutorService executor = Executors.newCachedThreadPool();
@@ -235,13 +252,14 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 	private int defaultRequiredAcks = DEFAULT_REQUIRED_ACKS;
 
-	/**
-	 * The number of Kafka partitions to use when module count can auto-grow.
-	 * Should be bigger than number of containers that will ever exist.
-	 */
-	private int numOfKafkaPartitionsForCountEqualsZero = 10;
+	private ConnectionFactory connectionFactory;
 
-	public KafkaMessageBus(String brokers, String zkAddress, MultiTypeCodec<Object> codec, String... headersToMap) {
+	private String offsetStoreTopic = "SpringXdOffsets";
+
+
+	public KafkaMessageBus(ZookeeperConnect zookeeperConnect, String brokers, String zkAddress,
+			MultiTypeCodec<Object> codec, String... headersToMap) {
+		this.zookeeperConnect = zookeeperConnect;
 		this.brokers = brokers;
 		this.zkAddress = zkAddress;
 		setCodec(codec);
@@ -254,6 +272,20 @@ public class KafkaMessageBus extends MessageBusSupport {
 		else {
 			this.headersToMap = STANDARD_HEADERS;
 		}
+
+	}
+
+	public void setOffsetStoreTopic(String offsetStoreTopic) {
+		this.offsetStoreTopic = offsetStoreTopic;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		// we instantiate the connection factory here due to https://jira.spring.io/browse/XD-2647
+		DefaultConnectionFactory defaultConnectionFactory =
+				new DefaultConnectionFactory(new ZookeeperConfiguration(this.zookeeperConnect));
+		defaultConnectionFactory.afterPropertiesSet();
+		this.connectionFactory = defaultConnectionFactory;
 
 	}
 
@@ -297,17 +329,15 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 	@Override
 	public void bindConsumer(String name, final MessageChannel moduleInputChannel, Properties properties) {
-		createKafkaConsumer(name, moduleInputChannel, properties,
-				createConsumerConnector(POINT_TO_POINT_SEMANTICS_CONSUMER_GROUP));
+		createKafkaConsumer(name, moduleInputChannel, properties, POINT_TO_POINT_SEMANTICS_CONSUMER_GROUP);
 		bindExistingProducerDirectlyIfPossible(name, moduleInputChannel);
-
 	}
 
 	@Override
 	public void bindPubSubConsumer(String name, MessageChannel inputChannel, Properties properties) {
 		// Usage of a different consumer group each time achieves pub-sub
 		String group = UUID.randomUUID().toString();
-		createKafkaConsumer(name, inputChannel, properties, createConsumerConnector(group));
+		createKafkaConsumer(name, inputChannel, properties, group);
 	}
 
 	@Override
@@ -326,11 +356,10 @@ public class KafkaMessageBus extends MessageBusSupport {
 				logger.info("Using kafka topic for outbound: " + name);
 			}
 
-
 			final String topicName = escapeTopicName(name);
-			int numPartitions = accessor.getNumberOfKafkaPartitions();
+			int numPartitions = accessor.getNumberOfKafkaPartitionsForProducer();
 
-			ensureTopicCreated(topicName, numPartitions, defaultReplicationFactor);
+			TopicMetadata targetTopicMetadata = ensureTopicCreated(topicName, numPartitions, defaultReplicationFactor);
 
 
 			ProducerMetadata<Integer, byte[]> producerMetadata = new ProducerMetadata<Integer, byte[]>(
@@ -363,11 +392,12 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 					@Override
 					protected void handleMessageInternal(Message<?> message) throws Exception {
-						producerConfiguration.send(topicName, null, message);
+						producerConfiguration.send(topicName, message.getHeaders().get("messageKey"), message);
 					}
 				};
 
-				MessageHandler handler = new SendingHandler(messageHandler, topicName, accessor);
+				MessageHandler handler = new SendingHandler(messageHandler, topicName, accessor,
+						targetTopicMetadata.partitionsMetadata().size());
 				EventDrivenConsumer consumer = new EventDrivenConsumer((SubscribableChannel) moduleOutputChannel, handler);
 				consumer.setBeanFactory(this.getBeanFactory());
 				consumer.setBeanName("outbound." + name);
@@ -404,7 +434,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 	/**
 	 * Creates a Kafka topic if needed, or try to increase its partition count to the desired number.
 	 */
-	private void ensureTopicCreated(final String topicName, int numPartitions, int replicationFactor) {
+	private TopicMetadata ensureTopicCreated(final String topicName, final int numPartitions, int replicationFactor) {
 
 		final int sessionTimeoutMs = 10000;
 		final int connectionTimeoutMs = 10000;
@@ -436,30 +466,44 @@ public class KafkaMessageBus extends MessageBusSupport {
 			retryTemplate.setBackOffPolicy(backOffPolicy);
 
 			try {
-				retryTemplate.execute(new RetryCallback<Boolean, Exception>() {
+				TopicMetadata topicMetadata = retryTemplate.execute(new RetryCallback<TopicMetadata, Exception>() {
 					@Override
-					public Boolean doWithRetry(RetryContext context) throws Exception {
+					public TopicMetadata doWithRetry(RetryContext context) throws Exception {
 						TopicMetadata topicMetadata = AdminUtils.fetchTopicMetadataFromZk(topicName, zkClient);
-						if (topicMetadata.errorCode() != ErrorMapping.NoError()) {
+						if (topicMetadata.errorCode() != ErrorMapping.NoError() || !topicName.equals(topicMetadata.topic())) {
 							// downcast to Exception because that's what the error throws
 							throw (Exception) ErrorMapping.exceptionFor(topicMetadata.errorCode());
 						}
-						return true;
+						List<PartitionMetadata> partitionMetadatas = new kafka.javaapi.TopicMetadata(topicMetadata).partitionsMetadata();
+						if (partitionMetadatas.size() != numPartitions) {
+							throw new IllegalStateException("The number of expected partitions was: " + numPartitions + ", but " +
+									partitionMetadatas.size() + " have been found instead");
+						}
+						for (PartitionMetadata partitionMetadata : partitionMetadatas) {
+							if (partitionMetadata.errorCode() != ErrorMapping.NoError()) {
+								throw (Exception) ErrorMapping.exceptionFor(partitionMetadata.errorCode());
+							}
+						}
+						return topicMetadata;
 					}
 				});
+				// work around an issue in Spring
+				this.connectionFactory.refreshLeaders(Collections.<String>emptySet());
+
+				return topicMetadata;
 			}
 			catch (Exception e) {
 				logger.error("Cannot initialize MessageBus", e);
 				throw new RuntimeException("Cannot initialize message bus:", e);
 			}
+
 		}
 		finally {
 			zkClient.close();
 		}
 	}
 
-	private void createKafkaConsumer(String name, final MessageChannel moduleInputChannel, Properties properties,
-			ConsumerConnector connector) {
+	private void createKafkaConsumer(String name, final MessageChannel moduleInputChannel, Properties properties, String group) {
 
 		if (name.startsWith(P2P_NAMED_CHANNEL_TYPE_PREFIX)) {
 			validateConsumerProperties(name, properties, SUPPORTED_NAMED_CONSUMER_PROPERTIES);
@@ -469,21 +513,65 @@ public class KafkaMessageBus extends MessageBusSupport {
 		}
 		KafkaPropertiesAccessor accessor = new KafkaPropertiesAccessor(properties);
 
-		Map<String, Integer> topicCountMap = new HashMap<String, Integer>();
 		int numThreads = accessor.getConcurrency(defaultConcurrency);
 		String topic = escapeTopicName(name);
-		topicCountMap.put(topic, numThreads);
 
+		ensureTopicCreated(topic, accessor.getCount() * numThreads, defaultReplicationFactor);
 
 		Decoder<byte[]> valueDecoder = new DefaultDecoder(null);
 		Decoder<Integer> keyDecoder = new IntegerEncoderDecoder();
-		Map<String, List<KafkaStream<Integer, byte[]>>> consumerMap = connector.createMessageStreams(
-				topicCountMap, keyDecoder, valueDecoder);
 
-		final KafkaStream<Integer, byte[]> stream = consumerMap.get(topic).iterator().next();
+		Collection<Partition> allPartitions = connectionFactory.getPartitions(topic);
+
+		Collection<Partition> listenedPartitions;
+
+		int moduleCount = accessor.getCount();
+
+		if (moduleCount == 1) {
+			listenedPartitions = allPartitions;
+		}
+		else {
+			listenedPartitions = new ArrayList<Partition>();
+			for (Partition partition : allPartitions) {
+				// divide partitions across modules
+				if (new PartitioningMetadata(accessor).isPartitionedModule()) {
+					if ((partition.getId() % accessor.getPartitionCount()) == accessor.getPartitionIndex()) {
+						listenedPartitions.add(partition);
+					}
+				}
+				else {
+					int moduleSequence = accessor.getSequence();
+					if (moduleCount == 0) {
+						throw new IllegalArgumentException("This type of transport does not support 0-count modules");
+					}
+					if (moduleCount == 1) {
+						listenedPartitions.add(partition);
+					}
+					else {
+						// sequence numbers are zero-based
+						if ((partition.getId() % moduleCount) == (moduleSequence - 1)) {
+							listenedPartitions.add(partition);
+						}
+					}
+				}
+			}
+		}
 
 		final DirectChannel bridge = new DirectChannel();
-		ReceivingHandler rh = new ReceivingHandler(connector);
+
+		KafkaMessageListenerContainer messageListenerContainer =
+				createMessageListenerContainer(group, numThreads, listenedPartitions);
+
+		KafkaMessageDrivenChannelAdapter kafkaMessageDrivenChannelAdapter =
+				new KafkaMessageDrivenChannelAdapter(messageListenerContainer);
+		kafkaMessageDrivenChannelAdapter.setBeanFactory(this.getBeanFactory());
+		kafkaMessageDrivenChannelAdapter.setKeyDecoder(keyDecoder);
+		kafkaMessageDrivenChannelAdapter.setPayloadDecoder(valueDecoder);
+		kafkaMessageDrivenChannelAdapter.setOutputChannel(bridge);
+		kafkaMessageDrivenChannelAdapter.afterPropertiesSet();
+		kafkaMessageDrivenChannelAdapter.start();
+
+		ReceivingHandler rh = new ReceivingHandler(kafkaMessageDrivenChannelAdapter);
 		rh.setOutputChannel(moduleInputChannel);
 		EventDrivenConsumer edc = new EventDrivenConsumer(bridge, rh);
 		edc.setBeanName("inbound." + name);
@@ -492,33 +580,47 @@ public class KafkaMessageBus extends MessageBusSupport {
 		addBinding(consumerBinding);
 		consumerBinding.start();
 
-
-		executor.submit(new Runnable() {
-
-			@Override
-			public void run() {
-				ConsumerIterator<Integer, byte[]> it = stream.iterator();
-				while (it.hasNext()) {
-					byte[] msg = it.next().message();
-					bridge.send(MessageBuilder.withPayload(msg).build());
-				}
-			}
-
-		});
 	}
 
-	/*default*/ConsumerConnector createConsumerConnector(String consumerGroup, String... keyValues) {
-		Properties props = new Properties();
-		props.put("zookeeper.connect", zkAddress);
-		props.put("group.id", consumerGroup);
-		Assert.isTrue(keyValues.length % 2 == 0, "keyValues must be an even number of key/value pairs");
-		for (int i = 0; i < keyValues.length; i += 2) {
-			String key = keyValues[i];
-			String value = keyValues[i + 1];
-			props.put(key, value);
+	public KafkaMessageListenerContainer createMessageListenerContainer(String group, int numThreads, String topic) {
+		return createMessageListenerContainer(group, numThreads, topic, null);
+	}
+
+	public KafkaMessageListenerContainer createMessageListenerContainer(String group, int numThreads,
+			Collection<Partition> listenedPartitions) {
+		return createMessageListenerContainer(group, numThreads, null, listenedPartitions);
+	}
+
+	private KafkaMessageListenerContainer createMessageListenerContainer(String group, int numThreads, String topic,
+			Collection<Partition> listenedPartitions) {
+		Assert.isTrue(StringUtils.hasText(topic) ^ !CollectionUtils.isEmpty(listenedPartitions),
+				"Exactly one of topic or a list of listened partitions must be provided");
+		KafkaMessageListenerContainer messageListenerContainer;
+		if (topic != null) {
+			messageListenerContainer = new KafkaMessageListenerContainer(connectionFactory, topic);
 		}
-		ConsumerConfig config = new ConsumerConfig(props);
-		return Consumer.createJavaConsumerConnector(config);
+		else {
+			messageListenerContainer = new KafkaMessageListenerContainer(connectionFactory,
+					listenedPartitions.toArray(new Partition[listenedPartitions.size()]));
+		}
+		if (logger.isDebugEnabled()) {
+			logger.debug("Listening to topic " + topic);
+		}
+		messageListenerContainer.setConcurrency(numThreads);
+		KafkaTopicMetadataStore springXDOffsets =
+				new KafkaTopicMetadataStore(zookeeperConnect, connectionFactory, offsetStoreTopic);
+		try {
+			springXDOffsets.afterPropertiesSet();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		MetadataStoreOffsetManager offsetManager = new MetadataStoreOffsetManager(connectionFactory);
+		offsetManager.setMetadataStore(springXDOffsets);
+		offsetManager.setConsumerId(group);
+		offsetManager.setReferenceTimestamp(OffsetRequest.EarliestTime());
+		messageListenerContainer.setOffsetManager(offsetManager);
+		return messageListenerContainer;
 	}
 
 	private class KafkaPropertiesAccessor extends AbstractBusPropertiesAccessor {
@@ -537,15 +639,17 @@ public class KafkaMessageBus extends MessageBusSupport {
 			super(properties);
 		}
 
-		public int getNumberOfKafkaPartitions() {
+		public int getNumberOfKafkaPartitionsForProducer() {
 			int concurrency = getProperty(NEXT_MODULE_CONCURRENCY, defaultConcurrency);
 			if (new PartitioningMetadata(this).isPartitionedModule()) {
 				return getPartitionCount() * concurrency;
 			}
 			else {
-				int downStreamModuleCount = getProperty(NEXT_MODULE_COUNT, 1);
-				int base = downStreamModuleCount == 0 ? numOfKafkaPartitionsForCountEqualsZero : downStreamModuleCount;
-				return base * concurrency;
+				int nextModuleCount = getProperty(NEXT_MODULE_COUNT, 1);
+				if (nextModuleCount == 0) {
+					throw new IllegalArgumentException("Module count cannot be zero");
+				}
+				return nextModuleCount * concurrency;
 			}
 		}
 
@@ -569,10 +673,10 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 	private class ReceivingHandler extends AbstractReplyProducingMessageHandler implements Lifecycle {
 
-		private ConsumerConnector connector;
+		private KafkaMessageDrivenChannelAdapter kafkaMessageDrivenChannelAdapter;
 
-		public ReceivingHandler(ConsumerConnector connector) {
-			this.connector = connector;
+		public ReceivingHandler(KafkaMessageDrivenChannelAdapter kafkaMessageDrivenChannelAdapter) {
+			this.kafkaMessageDrivenChannelAdapter = kafkaMessageDrivenChannelAdapter;
 			this.setBeanFactory(KafkaMessageBus.this.getBeanFactory());
 		}
 
@@ -586,8 +690,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 			catch (UnsupportedEncodingException e) {
 				logger.error("Could not convert message", e);
 			}
-			Message<?> result = deserializePayloadIfNecessary(theRequestMessage);
-			return result;
+			return deserializePayloadIfNecessary(theRequestMessage);
 		}
 
 		@Override
@@ -596,7 +699,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 		@Override
 		public void stop() {
-			connector.shutdown();
+			kafkaMessageDrivenChannelAdapter.stop();
 		}
 
 		@Override
@@ -616,13 +719,28 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 		private final String topicName;
 
+		private final int numberOfKafkaPartitions;
+
+		private int factor;
+
 
 		private SendingHandler(MessageHandler delegate, String topicName,
-				KafkaPropertiesAccessor properties) {
+				KafkaPropertiesAccessor properties, int numberOfPartitions) {
 			this.delegate = delegate;
 			this.topicName = topicName;
+			this.numberOfKafkaPartitions = numberOfPartitions;
 			this.partitioningMetadata = new PartitioningMetadata(properties);
 			this.setBeanFactory(KafkaMessageBus.this.getBeanFactory());
+			if (partitioningMetadata.isPartitionedModule()) {
+				// ceiling division of total number of kafka partitions to the Spring XD partition count
+				// a container with a certain partition index will listen to at most this number of
+				// partitions, evenly distributed. E.g. for 8 kafka partitions and 3 partition indices
+				// the factor is 3, partition 0 will listen to 0,3,6, etc.
+				// this value will be used further fanning data out to the multiple Kafka partitions that
+				// are assigned to a given partition index
+				this.factor = (numberOfKafkaPartitions + partitioningMetadata.getPartitionCount() - 1)
+						/ partitioningMetadata.getPartitionCount();
+			}
 		}
 
 		@Override
@@ -631,7 +749,11 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 			int partition;
 			if (partitioningMetadata.isPartitionedModule()) {
-				partition = determinePartition(message, partitioningMetadata);
+				// this is the logical partition in Spring XD - we need to fan out the messages further
+				int springXdPartition = determinePartition(message, partitioningMetadata);
+				// in order to do so, we will generate a number whose modulus when applied to total partition count
+				// is equal to springXdPartition
+				partition = (roundRobin()%factor) * partitioningMetadata.getPartitionCount() + springXdPartition;
 			}
 			else {
 				// The value will be modulo-ed by numPartitions by Kafka itself

--- a/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
+++ b/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
@@ -1,23 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:context="http://www.springframework.org/schema/context"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
+
+	<bean id="zookeeperConnect" class="org.springframework.integration.kafka.support.ZookeeperConnect">
+		<property name="zkConnect" value="${xd.messagebus.kafka.zkAddress}"/>
+	</bean>
+
+
 	<bean id="messageBus" class="org.springframework.xd.dirt.integration.kafka.KafkaMessageBus">
+		<constructor-arg ref="zookeeperConnect"/>
 		<constructor-arg value="${xd.messagebus.kafka.brokers}"/>
 		<constructor-arg value="${xd.messagebus.kafka.zkAddress}"/>
 		<constructor-arg ref="codec"/>
 		<constructor-arg value="#{new String[0]}"/>
 
-		<property name="defaultBatchingEnabled" value="${xd.messagebus.kafka.default.batchingEnabled}" />
-		<property name="defaultBatchSize" value="${xd.messagebus.kafka.default.batchSize}" />
-		<property name="defaultBatchTimeout" value="${xd.messagebus.kafka.default.batchTimeout}" />
+		<property name="defaultBatchingEnabled" value="${xd.messagebus.kafka.default.batchingEnabled}"/>
+		<property name="defaultBatchSize" value="${xd.messagebus.kafka.default.batchSize}"/>
+		<property name="defaultBatchTimeout" value="${xd.messagebus.kafka.default.batchTimeout}"/>
 		<property name="defaultReplicationFactor" value="${xd.messagebus.kafka.default.replicationFactor}"/>
 		<property name="defaultConcurrency" value="${xd.messagebus.kafka.default.concurrency}"/>
 		<property name="defaultRequiredAcks" value="${xd.messagebus.kafka.default.requiredAcks}"/>
 		<property name="defaultCompressionCodec" value="${xd.messagebus.kafka.default.compressionCodec}"/>
+		<property name="offsetStoreTopic" value="${xd.messagebus.kafka.offsetStoreTopic}"/>
 	</bean>
 
 </beans>

--- a/spring-xd-messagebus-local/src/main/java/org/springframework/xd/dirt/integration/bus/local/LocalMessageBus.java
+++ b/spring-xd-messagebus-local/src/main/java/org/springframework/xd/dirt/integration/bus/local/LocalMessageBus.java
@@ -143,13 +143,13 @@ public class LocalMessageBus extends MessageBusSupport {
 	 */
 	@Override
 	public void bindConsumer(String name, MessageChannel moduleInputChannel, Properties properties) {
-		validateConsumerProperties(name, properties, Collections.emptySet());
+		validateConsumerProperties(name, properties, CONSUMER_STANDARD_PROPERTIES);
 		doRegisterConsumer(name, moduleInputChannel, getChannelProvider(name), properties);
 	}
 
 	@Override
 	public void bindPubSubConsumer(String name, MessageChannel moduleInputChannel, Properties properties) {
-		validateConsumerProperties(name, properties, Collections.emptySet());
+		validateConsumerProperties(name, properties, CONSUMER_STANDARD_PROPERTIES);
 		doRegisterConsumer(name, moduleInputChannel, this.pubsubChannelProvider, properties);
 	}
 
@@ -193,7 +193,7 @@ public class LocalMessageBus extends MessageBusSupport {
 	@Override
 	public void bindRequestor(final String name, MessageChannel requests, final MessageChannel replies,
 			Properties properties) {
-		validateConsumerProperties(name, properties, Collections.emptySet());
+		validateConsumerProperties(name, properties, CONSUMER_STANDARD_PROPERTIES);
 		final MessageChannel requestChannel = this.findOrCreateRequestReplyChannel("requestor." + name);
 		// TODO: handle Pollable ?
 		Assert.isInstanceOf(SubscribableChannel.class, requests);
@@ -218,7 +218,7 @@ public class LocalMessageBus extends MessageBusSupport {
 	@Override
 	public void bindReplier(String name, final MessageChannel requests, MessageChannel replies,
 			Properties properties) {
-		validateConsumerProperties(name, properties, Collections.emptySet());
+		validateConsumerProperties(name, properties, CONSUMER_STANDARD_PROPERTIES);
 		SubscribableChannel requestChannel = this.findOrCreateRequestReplyChannel("requestor." + name);
 		requestChannel.subscribe(new MessageHandler() {
 

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -128,9 +128,10 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 	}));
 
 	/**
-	 * Retry + rabbit consumer properties.
+	 * Standard + retry + rabbit consumer properties.
 	 */
 	private static final Set<Object> SUPPORTED_BASIC_CONSUMER_PROPERTIES = new SetBuilder()
+			.addAll(CONSUMER_STANDARD_PROPERTIES)
 			.addAll(CONSUMER_RETRY_PROPERTIES)
 			.addAll(RABBIT_CONSUMER_PROPERTIES)
 			.build();

--- a/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -96,6 +96,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 	 * Retry only.
 	 */
 	private static final Set<Object> SUPPORTED_PUBSUB_CONSUMER_PROPERTIES = new SetBuilder()
+			.addAll(CONSUMER_STANDARD_PROPERTIES)
 			.addAll(CONSUMER_RETRY_PROPERTIES)
 			.build();
 
@@ -103,6 +104,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 	 * Retry + concurrency.
 	 */
 	private static final Set<Object> SUPPORTED_NAMED_CONSUMER_PROPERTIES = new SetBuilder()
+			.addAll(CONSUMER_STANDARD_PROPERTIES)
 			.addAll(CONSUMER_RETRY_PROPERTIES)
 			.add(BusProperties.CONCURRENCY)
 			.build();
@@ -120,6 +122,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 	 */
 	private static final Set<Object> SUPPORTED_REPLYING_CONSUMER_PROPERTIES = new SetBuilder()
 			// request
+			.addAll(CONSUMER_STANDARD_PROPERTIES)
 			.addAll(CONSUMER_RETRY_PROPERTIES)
 			.add(BusProperties.CONCURRENCY)
 			.build();

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/AbstractBusPropertiesAccessor.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/AbstractBusPropertiesAccessor.java
@@ -255,6 +255,24 @@ public abstract class AbstractBusPropertiesAccessor implements BusProperties {
 	}
 
 	/**
+	 * The sequence number for this module.
+	 *
+	 * @return the sequence number.
+	 */
+	public int getSequence() {
+		return getProperty(SEQUENCE, 1);
+	}
+
+	/**
+	 * The module count.
+	 *
+	 * @return the module count.
+	 */
+	public int getCount() {
+		return getProperty(COUNT, 1);
+	}
+
+	/**
 	 * The number of partitions for this module.
 	 * @return The count.
 	 */

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
@@ -55,6 +55,18 @@ public interface BusProperties {
 	public static final String MAX_CONCURRENCY = "maxConcurrency";
 
 	/**
+	 *  The sequence index of the module.
+	 *  In a partitioned stream, it is identical to the partition index.
+	 */
+	public static final String SEQUENCE = "sequence";
+
+	/**
+	 *  The number of consumers, i.e. module instances in the stream.
+	 *  In a partitioned stream, it is identical to the partition count.
+	 */
+	public static final String COUNT = "count";
+
+	/**
 	 * The partition count.
 	 */
 	public static final String PARTITION_COUNT = "partitionCount";

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -112,6 +112,12 @@ public abstract class MessageBusSupport
 	/**
 	 * The set of properties every bus implementation must support (or at least tolerate).
 	 */
+
+	protected static final Set<Object> CONSUMER_STANDARD_PROPERTIES = new SetBuilder()
+			.add(BusProperties.COUNT)
+			.add(BusProperties.SEQUENCE)
+			.build();
+
 	protected static final Set<Object> PRODUCER_STANDARD_PROPERTIES = new HashSet<Object>(Arrays.asList(
 			BusProperties.NEXT_MODULE_COUNT
 			));
@@ -917,6 +923,10 @@ public abstract class MessageBusSupport
 
 		public boolean isPartitionedModule() {
 			return StringUtils.hasText(this.partitionKeyExtractorClass) || this.partitionKeyExpression != null;
+		}
+
+		public int getPartitionCount() {
+			return partitionCount;
 		}
 	}
 

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/KafkaSourceSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/KafkaSourceSinkTests.java
@@ -88,7 +88,7 @@ public class KafkaSourceSinkTests extends AbstractStreamIntegrationTest {
 		final CounterSink counter = metrics().newCounterSink();
 		stream().create(generateStreamName(), "kafka --topic='%s' --zkconnect=%s | " +
 				"filter --expression=payload.toString().contains('%s') | %s",
-				topicToUse, kafkaTestSupport.getZkconnectstring(), stringToPost, counter );
+				topicToUse, kafkaTestSupport.getZkConnectString(), stringToPost, counter );
 		httpSource.ensureReady().postData(stringToPost);
 		assertThat(counter, eventually(exists()));
 	}

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/KafkaTransportSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/KafkaTransportSparkStreamingTests.java
@@ -21,7 +21,6 @@ import java.util.Properties;
 import kafka.utils.TestUtils;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 
 import org.springframework.xd.dirt.integration.bus.KafkaConnectionPropertyNames;
 import org.springframework.xd.test.kafka.KafkaTestSupport;
@@ -29,7 +28,6 @@ import org.springframework.xd.test.kafka.KafkaTestSupport;
 /**
  * @author Ilayaperumal Gopinathan
  */
-@Ignore
 public class KafkaTransportSparkStreamingTests extends AbstractSparkStreamingTests {
 
 	@ClassRule

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
@@ -24,7 +24,6 @@ import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkInterruptedException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.log4j.Level;
 import org.junit.Rule;
 
 import org.springframework.xd.test.AbstractExternalResourceTestSupport;
@@ -58,7 +57,7 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 		this.brokerConfig = brokerConfig;
 	}
 
-	public String getZkconnectstring() {
+	public String getZkConnectString() {
 		return zookeeper.getConnectString();
 	}
 
@@ -91,7 +90,7 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 		try {
 			int zkConnectionTimeout = 6000;
 			int zkSessionTimeout = 6000;
-			zkClient = new ZkClient(getZkconnectstring(), zkSessionTimeout, zkConnectionTimeout, ZKStringSerializer$.MODULE$);
+			zkClient = new ZkClient(getZkConnectString(), zkSessionTimeout, zkConnectionTimeout, ZKStringSerializer$.MODULE$);
 		}
 		catch (Exception e) {
 			zookeeper.shutdown();


### PR DESCRIPTION
- Use the KafkaMessageDrivenChannelAdapter for consuming messages, backed by a KafkaTopicMetadataStore
- For partitioning between listeners, added Bus properties for count and sequence, available with all deployments
- For partitioned streams, fan out messages across the Kafka partitions that belong to a logical Spring XD partition;
- Kafka partition assigning scheme ensures that for a given deployment, partitions alocation to a specific module sequence number or partition index will be preserved

Note: introducing the simple consumer based API disables support for dynamic scaling of modules (aka module.moduleName.count=0 and module.*.count=0)