### PR TITLE
[Sprint 42] XD-2698 Kafka tests use an external broker by default

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/ZookeeperClientConnectTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/ZookeeperClientConnectTests.java
@@ -81,7 +81,7 @@ public class ZookeeperClientConnectTests {
 	 */
 	@Test
 	public void testZooKeeperClientConnectString() {
-		String zkClientConnect = "localhost:2181,localhost:2182,localhost:2183";
+		String zkClientConnect = "localhost:3181,localhost:3182,localhost:3183";
 
 		setUp(zkClientConnect, null, true);
 

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/KafkaTransportSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/KafkaTransportSparkStreamingTests.java
@@ -16,10 +16,6 @@
 
 package org.springframework.xd.spark.streaming;
 
-import java.util.Properties;
-
-import kafka.utils.TestUtils;
-
 import org.junit.ClassRule;
 
 import org.springframework.xd.dirt.integration.bus.KafkaConnectionPropertyNames;
@@ -31,16 +27,11 @@ import org.springframework.xd.test.kafka.KafkaTestSupport;
 public class KafkaTransportSparkStreamingTests extends AbstractSparkStreamingTests {
 
 	@ClassRule
-	public static KafkaTestSupport kafkaTestSupport;
+	public static KafkaTestSupport kafkaTestSupport = new KafkaTestSupport();
 
 	static {
-		kafkaTestSupport = new KafkaTestSupport();
-		Properties brokerConfigProperties = TestUtils.createBrokerConfig(0, TestUtils.choosePort());
-		kafkaTestSupport.setBrokerConfig(brokerConfigProperties);
-		System.setProperty(KafkaConnectionPropertyNames.KAFKA_BROKERS,
-				brokerConfigProperties.getProperty("host.name") + ":" + brokerConfigProperties.getProperty("port"));
-		System.setProperty(KafkaConnectionPropertyNames.KAFKA_ZK_ADDRESS,
-				brokerConfigProperties.getProperty("zookeeper.connect"));
+		System.setProperty(KafkaConnectionPropertyNames.KAFKA_BROKERS, kafkaTestSupport.getBrokerAddress());
+		System.setProperty(KafkaConnectionPropertyNames.KAFKA_ZK_ADDRESS, kafkaTestSupport.getZkConnectString());
 	}
 
 	public KafkaTransportSparkStreamingTests() {

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/KafkaTransportSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/KafkaTransportSparkStreamingTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.xd.spark.streaming;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
 import org.springframework.xd.dirt.integration.bus.KafkaConnectionPropertyNames;
@@ -27,11 +29,34 @@ import org.springframework.xd.test.kafka.KafkaTestSupport;
 public class KafkaTransportSparkStreamingTests extends AbstractSparkStreamingTests {
 
 	@ClassRule
-	public static KafkaTestSupport kafkaTestSupport = new KafkaTestSupport();
+	public static final KafkaTestSupport kafkaTestSupport = new KafkaTestSupport();
 
-	static {
+	private static String originalKafkaBrokers = null;
+
+	private static String originalKafkaZkAddress = null;
+
+	@BeforeClass
+	public static void setUpClass() {
+		originalKafkaBrokers = System.getProperty(KafkaConnectionPropertyNames.KAFKA_BROKERS);
+		originalKafkaZkAddress = System.getProperty(KafkaConnectionPropertyNames.KAFKA_ZK_ADDRESS);
 		System.setProperty(KafkaConnectionPropertyNames.KAFKA_BROKERS, kafkaTestSupport.getBrokerAddress());
 		System.setProperty(KafkaConnectionPropertyNames.KAFKA_ZK_ADDRESS, kafkaTestSupport.getZkConnectString());
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		if (originalKafkaBrokers == null) {
+			System.clearProperty(KafkaConnectionPropertyNames.KAFKA_BROKERS);
+		}
+		else {
+			System.setProperty(KafkaConnectionPropertyNames.KAFKA_BROKERS, originalKafkaBrokers);
+		}
+		if (originalKafkaZkAddress == null) {
+			System.clearProperty(KafkaConnectionPropertyNames.KAFKA_ZK_ADDRESS);
+		}
+		else {
+			System.setProperty(KafkaConnectionPropertyNames.KAFKA_ZK_ADDRESS, originalKafkaZkAddress);
+		}
 	}
 
 	public KafkaTransportSparkStreamingTests() {

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
@@ -96,14 +96,9 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 	@Override
 	protected void obtainResource() throws Exception {
 		if (embedded) {
-			try {
-				log.debug("Starting Zookeeper");
-				zookeeper = new EmbeddedZookeeper(TestZKUtils.zookeeperConnect());
-				log.debug("Started Zookeeper at " + zookeeper.getConnectString());
-			}
-			catch (Exception e) {
-				throw new RuntimeException("Issues creating the ZK server", e);
-			}
+			log.debug("Starting Zookeeper");
+			zookeeper = new EmbeddedZookeeper(TestZKUtils.zookeeperConnect());
+			log.debug("Started Zookeeper at " + zookeeper.getConnectString());
 			try {
 				int zkConnectionTimeout = 6000;
 				int zkSessionTimeout = 6000;
@@ -111,7 +106,7 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 			}
 			catch (Exception e) {
 				zookeeper.shutdown();
-				throw new RuntimeException("Issues creating the ZK client", e);
+				throw e;
 			}
 			try {
 				log.debug("Creating Kafka server");
@@ -122,18 +117,13 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 			catch (Exception e) {
 				zookeeper.shutdown();
 				zkClient.close();
-				throw new RuntimeException("Issues creating the Kafka server", e);
+				throw e;
 			}
 		}
 		else {
-			try {
-				this.zkClient = new ZkClient(DEFAULT_ZOOKEEPER_CONNECT, 5000, 5000, ZKStringSerializer$.MODULE$);
-				if (ZkUtils.getAllBrokersInCluster(zkClient).size() == 0) {
-					throw new RuntimeException("Kafka server not available on localhost");
-				}
-			}
-			catch (Exception e) {
-				throw new RuntimeException("Issues connecting to ZK server");
+			this.zkClient = new ZkClient(DEFAULT_ZOOKEEPER_CONNECT, 5000, 5000, ZKStringSerializer$.MODULE$);
+			if (ZkUtils.getAllBrokersInCluster(zkClient).size() == 0) {
+				throw new RuntimeException("Kafka server not available");
 			}
 		}
 	}

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
@@ -17,9 +17,16 @@
 package org.springframework.xd.test.kafka;
 
 
+import java.util.Properties;
+
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
-import kafka.utils.*;
+import kafka.utils.SystemTime$;
+import kafka.utils.TestUtils;
+import kafka.utils.TestZKUtils;
+import kafka.utils.Utils;
+import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkInterruptedException;
 import org.apache.commons.logging.Log;
@@ -27,8 +34,6 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Rule;
 
 import org.springframework.xd.test.AbstractExternalResourceTestSupport;
-
-import java.util.Properties;
 
 /**
  * JUnit {@link Rule} that starts an embedded Kafka server (with an associated Zookeeper)
@@ -39,7 +44,15 @@ import java.util.Properties;
  */
 public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String> {
 
-	private Log log = LogFactory.getLog(KafkaTestSupport.class);
+	private static final Log log = LogFactory.getLog(KafkaTestSupport.class);
+
+	private static final String XD_KAFKA_TEST_EMBEDDED = "XD_KAFKA_TEST_EMBEDDED";
+
+	public static final boolean embedded;
+
+	private static final String DEFAULT_ZOOKEEPER_CONNECT = "localhost:2181";
+
+	private static final String DEFAULT_KAFKA_CONNECT = "localhost:9092";
 
 	private ZkClient zkClient;
 
@@ -49,81 +62,99 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 
 	private Properties brokerConfig = TestUtils.createBrokerConfig(0, TestUtils.choosePort());
 
+	static {
+		embedded = "true".equals(System.getProperty(XD_KAFKA_TEST_EMBEDDED));
+		log.info(String.format("Testing with %s Kafka broker", embedded ? "embedded" : "external"));
+	}
+
 	public KafkaTestSupport() {
 		super("KAFKA");
 	}
 
-	public void setBrokerConfig(Properties brokerConfig) {
-		this.brokerConfig = brokerConfig;
-	}
-
 	public String getZkConnectString() {
-		return zookeeper.getConnectString();
+		if (embedded) {
+			return zookeeper.getConnectString();
+		}
+		else {
+			return DEFAULT_ZOOKEEPER_CONNECT;
+		}
 	}
 
 	public ZkClient getZkClient() {
 		return this.zkClient;
 	}
 
-	public EmbeddedZookeeper getZookeeper() {
-		return zookeeper;
-	}
-
-	public KafkaServer getKafkaServer() {
-		return kafkaServer;
-	}
-
 	public String getBrokerAddress() {
-		return getKafkaServer().config().hostName() + ":" + getKafkaServer().config().port();
+		if (embedded) {
+			return kafkaServer.config().hostName() + ":" + kafkaServer.config().port();
+		}
+		else {
+			return DEFAULT_KAFKA_CONNECT;
+		}
 	}
 
 	@Override
 	protected void obtainResource() throws Exception {
-		try {
-			log.debug("Starting Zookeeper");
-			zookeeper = new EmbeddedZookeeper(TestZKUtils.zookeeperConnect());
-			log.debug("Started Zookeeper at " + zookeeper.getConnectString());
+		if (embedded) {
+			try {
+				log.debug("Starting Zookeeper");
+				zookeeper = new EmbeddedZookeeper(TestZKUtils.zookeeperConnect());
+				log.debug("Started Zookeeper at " + zookeeper.getConnectString());
+			}
+			catch (Exception e) {
+				throw new RuntimeException("Issues creating the ZK server", e);
+			}
+			try {
+				int zkConnectionTimeout = 6000;
+				int zkSessionTimeout = 6000;
+				zkClient = new ZkClient(getZkConnectString(), zkSessionTimeout, zkConnectionTimeout, ZKStringSerializer$.MODULE$);
+			}
+			catch (Exception e) {
+				zookeeper.shutdown();
+				throw new RuntimeException("Issues creating the ZK client", e);
+			}
+			try {
+				log.debug("Creating Kafka server");
+				Properties brokerConfigProperties = brokerConfig;
+				kafkaServer = TestUtils.createServer(new KafkaConfig(brokerConfigProperties), SystemTime$.MODULE$);
+				log.debug("Created Kafka server at " + kafkaServer.config().hostName() + ":" + kafkaServer.config().port());
+			}
+			catch (Exception e) {
+				zookeeper.shutdown();
+				zkClient.close();
+				throw new RuntimeException("Issues creating the Kafka server", e);
+			}
 		}
-		catch (Exception e) {
-			throw new RuntimeException("Issues creating the ZK server", e);
-		}
-		try {
-			int zkConnectionTimeout = 6000;
-			int zkSessionTimeout = 6000;
-			zkClient = new ZkClient(getZkConnectString(), zkSessionTimeout, zkConnectionTimeout, ZKStringSerializer$.MODULE$);
-		}
-		catch (Exception e) {
-			zookeeper.shutdown();
-			throw new RuntimeException("Issues creating the ZK client", e);
-		}
-		try {
-			log.debug("Creating Kafka server");
-			Properties brokerConfigProperties = brokerConfig;
-			kafkaServer = TestUtils.createServer(new KafkaConfig(brokerConfigProperties), SystemTime$.MODULE$);
-			log.debug("Created Kafka server at " + kafkaServer.config().hostName() + ":" + kafkaServer.config().port());
-		}
-		catch (Exception e) {
-			zookeeper.shutdown();
-			zkClient.close();
-			throw new RuntimeException("Issues creating the Kafka server", e);
+		else {
+			try {
+				this.zkClient = new ZkClient(DEFAULT_ZOOKEEPER_CONNECT, 5000, 5000, ZKStringSerializer$.MODULE$);
+				if (ZkUtils.getAllBrokersInCluster(zkClient).size() == 0) {
+					throw new RuntimeException("Kafka server not available on localhost");
+				}
+			}
+			catch (Exception e) {
+				throw new RuntimeException("Issues connecting to ZK server");
+			}
 		}
 	}
 
 	@Override
 	protected void cleanupResource() throws Exception {
-		try {
-			kafkaServer.shutdown();
-		}
-		catch (Exception e) {
-			// ignore errors on shutdown
-			log.error(e);
-		}
-		try {
-			Utils.rm(kafkaServer.config().logDirs());
-		}
-		catch (Exception e) {
-			// ignore errors on shutdown
-			log.error(e);
+		if (embedded) {
+			try {
+				kafkaServer.shutdown();
+			}
+			catch (Exception e) {
+				// ignore errors on shutdown
+				log.error(e);
+			}
+			try {
+				Utils.rm(kafkaServer.config().logDirs());
+			}
+			catch (Exception e) {
+				// ignore errors on shutdown
+				log.error(e);
+			}
 		}
 		try {
 			zkClient.close();
@@ -132,12 +163,14 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 			// ignore errors on shutdown
 			log.error(e);
 		}
-		try {
-			zookeeper.shutdown();
-		}
-		catch (Exception e) {
-			// ignore errors on shutdown
-			log.error(e);
+		if (embedded) {
+			try {
+				zookeeper.shutdown();
+			}
+			catch (Exception e) {
+				// ignore errors on shutdown
+				log.error(e);
+			}
 		}
 	}
 


### PR DESCRIPTION
- Make existing rule configurable, using the default Zookeeper settings;
- When running externalized, Kafka tests will not start if server is not available;
- allow the `XD_KAFKA_TEST_EMBEDDED=true` system property for enabling embedded tests, if necessary;
- ensure that other tests are not affected by the running ZK