### PR TITLE
[Sprint: 42] XD-2689 Make yarn.application.classpath configurable for Sqoop

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -248,10 +248,10 @@ endpoints:
 # Hadoop properties
 #spring:
 #  hadoop:
-#   fsUri: hdfs://localhost:8020
-#   resourceManagerHost: localhost
-#   resourceManagerPort: 8032
-
+#    fsUri: hdfs://localhost:8020
+#    resourceManagerHost: localhost
+#    resourceManagerPort: 8032
+#    yarnApplicationClasspath:
 ---
 # Zookeeper properties
 # namespace is the path under the root where XD's top level nodes will be created

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.sqoop.Sqoop;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -115,6 +116,11 @@ public class SqoopRunner {
 				configOptions.get(YarnConfiguration.RM_ADDRESS) != null) {
 			configuration.set(YarnConfiguration.RM_ADDRESS,
 					configOptions.get(YarnConfiguration.RM_ADDRESS));
+		}
+		if (configOptions.containsKey(YarnConfiguration.YARN_APPLICATION_CLASSPATH) &&
+				StringUtils.hasText(configOptions.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH))) {
+			configuration.set(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
+					configOptions.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH));
 		}
 		configuration.set("mapreduce.framework.name", "yarn");
 		return configuration;

--- a/modules/job/sqoop/config/sqoop.xml
+++ b/modules/job/sqoop/config/sqoop.xml
@@ -26,6 +26,7 @@
 				<value>jdbc.password=${password}</value>
 				<value>fs.defaultFS=${fsUri}</value>
 				<value>yarn.resourcemanager.address=${resourceManagerHost}:${resourceManagerPort}</value>
+				<value>yarn.application.classpath=${spring.hadoop.yarnApplicationClasspath}</value>
 			</list>
 		</property>
 	</bean>

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -57,6 +57,7 @@ spring:
     fsUri: hdfs://localhost:8020
     resourceManagerHost: localhost
     resourceManagerPort: 8032
+    yarnApplicationClasspath:
 
 endpoints:
   jolokia:


### PR DESCRIPTION
- this is necessary when the Hadoop cluster uses a classpath configuration that differs from the default Apache Hadoop config

- this could also be used by custom mapreduce modules etc.