### PR TITLE
[Sprint:42] XD-2697 Add additional config options for Sqoop job

### DIFF
--- a/config/xd-container-logger.properties
+++ b/config/xd-container-logger.properties
@@ -36,10 +36,11 @@ log4j.logger.org.apache.zookeeper.server.PrepRequestProcessor=WARN
 # This prevents the WARN level about a non-static, @Bean method in Spring Batch that is irrelevant
 log4j.logger.org.springframework.context.annotation.ConfigurationClassEnhancer=ERROR
 
-
-
 # This prevents boot LoggingApplicationListener logger's misleading warning message
 log4j.logger.org.springframework.boot.logging.LoggingApplicationListener=ERROR
 
 # This is for the throughput-sampler sink module
 log4j.logger.org.springframework.xd.integration.throughput=INFO
+
+# This prevents Hadoop configuration warnings
+log4j.logger.org.apache.hadoop.conf.Configuration=ERROR

--- a/config/xd-singlenode-logger.properties
+++ b/config/xd-singlenode-logger.properties
@@ -36,7 +36,6 @@ log4j.logger.org.apache.zookeeper.jmx.MBeanRegistry=ERROR
 # This prevents the WARN level about a non-static, @Bean method in Spring Batch that is irrelevant
 log4j.logger.org.springframework.context.annotation.ConfigurationClassEnhancer=ERROR
 
-
 # This prevents the "Error:KeeperErrorCode = NodeExists" INFO messages
 # logged by ZooKeeper when a parent node does not exist while
 # invoking Curator's creatingParentsIfNeeded node builder.
@@ -47,3 +46,6 @@ log4j.logger.org.springframework.boot.logging.LoggingApplicationListener=ERROR
 
 # This is for the throughput-sampler sink module
 log4j.logger.org.springframework.xd.integration.throughput=INFO
+
+# This prevents Hadoop configuration warnings
+log4j.logger.org.apache.hadoop.conf.Configuration=ERROR

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
@@ -18,9 +18,12 @@ package org.springframework.xd.sqoop;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.batch.step.tasklet.x.AbstractProcessBuilderTasklet;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -34,6 +37,8 @@ import java.util.List;
 public class SqoopTasklet extends AbstractProcessBuilderTasklet implements InitializingBean {
 
 	private static final String SQOOP_RUNNER_CLASS = "org.springframework.xd.sqoop.SqoopRunner";
+
+	private static final String SPRING_HADOOP_CONFIG_PREFIX = "spring.hadoop.config";
 
 	private String[] arguments;
 
@@ -57,6 +62,17 @@ public class SqoopTasklet extends AbstractProcessBuilderTasklet implements Initi
 		command.add("java");
 		command.add(SQOOP_RUNNER_CLASS);
 		command.addAll(Arrays.asList(arguments));
+		Iterator<PropertySource<?>> i = environment.getPropertySources().iterator();
+		while (i.hasNext()) {
+			PropertySource<?> p = i.next();
+			if (p instanceof EnumerablePropertySource) {
+				for (String name : ((EnumerablePropertySource)p).getPropertyNames()) {
+					if(name.startsWith(SPRING_HADOOP_CONFIG_PREFIX)) {
+						command.add(name + "=" + environment.getProperty(name));
+					}
+				}
+			}
+		}
 		return command;
 	}
 

--- a/extensions/spring-xd-extension-sqoop/src/main/resources/log4j.xml
+++ b/extensions/spring-xd-extension-sqoop/src/main/resources/log4j.xml
@@ -23,6 +23,11 @@
 		<level value="info" />
 	</logger>
 
+	<!-- Supress configuration warnings -->
+	<logger name="org.apache.hadoop.conf.Configuration">
+		<level value="error" />
+	</logger>
+
 	<!-- Root Logger -->
 	<root>
 		<priority value="info" />

--- a/modules/job/sqoop/config/sqoop.xml
+++ b/modules/job/sqoop/config/sqoop.xml
@@ -27,6 +27,7 @@
 				<value>fs.defaultFS=${fsUri}</value>
 				<value>yarn.resourcemanager.address=${resourceManagerHost}:${resourceManagerPort}</value>
 				<value>yarn.application.classpath=${spring.hadoop.yarnApplicationClasspath}</value>
+				<value>mapreduce.framework.name=yarn</value>
 			</list>
 		</property>
 	</bean>


### PR DESCRIPTION
- running against Hortonworks HDP 2.2 we need additional config options for job to run

- extra config options should be specified under spring.hadoop.config key like:

````
    spring:
      hadoop:
        config:
            mapreduce.application.framework.path: /hdp/apps/2.2.0.0-2041/mapreduce/mapreduce.tar.gz#mr-framework
            yarn.app.mapreduce.am.command-opts: '-Dhdp.version=2.2.0.0-2041'
            mapreduce.application.classpath: '$PWD/mr-framework/hadoop/share/hadoop/mapreduce/*:$PWD/mr-framework/hadoop/share/hadoop/mapreduce/lib/*:$PWD/mr-framework/hadoop/share/hadoop/common/*:$PWD/mr-framework/hadoop/share/hadoop/common/lib/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/*:$PWD/mr-framework/hadoop/share/hadoop/yarn/lib/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/*:$PWD/mr-framework/hadoop/share/hadoop/hdfs/lib/*:/etc/hadoop/conf/secure'
````

- also adding xd/config directory to classpath for Sqoop job so users can place yarn-site.xml config file in there if needed