### PR TITLE
[Sprint: 42] XD-2688 Adding Guava 14.0.1 as a dependency for Cloudera CDH5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ ext {
 	// Also in IO
 	nettyVersion = '3.7.0.Final' // N.B. Reactor depends on Netty 4
 	hadoopGuavaVersion = '11.0.2' // This is only used by the mini cluster in the spring-xd-batch-extension tests
+	cdh5GuavaVersion = '14.0.1' // This is only used by the CDH 5 module for the xd/lib/cdh5 classpath jars
 	oldGuavaVersion = '15.0'  // This is only used by spring-xd-integration-test, IO uses version 17.0
 	guavaVersion = '16.0.1'
 

--- a/config/servers.yml
+++ b/config/servers.yml
@@ -248,10 +248,10 @@ endpoints:
 # Hadoop properties
 #spring:
 #  hadoop:
-#   fsUri: hdfs://localhost:8020
-#   resourceManagerHost: localhost
-#   resourceManagerPort: 8032
-
+#    fsUri: hdfs://localhost:8020
+#    resourceManagerHost: localhost
+#    resourceManagerPort: 8032
+#    yarnApplicationClasspath:
 ---
 # Zookeeper properties
 # namespace is the path under the root where XD's top level nodes will be created

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.sqoop.Sqoop;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -115,6 +116,11 @@ public class SqoopRunner {
 				configOptions.get(YarnConfiguration.RM_ADDRESS) != null) {
 			configuration.set(YarnConfiguration.RM_ADDRESS,
 					configOptions.get(YarnConfiguration.RM_ADDRESS));
+		}
+		if (configOptions.containsKey(YarnConfiguration.YARN_APPLICATION_CLASSPATH) &&
+				StringUtils.hasText(configOptions.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH))) {
+			configuration.set(YarnConfiguration.YARN_APPLICATION_CLASSPATH,
+					configOptions.get(YarnConfiguration.YARN_APPLICATION_CLASSPATH));
 		}
 		configuration.set("mapreduce.framework.name", "yarn");
 		return configuration;

--- a/gradle/build-hadoop-distros.gradle
+++ b/gradle/build-hadoop-distros.gradle
@@ -110,6 +110,16 @@ project('spring-xd-hadoop:hadoop26') {
 
 project('spring-xd-hadoop:cdh5') {
 	description = 'Cloudera CDH 5 dependencies'
+	configurations.all {
+		resolutionStrategy {
+			eachDependency { DependencyResolveDetails details ->
+				//Force version of Guava
+				if (details.requested.group == 'com.google.guava') {
+					details.useVersion "$cdh5GuavaVersion"
+				}
+			}
+		}
+	}
 	dependencies {
 		runtime ("org.springframework.data:spring-data-hadoop:${springDataHadoopBase}-cdh5") {
 			exclude group: 'org.apache.hadoop'
@@ -139,6 +149,8 @@ project('spring-xd-hadoop:cdh5') {
 		include 'jetty-util-*'
 		include 'jersey-core-*'
 		include 'jersey-server-*'
+		// CDH5 needs an older Guava version (pre 15.0 - XD has 16.0.1)
+		include 'guava-*'
 		// Pig dependencies
 		include 'pig-*'
 		include 'automaton-*'

--- a/modules/job/sqoop/config/sqoop.xml
+++ b/modules/job/sqoop/config/sqoop.xml
@@ -26,6 +26,7 @@
 				<value>jdbc.password=${password}</value>
 				<value>fs.defaultFS=${fsUri}</value>
 				<value>yarn.resourcemanager.address=${resourceManagerHost}:${resourceManagerPort}</value>
+				<value>yarn.application.classpath=${spring.hadoop.yarnApplicationClasspath}</value>
 			</list>
 		</property>
 	</bean>

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -57,6 +57,7 @@ spring:
     fsUri: hdfs://localhost:8020
     resourceManagerHost: localhost
     resourceManagerPort: 8032
+    yarnApplicationClasspath:
 
 endpoints:
   jolokia:


### PR DESCRIPTION
- placing guava 14.0.1 in lib/cdh5 seems to override the 16.0.1 version we have on XD classpath

- haven't noticed any issues using this older version and it's the only way I could find to get YARN app submissions to work with CDH5

(depends on PR 1441)