### PR TITLE
XD-2655 Configure deployment timeout

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -290,9 +290,16 @@ endpoints:
 #
 # The default value for this property is 15000 ms.
 #
-# xd:
+#xd:
 #  admin:
 #    quietPeriod: 15000
+---
+# Module deployment timeout
+# The module deployment timeout is the amount of time the Module deployment writer
+# waits to get the deployment status after writing the ZK deployment requests' paths
+#xd:
+#  admin:
+#    deploymentTimeout: 30000
 ---
 # User Extensions: Where XD scans the classpath to discover extended container configuration to add beans to the Plugins context.
 # Each property may be a comma delimited string. 'basepackages' refers to package names used for

--- a/config/servers.yml
+++ b/config/servers.yml
@@ -295,8 +295,8 @@ endpoints:
 #    quietPeriod: 15000
 ---
 # Module deployment timeout
-# The module deployment timeout is the amount of time the Module deployment writer
-# waits to get the deployment status after writing the ZK deployment requests' paths
+# The module deployment timeout is the number of milliseconds the admin server
+# will wait for a response to a module deployment request to a container.
 #xd:
 #  admin:
 #    deploymentTimeout: 30000

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,7 @@ public class ContainerListener implements PathChildrenCacheListener {
 	 * @param jobDeployments cache of children for job deployments path
 	 * @param moduleDeploymentRequests cache of children for requested module deployments path
 	 * @param containerMatcher matches modules to containers
+	 * @param moduleDeploymentWriter utility that writes deployment requests to zk path
 	 * @param stateCalculator calculator for stream/job state
 	 * @param quietPeriod AtomicLong indicating quiet period for new container module deployments
 	 */
@@ -105,14 +106,14 @@ public class ContainerListener implements PathChildrenCacheListener {
 			StreamFactory streamFactory, JobFactory jobFactory,
 			PathChildrenCache streamDeployments, PathChildrenCache jobDeployments,
 			PathChildrenCache moduleDeploymentRequests, ContainerMatcher containerMatcher,
-			DeploymentUnitStateCalculator stateCalculator,
+			ModuleDeploymentWriter moduleDeploymentWriter, DeploymentUnitStateCalculator stateCalculator,
 			ScheduledExecutorService executorService, AtomicLong quietPeriod) {
 		this.containerMatchingModuleRedeployer = new ContainerMatchingModuleRedeployer(zkConnection,
 				containerRepository, streamFactory, jobFactory, streamDeployments, jobDeployments,
-				moduleDeploymentRequests, containerMatcher, stateCalculator);
+				moduleDeploymentRequests, containerMatcher, moduleDeploymentWriter, stateCalculator);
 		this.departingContainerModuleRedeployer = new DepartingContainerModuleRedeployer(zkConnection,
 				containerRepository, streamFactory, jobFactory, moduleDeploymentRequests, containerMatcher,
-				stateCalculator);
+				moduleDeploymentWriter, stateCalculator);
 		this.quietPeriod = quietPeriod;
 		this.executorService = executorService;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerMatchingModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ContainerMatchingModuleRedeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ public class ContainerMatchingModuleRedeployer extends ModuleRedeployer {
 	 * @param jobDeployments cache of children for job deployments path
 	 * @param moduleDeploymentRequests cache of children for requested module deployments path
 	 * @param containerMatcher matches modules to containers
+	 * @param moduleDeploymentWriter utility that writes deployment requests to zk path
 	 * @param stateCalculator calculator for stream/job state
 	 */
 	public ContainerMatchingModuleRedeployer(ZooKeeperConnection zkConnection,
@@ -84,9 +85,9 @@ public class ContainerMatchingModuleRedeployer extends ModuleRedeployer {
 			StreamFactory streamFactory, JobFactory jobFactory,
 			PathChildrenCache streamDeployments, PathChildrenCache jobDeployments,
 			PathChildrenCache moduleDeploymentRequests, ContainerMatcher containerMatcher,
-			DeploymentUnitStateCalculator stateCalculator) {
+			ModuleDeploymentWriter moduleDeploymentWriter, DeploymentUnitStateCalculator stateCalculator) {
 		super(zkConnection, containerRepository, streamFactory, jobFactory, moduleDeploymentRequests, containerMatcher,
-				stateCalculator);
+				moduleDeploymentWriter, stateCalculator);
 		this.streamDeployments = streamDeployments;
 		this.jobDeployments = jobDeployments;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DepartingContainerModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DepartingContainerModuleRedeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,15 +66,16 @@ public class DepartingContainerModuleRedeployer extends ModuleRedeployer {
 	 * @param jobFactory factory to construct {@link Job}
 	 * @param moduleDeploymentRequests cache of children for requested module deployments path
 	 * @param containerMatcher matches modules to containers
+	 * @param moduleDeploymentWriter utility that writes deployment requests to zk path
 	 * @param stateCalculator calculator for stream/job state
 	 */
 	public DepartingContainerModuleRedeployer(ZooKeeperConnection zkConnection,
 			ContainerRepository containerRepository,
 			StreamFactory streamFactory, JobFactory jobFactory,
 			PathChildrenCache moduleDeploymentRequests, ContainerMatcher containerMatcher,
-			DeploymentUnitStateCalculator stateCalculator) {
+			ModuleDeploymentWriter moduleDeploymentWriter, DeploymentUnitStateCalculator stateCalculator) {
 		super(zkConnection, containerRepository, streamFactory, jobFactory, moduleDeploymentRequests, containerMatcher,
-				stateCalculator);
+				moduleDeploymentWriter, stateCalculator);
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
@@ -181,7 +181,7 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 	 * Amount of time to wait for a status to be written to all module
 	 * deployment request paths.
 	 */
-	private final AtomicLong deploymentTimeout = new AtomicLong(30000);
+	private long deploymentTimeout = 30000;
 
 	/**
 	 * Property for specifying the {@link #deploymentTimeout deployment timeout}.
@@ -247,7 +247,7 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 			}
 			String timeout = this.applicationContext.getEnvironment().getProperty(DEPLOYMENT_TIMEOUT_PROPERTY);
 			if (StringUtils.hasText(timeout)) {
-				deploymentTimeout.set(Long.parseLong(timeout));
+				deploymentTimeout = Long.parseLong(timeout);
 			}
 			if (this.zkConnection.isConnected()) {
 				if (this.applicationContext.equals(((ContextRefreshedEvent) event).getApplicationContext())) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentSupervisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,6 +178,17 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 	public static final String QUIET_PERIOD_PROPERTY = "xd.admin.quietPeriod";
 
 	/**
+	 * Amount of time to wait for a status to be written to all module
+	 * deployment request paths.
+	 */
+	private final AtomicLong deploymentTimeout = new AtomicLong(30000);
+
+	/**
+	 * Property for specifying the {@link #deploymentTimeout deployment timeout}.
+	 */
+	public static final String DEPLOYMENT_TIMEOUT_PROPERTY = "xd.admin.deploymentTimeout";
+
+	/**
 	 * Construct a {@code DeploymentSupervisor}.
 	 *
 	 * @param zkConnection ZooKeeper connection
@@ -234,7 +245,10 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 				quietPeriod.set(Long.parseLong(delay));
 				logger.info("Set container quiet period to {} ms", delay);
 			}
-
+			String timeout = this.applicationContext.getEnvironment().getProperty(DEPLOYMENT_TIMEOUT_PROPERTY);
+			if (StringUtils.hasText(timeout)) {
+				deploymentTimeout.set(Long.parseLong(timeout));
+			}
 			if (this.zkConnection.isConnected()) {
 				if (this.applicationContext.equals(((ContextRefreshedEvent) event).getApplicationContext())) {
 					// initial registration, we don't yet have a port info
@@ -464,8 +478,10 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 			StreamDeploymentListener streamDeploymentListener;
 			JobDeploymentListener jobDeploymentListener;
 			ContainerListener containerListener;
+			ModuleDeploymentWriter moduleDeploymentWriter;
 
 			try {
+				moduleDeploymentWriter = new ModuleDeploymentWriter(zkConnection, deploymentTimeout);
 				StreamFactory streamFactory = new StreamFactory(streamDefinitionRepository, moduleRegistry,
 						moduleOptionsMetadataResolver);
 
@@ -484,6 +500,7 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 						containerRepository,
 						streamFactory,
 						containerMatcher,
+						moduleDeploymentWriter,
 						stateCalculator);
 
 				streamDeployments = instantiatePathChildrenCache(client, Paths.STREAM_DEPLOYMENTS);
@@ -500,6 +517,7 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 						containerRepository,
 						jobFactory,
 						containerMatcher,
+						moduleDeploymentWriter,
 						stateCalculator);
 
 				jobDeployments = instantiatePathChildrenCache(client, Paths.JOB_DEPLOYMENTS);
@@ -515,6 +533,7 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 						jobDeployments,
 						moduleDeploymentRequests,
 						containerMatcher,
+						moduleDeploymentWriter,
 						stateCalculator,
 						executorService,
 						quietPeriod);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/InitialDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/InitialDeploymentListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,16 +79,18 @@ public abstract class InitialDeploymentListener implements PathChildrenCacheList
 	 * @param moduleDeploymentRequests the requested module deployments
 	 * @param containerRepository repository to obtain container data
 	 * @param containerMatcher matches modules to containers
+	 * @param moduleDeploymentWriter utility that writes deployment requests to zk path
 	 * @param stateCalculator calculator for stream state
 	 */
 	public InitialDeploymentListener(ZooKeeperConnection zkConnection,
 			PathChildrenCache moduleDeploymentRequests,
 			ContainerRepository containerRepository,
-			ContainerMatcher containerMatcher, DeploymentUnitStateCalculator stateCalculator) {
+			ContainerMatcher containerMatcher, ModuleDeploymentWriter moduleDeploymentWriter,
+			DeploymentUnitStateCalculator stateCalculator) {
 		this.moduleDeploymentRequests = moduleDeploymentRequests;
 		this.containerMatcher = containerMatcher;
 		this.containerRepository = containerRepository;
-		this.moduleDeploymentWriter = new ModuleDeploymentWriter(zkConnection, containerMatcher);
+		this.moduleDeploymentWriter = moduleDeploymentWriter;
 		this.stateCalculator = stateCalculator;
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/JobDeploymentListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,8 +81,10 @@ public class JobDeploymentListener extends InitialDeploymentListener {
 	 */
 	public JobDeploymentListener(ZooKeeperConnection zkConnection, PathChildrenCache moduleDeploymentRequests,
 			ContainerRepository containerRepository, JobFactory jobFactory,
-			ContainerMatcher containerMatcher, DeploymentUnitStateCalculator stateCalculator) {
-		super(zkConnection, moduleDeploymentRequests, containerRepository, containerMatcher, stateCalculator);
+			ContainerMatcher containerMatcher, ModuleDeploymentWriter moduleDeploymentWriter,
+			DeploymentUnitStateCalculator stateCalculator) {
+		super(zkConnection, moduleDeploymentRequests, containerRepository, containerMatcher, moduleDeploymentWriter,
+				stateCalculator);
 		this.jobFactory = jobFactory;
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.curator.framework.api.CuratorWatcher;
 import org.apache.zookeeper.KeeperException;
@@ -79,7 +78,7 @@ public class ModuleDeploymentWriter {
 	 * deployment request paths.
 	 *
 	 */
-	private final AtomicLong deploymentTimeout;
+	private final long deploymentTimeout;
 
 	/**
 	 * Construct a {@code ModuleDeploymentWriter}.
@@ -87,7 +86,7 @@ public class ModuleDeploymentWriter {
 	 * @param zkConnection         ZooKeeper connection
 	 * @param deploymentTimeout    Deployment timeout to wait for status
 	 */
-	public ModuleDeploymentWriter(ZooKeeperConnection zkConnection, AtomicLong deploymentTimeout) {
+	public ModuleDeploymentWriter(ZooKeeperConnection zkConnection, long deploymentTimeout) {
 		this.zkConnection = zkConnection;
 		this.deploymentTimeout = deploymentTimeout;
 	}
@@ -467,7 +466,7 @@ public class ModuleDeploymentWriter {
 		 */
 		public synchronized Collection<ModuleDeploymentStatus> getResults() throws InterruptedException {
 			long now = System.currentTimeMillis();
-			long expiryTime = now + deploymentTimeout.get();
+			long expiryTime = now + deploymentTimeout;
 			while (pending.size() > 0 && now < expiryTime) {
 				wait(expiryTime - now);
 				now = System.currentTimeMillis();

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleDeploymentWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.curator.framework.api.CuratorWatcher;
 import org.apache.zookeeper.KeeperException;
@@ -44,16 +45,13 @@ import org.springframework.xd.module.RuntimeModuleDeploymentProperties;
 /**
  * Utility class to write module deployment requests under {@code /xd/deployments/modules}.
  * There are several {@code writeDeployment} methods that allow for targeting
- * a deployment to a specific container or to a collection of containers indicated
- * by the {@link org.springframework.xd.dirt.server.ContainerMatcher} passed into
- * the constructor.
+ * a deployment to a specific container or a collection of containers.
  * <p/>
  * General usage is to invoke {@code writeDeployment} and examine the {@link ModuleDeploymentStatus}
  * object that is returned. This invocation will block until:
  * <ul>
  *     <li>all containers have "responded" by updating the ZooKeeper nodes</li>
- *     <li>the timeout period elapses without all containers responding
- *         (default value is {@link #DEFAULT_TIMEOUT}.</li>
+ *     <li>the timeout period elapses without all containers responding.</li>
  *     <li>the waiting thread is interrupted</li>
  * </ul>
  * The results may be examined to obtain detailed information about each deployment
@@ -72,13 +70,6 @@ public class ModuleDeploymentWriter {
 	private static final Logger logger = LoggerFactory.getLogger(ModuleDeploymentWriter.class);
 
 	/**
-	 * Default timeout in milliseconds.
-	 *
-	 * @see #timeout
-	 */
-	private final static long DEFAULT_TIMEOUT = 30000;
-
-	/**
 	 * ZooKeeper connection.
 	 */
 	private final ZooKeeperConnection zkConnection;
@@ -86,32 +77,19 @@ public class ModuleDeploymentWriter {
 	/**
 	 * Amount of time to wait for a status to be written to all module
 	 * deployment request paths.
-	 */
-	private final long timeout;
-
-
-	/**
-	 * Construct a {@code ModuleDeploymentWriter} with the default timeout
-	 * value indicated by {@link #DEFAULT_TIMEOUT}.
 	 *
-	 * @param zkConnection         ZooKeeper connection
-	 * @param containerMatcher     matcher for modules to containers
 	 */
-	public ModuleDeploymentWriter(ZooKeeperConnection zkConnection, ContainerMatcher containerMatcher) {
-		this(zkConnection, containerMatcher, DEFAULT_TIMEOUT);
-	}
+	private final AtomicLong deploymentTimeout;
 
 	/**
 	 * Construct a {@code ModuleDeploymentWriter}.
 	 *
 	 * @param zkConnection         ZooKeeper connection
-	 * @param containerMatcher     matcher for modules to containers
-	 * @param timeout    amount of time to wait for module deployments
+	 * @param deploymentTimeout    Deployment timeout to wait for status
 	 */
-	public ModuleDeploymentWriter(ZooKeeperConnection zkConnection, ContainerMatcher containerMatcher,
-			long timeout) {
+	public ModuleDeploymentWriter(ZooKeeperConnection zkConnection, AtomicLong deploymentTimeout) {
 		this.zkConnection = zkConnection;
-		this.timeout = timeout;
+		this.deploymentTimeout = deploymentTimeout;
 	}
 
 
@@ -489,7 +467,7 @@ public class ModuleDeploymentWriter {
 		 */
 		public synchronized Collection<ModuleDeploymentStatus> getResults() throws InterruptedException {
 			long now = System.currentTimeMillis();
-			long expiryTime = now + timeout;
+			long expiryTime = now + deploymentTimeout.get();
 			while (pending.size() > 0 && now < expiryTime) {
 				wait(expiryTime - now);
 				now = System.currentTimeMillis();
@@ -504,7 +482,7 @@ public class ModuleDeploymentWriter {
 								key.moduleDescriptorKey,
 								ModuleDeploymentStatus.State.failed,
 								String.format("Deployment of module '%s' to container '%s' timed out after %d ms",
-										key.moduleDescriptorKey, key.container, timeout)));
+										key.moduleDescriptorKey, key.container, deploymentTimeout)));
 			}
 			return results.values();
 		}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleRedeployer.java
@@ -120,16 +120,17 @@ public abstract class ModuleRedeployer {
 	 * @param jobFactory factory to construct {@link Job}
 	 * @param moduleDeploymentRequests cache of children for requested module deployments path
 	 * @param containerMatcher matches modules to containers
+	 * @param moduleDeploymentWriter utility that writes deployment requests to zk path
 	 * @param stateCalculator calculator for stream/job state
 	 */
 	public ModuleRedeployer(ZooKeeperConnection zkConnection,
 			ContainerRepository containerRepository, StreamFactory streamFactory, JobFactory jobFactory,
 			PathChildrenCache moduleDeploymentRequests, ContainerMatcher containerMatcher,
-			DeploymentUnitStateCalculator stateCalculator) {
+			ModuleDeploymentWriter moduleDeploymentWriter, DeploymentUnitStateCalculator stateCalculator) {
 		this.zkConnection = zkConnection;
 		this.containerRepository = containerRepository;
 		this.containerMatcher = containerMatcher;
-		this.moduleDeploymentWriter = new ModuleDeploymentWriter(zkConnection, containerMatcher);
+		this.moduleDeploymentWriter = moduleDeploymentWriter;
 		this.moduleDeploymentRequests = moduleDeploymentRequests;
 		this.streamFactory = streamFactory;
 		this.jobFactory = jobFactory;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/StreamDeploymentListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,14 +73,17 @@ public class StreamDeploymentListener extends InitialDeploymentListener {
 	 * @param containerRepository repository to obtain container data
 	 * @param streamFactory factory to construct {@link Stream}
 	 * @param containerMatcher matches modules to containers
+	 * @param moduleDeploymentWriter utility that writes deployment requests to zk path
 	 * @param stateCalculator calculator for stream state
 	 */
 	public StreamDeploymentListener(ZooKeeperConnection zkConnection,
 			PathChildrenCache moduleDeploymentRequests,
 			ContainerRepository containerRepository,
 			StreamFactory streamFactory,
-			ContainerMatcher containerMatcher, DeploymentUnitStateCalculator stateCalculator) {
-		super(zkConnection, moduleDeploymentRequests, containerRepository, containerMatcher, stateCalculator);
+			ContainerMatcher containerMatcher, ModuleDeploymentWriter moduleDeploymentWriter,
+			DeploymentUnitStateCalculator stateCalculator) {
+		super(zkConnection, moduleDeploymentRequests, containerRepository, containerMatcher, moduleDeploymentWriter,
+				stateCalculator);
 		this.streamFactory = streamFactory;
 	}
 


### PR DESCRIPTION
 - Add `xd.admin.deploymentTimeout` property which can be
configured via servers.yml
 - Make single instance of ModuleDeploymentWriter for the admin JVM
 - Refactor `ModuleDeploymentWriter`
    - remove container matcher dependency as it is no longer needed
in its constructor
    - always set deployment timeout