### PR TITLE
XD-2499(2): Inherit restartable option

### DIFF
--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests-context.xml
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests-context.xml
@@ -18,6 +18,7 @@
 	<util:properties id="props">
 		<prop key="restartable">false</prop>
 		<prop key="xd.config.home">file:../../config</prop>
+		<prop key="partitionResultsTimeout">3600000</prop>
 	</util:properties>
 
 	<import resource="file:../../modules/job/ftphdfs/config/ftphdfs.xml" />

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests-context.xml
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests-context.xml
@@ -19,6 +19,7 @@
 
 	<util:properties id="props">
 		<prop key="restartable">false</prop>
+		<prop key="partitionResultsTimeout">3600000</prop>
 	</util:properties>
 
 	<bean id="jobLauncher" class="org.springframework.batch.core.launch.support.SimpleJobLauncher">

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcHdfsOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcHdfsOptionsMetadata.java
@@ -38,8 +38,8 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * @author Thomas Risberg
  * @author Glenn Renfro
  */
-@Mixin({ JdbcConnectionMixin.class, JdbcConnectionPoolMixin.class, BatchJobRestartableOptionMixin.class,
-	BatchJobFieldDelimiterOptionMixin.class, BatchJobCommitIntervalOptionMixin.class, HadoopConfigurationMixin.class,
+@Mixin({ JdbcConnectionMixin.class, JdbcConnectionPoolMixin.class, BatchJobFieldDelimiterOptionMixin.class,
+		BatchJobCommitIntervalOptionMixin.class, HadoopConfigurationMixin.class,
 		BatchJobSinglestepPartitionSupportOptionMixin.class})
 public class JdbcHdfsOptionsMetadata {
 

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/singlestep-partition-support.xml
@@ -92,7 +92,7 @@
 	</bean>
 
 	<bean id="replyChannelRegistry" class="org.springframework.integration.channel.DefaultHeaderChannelRegistry">
-		<constructor-arg value="${partitionResultsTimeout:3600000}" />
+		<constructor-arg value="${partitionResultsTimeout}" />
 	</bean>
 
 </beans>

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobSinglestepPartitionSupportOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobSinglestepPartitionSupportOptionMixin.java
@@ -18,6 +18,7 @@
 
 package org.springframework.xd.module.options.mixins;
 
+import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
 
 /**
@@ -25,6 +26,7 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  *
  * @author Eric Bottard
  */
+@Mixin(BatchJobRestartableOptionMixin.class)
 public class BatchJobSinglestepPartitionSupportOptionMixin {
 
 	private long partitionResultsTimeout = 300000;

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/FlattenedCompositeModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/FlattenedCompositeModuleOptionsMetadata.java
@@ -61,13 +61,15 @@ public class FlattenedCompositeModuleOptionsMetadata implements ModuleOptionsMet
 			Set<String> optionNames = new HashSet<String>();
 			momToSupportedOptions.put(delegate, optionNames);
 			for (ModuleOption option : delegate) {
-				if (options.get(option.getName()) != null) {
+				ModuleOption alreadyThere = options.get(option.getName());
+				// It's ok to have the exact "same" option in several delegates, e.g. via Mixin Diamond inheritance
+				if (alreadyThere != null && !alreadyThere.equals(option)) {
 					/*
 					 * XD-1472: InputType treated as a special case. If the module defines a default, do not replace it
 					 * with a null value (the global default)
 					 */
 					if (option.getName().equals(INPUT_TYPE)) {
-						inputType = options.get(option.getName());
+						inputType = alreadyThere;
 					}
 					else {
 						reportOptionCollision(delegates, option.getName());
@@ -87,12 +89,11 @@ public class FlattenedCompositeModuleOptionsMetadata implements ModuleOptionsMet
 			for (ModuleOption option : delegate) {
 				if (option.getName().equals(optionName)) {
 					offenders.add(delegate);
-					break;
 				}
 			}
 		}
 		throw new IllegalArgumentException(String.format(
-				"Module option named '%s' is present in several delegates: %s",
+				"Module option named '%s' is present in several delegates, with different attributes: %s",
 				optionName, offenders));
 	}
 

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOption.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOption.java
@@ -77,6 +77,32 @@ public class ModuleOption {
 	}
 
 	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		ModuleOption that = (ModuleOption) o;
+
+		if (hidden != that.hidden) return false;
+		if (defaultValue != null ? !defaultValue.equals(that.defaultValue) : that.defaultValue != null) return false;
+		if (description != null ? !description.equals(that.description) : that.description != null) return false;
+		if (!name.equals(that.name)) return false;
+		if (type != null ? !type.equals(that.type) : that.type != null) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = name.hashCode();
+		result = 31 * result + (description != null ? description.hashCode() : 0);
+		result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
+		result = 31 * result + (hidden ? 1 : 0);
+		result = 31 * result + (type != null ? type.hashCode() : 0);
+		return result;
+	}
+
+	@Override
 	public String toString() {
 		return "ModuleOption [name=" + name + ", type=" + type + ", defaultValue=" + defaultValue + ", description="
 				+ description + "]";

--- a/spring-xd-shell/src/test/resources/spring-xd/xd/modules/job/jobWithPartitions/config/jobWithPartitions.properties
+++ b/spring-xd-shell/src/test/resources/spring-xd/xd/modules/job/jobWithPartitions/config/jobWithPartitions.properties
@@ -1,1 +1,1 @@
-options_class = org.springframework.xd.module.options.mixins.BatchJobRestartableOptionMixin
+options_class = org.springframework.xd.module.options.mixins.BatchJobSinglestepPartitionSupportOptionMixin


### PR DESCRIPTION
Followup to initial XD-2499 implementation:
* Make restartable option part of partition-awareness
* Remove default from xml
* Fix failing tests
* Allow multiple inclusion of an option as long as it's the exact same attributes
