### PR TITLE
[Sprint: 42] XD-2683 Spark streaming module type conversion

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/JsonToPojoMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/JsonToPojoMessageConverter.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 
 
 /**
- * 
+ *
  * @author David Turanski
  */
 public class JsonToPojoMessageConverter extends AbstractFromMessageConverter {
@@ -38,7 +38,7 @@ public class JsonToPojoMessageConverter extends AbstractFromMessageConverter {
 
 	@Override
 	protected Class<?>[] supportedPayloadTypes() {
-		return new Class<?>[] { String.class, byte[].class };
+		return new Class<?>[] {String.class, byte[].class};
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/PojoToJsonMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/PojoToJsonMessageConverter.java
@@ -46,7 +46,7 @@ public class PojoToJsonMessageConverter extends AbstractFromMessageConverter {
 
 	@Override
 	protected Class<?>[] supportedTargetTypes() {
-		return new Class<?>[] { String.class };
+		return new Class<?>[] {String.class};
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingChannel.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingChannel.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.plugins.spark.streaming;
+
+import java.io.Serializable;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.util.MimeType;
+import org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionPlugin;
+import org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionSupport;
+import org.springframework.xd.dirt.util.ConfigLocations;
+
+/**
+ * The {@link org.springframework.integration.channel.DirectChannel} that provides support for
+ * spark streaming configurations.
+ *
+ * @author Ilayaperumal Gopinathan
+ */
+public class SparkStreamingChannel extends DirectChannel implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Configure message converter for this direct channel.
+	 *
+	 * @param contentType the content type to use
+	 */
+	protected void configureMessageConverter(MimeType contentType) {
+		ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(
+				new String[] {ConfigLocations.XD_CONFIG_ROOT + "plugins/module-type-conversion.xml"});
+		ModuleTypeConversionPlugin typeConversionPlugin = (ModuleTypeConversionPlugin) context.getBean("moduleTypeConversionPlugin");
+		ModuleTypeConversionSupport moduleTypeConversionSupport = typeConversionPlugin.getModuleTypeConversionSupport();
+		moduleTypeConversionSupport.configureMessageConverters(this, contentType, Thread.currentThread().getContextClassLoader());
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionPlugin.java
@@ -36,6 +36,7 @@ import org.springframework.xd.module.core.Plugin;
  * which may be provided by end users.
  * 
  * @author David Turanski
+ * @author Ilayaperumal Gopinathan
  * @since 1.0
  */
 public class ModuleTypeConversionPlugin extends AbstractPlugin {
@@ -62,7 +63,7 @@ public class ModuleTypeConversionPlugin extends AbstractPlugin {
 	/**
 	 * Get the underlying {@link org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionSupport} which could be
 	 * further used by any other plugin that requires to apply module type conversion explicitly.
-	 * See {@link org.springframework.xd.dirt.plugins.spark.streaming.SparkStreamingMessageConverterSupport}
+	 * See {@link org.springframework.xd.dirt.plugins.spark.streaming.SparkStreamingChannel}
 	 *
 	 * @return return the underlying module type-conversion support object
 	 */
@@ -73,10 +74,10 @@ public class ModuleTypeConversionPlugin extends AbstractPlugin {
 	@Override
 	public void postProcessModule(Module module) {
 		if (module.getType() == ModuleType.source || module.getType() == ModuleType.processor) {
-			moduleTypeConversionSupport.configureModuleMessageConverters(module, false);
+			moduleTypeConversionSupport.configureModuleOutputChannelMessageConverters(module);
 		}
 		if (module.getType() == ModuleType.sink || module.getType() == ModuleType.processor) {
-			moduleTypeConversionSupport.configureModuleMessageConverters(module, true);
+			moduleTypeConversionSupport.configureModuleInputChannelMessageConverters(module);
 		}
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionPlugin.java
@@ -21,23 +21,13 @@ import java.util.Collection;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.aop.framework.Advised;
-import org.springframework.aop.support.AopUtils;
-import org.springframework.integration.channel.AbstractMessageChannel;
-import org.springframework.messaging.converter.CompositeMessageConverter;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.MimeType;
 import org.springframework.xd.dirt.integration.bus.converter.AbstractFromMessageConverter;
 import org.springframework.xd.dirt.integration.bus.converter.CompositeMessageConverterFactory;
-import org.springframework.xd.dirt.integration.bus.converter.ConversionException;
-import org.springframework.xd.dirt.integration.bus.converter.MessageConverterUtils;
 import org.springframework.xd.dirt.plugins.AbstractPlugin;
-import org.springframework.xd.dirt.plugins.ModuleConfigurationException;
 import org.springframework.xd.module.ModuleType;
 import org.springframework.xd.module.core.Module;
 import org.springframework.xd.module.core.Plugin;
-import org.springframework.xd.module.core.SimpleModule;
 
 
 /**
@@ -54,6 +44,8 @@ public class ModuleTypeConversionPlugin extends AbstractPlugin {
 
 	private final CompositeMessageConverterFactory converterFactory;
 
+	private final ModuleTypeConversionSupport moduleTypeConversionSupport;
+
 	/**
 	 * @param converters a list of default converters
 	 * @param customConverters a list of custom converters to extend the default converters
@@ -64,92 +56,33 @@ public class ModuleTypeConversionPlugin extends AbstractPlugin {
 			converters.addAll(customConverters);
 		}
 		this.converterFactory = new CompositeMessageConverterFactory(converters);
+		this.moduleTypeConversionSupport = new ModuleTypeConversionSupport(this.converterFactory);
+	}
+
+	/**
+	 * Get the underlying {@link org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionSupport} which could be
+	 * further used by any other plugin that requires to apply module type conversion explicitly.
+	 * See {@link org.springframework.xd.dirt.plugins.spark.streaming.SparkStreamingMessageConverterSupport}
+	 *
+	 * @return return the underlying module type-conversion support object
+	 */
+	public ModuleTypeConversionSupport getModuleTypeConversionSupport() {
+		return this.moduleTypeConversionSupport;
 	}
 
 	@Override
 	public void postProcessModule(Module module) {
-		String outputType = null;
-		String inputType = null;
 		if (module.getType() == ModuleType.source || module.getType() == ModuleType.processor) {
-			outputType = module.getProperties().getProperty("outputType");
+			moduleTypeConversionSupport.configureModuleMessageConverters(module, false);
 		}
 		if (module.getType() == ModuleType.sink || module.getType() == ModuleType.processor) {
-			inputType = module.getProperties().getProperty("inputType");
+			moduleTypeConversionSupport.configureModuleMessageConverters(module, true);
 		}
-		if (outputType != null) {
-			configureModuleConverters(outputType, module, false);
-		}
-		if (inputType != null) {
-			configureModuleConverters(inputType, module, true);
-		}
-	}
-
-	private void configureModuleConverters(String contentTypeString, Module module, boolean isInput) {
-		if (logger.isDebugEnabled()) {
-			logger.debug("module " + (isInput ? "input" : "output") + "Type is " + contentTypeString);
-		}
-		SimpleModule sm = (SimpleModule) module;
-		try {
-			MimeType contentType = resolveContentType(contentTypeString, module);
-
-			AbstractMessageChannel channel = getChannel(module, isInput);
-
-			CompositeMessageConverter converters = null;
-			try {
-				converters = converterFactory.newInstance(contentType);
-			}
-			catch (ConversionException e) {
-				throw new ModuleConfigurationException(e.getMessage() +
-						"(" +
-						module.getName() + " --" + (isInput ? "input" : "output") + "Type=" + contentTypeString
-						+ ")");
-			}
-
-			Class<?> dataType = MessageConverterUtils.getJavaTypeForContentType(contentType,
-					sm.getApplicationContext().getClassLoader());
-			if (dataType == null) {
-				throw new ModuleConfigurationException("Content type is not supported for " +
-						module.getName() + " --" + (isInput ? "input" : "output") + "Type=" + contentTypeString);
-			}
-			else {
-				channel.setDatatypes(dataType);
-				channel.setMessageConverter(converters);
-			}
-
-		}
-		catch (Throwable t) {
-			throw new ModuleConfigurationException(t.getMessage(), t);
-		}
-	}
-
-	// Workaround for when the channel is proxied and can't be cast directly to AbstractMessageChannel
-	private AbstractMessageChannel getChannel(Module module, boolean isInput) throws Exception {
-		String name = isInput ? "input" : "output";
-		Object channel = module.getComponent(name, Object.class);
-
-		if (AopUtils.isJdkDynamicProxy(channel)) {
-			return (AbstractMessageChannel) (((Advised) channel).getTargetSource().getTarget());
-		}
-
-		return (AbstractMessageChannel) channel;
-	}
-
-	private MimeType resolveContentType(String type, Module module) throws ClassNotFoundException, LinkageError {
-		if (!type.contains("/")) {
-			Class<?> javaType = resolveJavaType(type, module);
-			return MessageConverterUtils.javaObjectMimeType(javaType);
-		}
-		return MimeType.valueOf(type);
-	}
-
-	private Class<?> resolveJavaType(String type, Module module) throws ClassNotFoundException, LinkageError {
-		SimpleModule sm = (SimpleModule) module;
-		return ClassUtils.forName(type, sm.getApplicationContext().getClassLoader());
 	}
 
 	@Override
 	public boolean supports(Module module) {
-		return true;
+		return module.shouldBind();
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionSupport.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionSupport.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.plugins.stream;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.integration.channel.AbstractMessageChannel;
+import org.springframework.messaging.converter.CompositeMessageConverter;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.MimeType;
+import org.springframework.util.StringUtils;
+import org.springframework.xd.dirt.integration.bus.converter.CompositeMessageConverterFactory;
+import org.springframework.xd.dirt.integration.bus.converter.ConversionException;
+import org.springframework.xd.dirt.integration.bus.converter.MessageConverterUtils;
+import org.springframework.xd.dirt.plugins.ModuleConfigurationException;
+import org.springframework.xd.module.core.Module;
+import org.springframework.xd.module.core.SimpleModule;
+
+/**
+ * Support class that configures the message converters for the module input/output channel.
+ *
+ * @author David Turanski
+ * @author Ilayaperumal Gopinathan
+ */
+public class ModuleTypeConversionSupport {
+
+	private final static Log logger = LogFactory.getLog(ModuleTypeConversionSupport.class);
+
+	private final CompositeMessageConverterFactory converterFactory;
+
+	private static final String INPUT_TYPE = "inputType";
+
+	private static final String OUTPUT_TYPE = "outputType";
+
+	public ModuleTypeConversionSupport(CompositeMessageConverterFactory converterFactory) {
+		this.converterFactory = converterFactory;
+	}
+
+	/**
+	 * Return {@link org.springframework.util.MimeType} for the module's input channel.
+	 *
+	 * @param module the underlying module
+	 * @return MimeType for the module's input channel, null if not set
+	 */
+	public static MimeType getInputMimeType(Module module) {
+		String contentTypeString = module.getProperties().getProperty(INPUT_TYPE);
+		return getMimeType(contentTypeString, module);
+	}
+
+	/**
+	 * Return {@link org.springframework.util.MimeType} for the module's output channel.
+	 *
+	 * @param module the underlying module
+	 * @return MimeType for the module's output channel, null if not set
+	 */
+	public static MimeType getOutputMimeType(Module module) {
+		String contentTypeString = module.getProperties().getProperty(OUTPUT_TYPE);
+		return getMimeType(contentTypeString, module);
+	}
+
+	/**
+	 * Return {@link org.springframework.util.MimeType} for the given content type string.
+	 *
+	 * @param contentTypeString the content type string
+	 * @param module the underlying module
+	 * @return the MimeType for the content type string
+	 */
+	private static MimeType getMimeType(String contentTypeString, Module module) {
+		MimeType mimeType = null;
+		if (StringUtils.hasText(contentTypeString)) {
+			try {
+				mimeType = resolveContentType(contentTypeString, module);
+			}
+			catch (ClassNotFoundException cfe) {
+				throw new IllegalArgumentException("Could not find the class required for " + contentTypeString, cfe);
+			}
+		}
+		return mimeType;
+	}
+
+
+	/**
+	 * Configure message converters for the given module.
+	 *
+	 * @param module the underlying module
+	 * @param isInput boolean to specify if the message converter is for input/output channel
+	 */
+	protected void configureModuleMessageConverters(Module module, boolean isInput) {
+		MimeType contentType = null;
+		if (isInput) {
+			contentType = getInputMimeType(module);
+		}
+		else {
+			contentType = getOutputMimeType(module);
+		}
+		if (contentType != null) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("module " + (isInput ? "input" : "output") + "Type is " + contentType);
+			}
+			SimpleModule sm = (SimpleModule) module;
+			try {
+				AbstractMessageChannel channel = getChannel(module, isInput);
+				configureMessageConverters(channel, contentType, sm.getApplicationContext().getClassLoader());
+			}
+			catch (Exception e) {
+				throw new ModuleConfigurationException(e.getMessage(), e);
+			}
+		}
+	}
+
+	/**
+	 * Configure the message converters for the given message channel and content type.
+	 * Detect the data types from the provided class loader.
+	 *
+	 * @param channel the message channel to configure the message converters
+	 * @param contentType the content type to use
+	 * @param classLoader the classloader to search the dataType(s) classes
+	 */
+	public void configureMessageConverters(AbstractMessageChannel channel, MimeType contentType,
+			ClassLoader classLoader) {
+		CompositeMessageConverter converters = null;
+		try {
+			converters = converterFactory.newInstance(contentType);
+		}
+		catch (ConversionException e) {
+			throw new ModuleConfigurationException(e.getMessage() +
+					"(" +
+					channel.getComponentName() + "Type=" + contentType + ")");
+		}
+
+		Class<?> dataType = MessageConverterUtils.getJavaTypeForContentType(contentType, classLoader);
+		if (dataType == null) {
+			throw new ModuleConfigurationException("Content type is not supported for " +
+					channel.getComponentName() + "Type=" + contentType);
+		}
+		else {
+			channel.setDatatypes(dataType);
+			channel.setMessageConverter(converters);
+		}
+
+	}
+
+	// Workaround for when the channel is proxied and can't be cast directly to AbstractMessageChannel
+	private AbstractMessageChannel getChannel(Module module, boolean isInput) throws Exception {
+		String name = isInput ? "input" : "output";
+		Object channel = module.getComponent(name, Object.class);
+
+		if (AopUtils.isJdkDynamicProxy(channel)) {
+			return (AbstractMessageChannel) (((Advised) channel).getTargetSource().getTarget());
+		}
+
+		return (AbstractMessageChannel) channel;
+	}
+
+	/**
+	 * Resolve the {@link org.springframework.util.MimeType} to use for the given content type
+	 * specified for the module input/output.
+	 *
+	 * @param type the content type
+	 * @param module the underlying module
+	 * @return the MimeType
+	 * @throws ClassNotFoundException
+	 * @throws LinkageError
+	 */
+	public static MimeType resolveContentType(String type, Module module) throws ClassNotFoundException, LinkageError {
+		if (!type.contains("/")) {
+			Class<?> javaType = resolveJavaType(type, module);
+			return MessageConverterUtils.javaObjectMimeType(javaType);
+		}
+		return MimeType.valueOf(type);
+	}
+
+	private static Class<?> resolveJavaType(String type, Module module) throws ClassNotFoundException, LinkageError {
+		SimpleModule sm = (SimpleModule) module;
+		return ClassUtils.forName(type, sm.getApplicationContext().getClassLoader());
+	}
+}

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/module-type-conversion.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/module-type-conversion.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	<bean id="moduleTypeConversionPlugin" class="org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionPlugin">
+		<constructor-arg name="converters" ref="xd.messageConverters"/>
+		<constructor-arg name="customConverters" ref="customMessageConverters"/>
+	</bean>
+	
+	<util:list id="xd.messageConverters">
+			<bean class="org.springframework.xd.dirt.integration.bus.converter.JsonToTupleMessageConverter"/>
+			<bean class="org.springframework.xd.dirt.integration.bus.converter.JsonToPojoMessageConverter"/>
+			<bean class="org.springframework.xd.dirt.integration.bus.converter.TupleToJsonMessageConverter"/>
+			<bean class="org.springframework.xd.dirt.integration.bus.converter.PojoToJsonMessageConverter"/>
+			<bean class="org.springframework.xd.dirt.integration.bus.converter.ByteArrayToStringMessageConverter"/>
+			<bean class="org.springframework.xd.dirt.integration.bus.converter.StringToByteArrayMessageConverter"/>
+			<bean class="org.springframework.xd.dirt.integration.bus.converter.PojoToStringMessageConverter"/>
+			<bean class="org.springframework.xd.dirt.integration.bus.converter.JavaToSerializedMessageConverter"/>
+			<bean class="org.springframework.xd.dirt.integration.bus.converter.SerializedToJavaMessageConverter"/>
+	</util:list>
+
+	<!-- Users can override this to add converters.-->
+	<util:list id="customMessageConverters"/>
+
+</beans>

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/streams.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/streams.xml
@@ -8,24 +8,4 @@
 	<!-- TODO: This id required by TestMessageBusInjection -->
 	<bean id="streamPlugin" class="org.springframework.xd.dirt.plugins.stream.StreamPlugin"/>
 
-	<bean class="org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionPlugin">
-		<constructor-arg name="converters" ref="xd.messageConverters"/>
-		<constructor-arg name="customConverters" ref="customMessageConverters"/>
-	</bean>
-	
-	<util:list id="xd.messageConverters">
-			<bean class="org.springframework.xd.dirt.integration.bus.converter.JsonToTupleMessageConverter"/>
-			<bean class="org.springframework.xd.dirt.integration.bus.converter.JsonToPojoMessageConverter"/>
-			<bean class="org.springframework.xd.dirt.integration.bus.converter.TupleToJsonMessageConverter"/>
-			<bean class="org.springframework.xd.dirt.integration.bus.converter.PojoToJsonMessageConverter"/>
-			<bean class="org.springframework.xd.dirt.integration.bus.converter.ByteArrayToStringMessageConverter"/>
-			<bean class="org.springframework.xd.dirt.integration.bus.converter.StringToByteArrayMessageConverter"/>
-			<bean class="org.springframework.xd.dirt.integration.bus.converter.PojoToStringMessageConverter"/>
-			<bean class="org.springframework.xd.dirt.integration.bus.converter.JavaToSerializedMessageConverter"/>
-			<bean class="org.springframework.xd.dirt.integration.bus.converter.SerializedToJavaMessageConverter"/>
-	</util:list>
-
-	<!-- Users can override this to add converters.-->
-	<util:list id="customMessageConverters"/>
-
 </beans>

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/RabbitTransportSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/RabbitTransportSparkStreamingTests.java
@@ -19,7 +19,7 @@ package org.springframework.xd.spark.streaming;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -34,9 +34,9 @@ public class RabbitTransportSparkStreamingTests extends AbstractSparkStreamingTe
 	@ClassRule
 	public static RabbitTestSupport rabbitTestSupport = new RabbitTestSupport();
 
-	protected List<String> queueNames = new ArrayList<String>();
+	protected static final List<String> queueNames = new ArrayList<String>();
 
-	private final RabbitAdmin rabbitAdmin;
+	private static RabbitAdmin rabbitAdmin;
 
 	public RabbitTransportSparkStreamingTests() {
 		super("rabbit");
@@ -49,9 +49,9 @@ public class RabbitTransportSparkStreamingTests extends AbstractSparkStreamingTe
 		addQueueNames(streamName, stream);
 	}
 
-	@After
-	public void cleanupRabbitQueues() {
-		super.tearDown();
+
+	@AfterClass
+	public static void cleanupRabbitQueues() {
 		for (String queueName: queueNames) {
 			rabbitAdmin.deleteQueue(queueName);
 		}

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkMessageSender.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkMessageSender.java
@@ -18,21 +18,36 @@ package org.springframework.xd.spark.streaming;
 
 import java.io.Serializable;
 
-import org.springframework.integration.channel.DirectChannel;
+import org.springframework.messaging.Message;
 
 /**
- * Abstract serializable channel that sends Spark RDD items to the XD MessageBus.
+ * Abstract class that defines abstract methods to support sending the computed messages out of spark cluster
+ * to XD MessageBus etc.
  *
  * @author Ilayaperumal Gopinathan
  */
-public abstract class SparkMessageSender extends DirectChannel implements Serializable {
+public abstract class SparkMessageSender implements Serializable {
 
-	private static final long serialVersionUID = 1L;
-
+	/**
+	 * Start the message sender
+	 */
 	public abstract void start();
 
+	/**
+	 * Stop the message sender
+	 */
 	public abstract void stop();
 
+	/**
+	 * Check if the message sender is running
+	 * @return boolean true if the sender is running
+	 */
 	public abstract boolean isRunning();
+
+	/**
+	 * Send the messages out of spark cluster
+	 * @param message the message to send
+	 */
+	public abstract void send(Message message);
 
 }

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkMessageSender.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkMessageSender.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 import org.springframework.messaging.Message;
 
 /**
- * Abstract class that defines abstract methods to support sending the computed messages out of spark cluster
+ * Abstract class that defines abstract methods to support sending the computed messages out of Spark cluster
  * to XD MessageBus etc.
  *
  * @author Ilayaperumal Gopinathan
@@ -45,7 +45,8 @@ public abstract class SparkMessageSender implements Serializable {
 	public abstract boolean isRunning();
 
 	/**
-	 * Send the messages out of spark cluster
+	 * Send a message out of Spark cluster.
+	 *
 	 * @param message the message to send
 	 */
 	public abstract void send(Message message);

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/ModuleExecutor.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/ModuleExecutor.java
@@ -71,7 +71,7 @@ public class ModuleExecutor implements SparkStreamingModuleExecutor<JavaDStreamL
 									}
 								}
 								while (results.hasNext()) {
-									messageSender.send(MessageBuilder.withPayload(results.next().toString()).build());
+									messageSender.send(MessageBuilder.withPayload(results.next()).build());
 								}
 							}
 							sender.stop();

--- a/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
+++ b/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
@@ -56,7 +56,7 @@ class ModuleExecutor extends SparkStreamingModuleExecutor[ReceiverInputDStream[A
             }
           }
           if (partition.hasNext) {
-            messageSender.send(MessageBuilder.withPayload(partition.next().toString()).build())
+            messageSender.send(MessageBuilder.withPayload(partition.next()).build())
           }
         })
       })


### PR DESCRIPTION
  - Set beanName for MessageBusReceiver's message storing channel as "input"
  - Configure the corresponding message converters in MessageBusReceiver's `onStart`
so that the dataType and converters are set and created at spark executor
  - Set beanName for MessageBusSender as "output"
  - Configure message converters inside the MessageBusSender's `start` so that
the dataType and converters are set and created at spark executor
  - Refactored `ModuleTypeConversionPlugin` configurations and made some of the
methods static so that they can be accessed by MessageBusSender/Receiver
  - Add tests