### PR TITLE
Fix Definition Typos

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
@@ -141,7 +141,7 @@ public class RestControllerAdvice {
 	@ResponseBody
 	@ExceptionHandler
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public VndErrors onInvalidDefintion(StreamDefinitionException e) {
+	public VndErrors onInvalidDefinition(StreamDefinitionException e) {
 		String logref = logDebug(e);
 		return new VndErrors(logref, e.getMessage());
 	}

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/JobOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/JobOperations.java
@@ -38,7 +38,7 @@ public interface JobOperations extends ResourceOperations {
 	/**
 	 * Create a new Job, optionally deploying it.
 	 */
-	public JobDefinitionResource createJob(String name, String defintion, boolean deploy);
+	public JobDefinitionResource createJob(String name, String definition, boolean deploy);
 
 	/**
 	 * Launch a job that is already deployed.

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/StreamOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/StreamOperations.java
@@ -30,7 +30,7 @@ public interface StreamOperations extends ResourceOperations {
 	/**
 	 * Create a new Stream, optionally deploying it.
 	 */
-	public StreamDefinitionResource createStream(String name, String defintion, boolean deploy);
+	public StreamDefinitionResource createStream(String name, String definition, boolean deploy);
 
 	/**
 	 * List streams known to the system.

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/StreamTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/StreamTemplate.java
@@ -36,10 +36,10 @@ public class StreamTemplate extends AbstractTemplate implements StreamOperations
 	}
 
 	@Override
-	public StreamDefinitionResource createStream(String name, String defintion, boolean deploy) {
+	public StreamDefinitionResource createStream(String name, String definition, boolean deploy) {
 		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
 		values.add("name", name);
-		values.add("definition", defintion);
+		values.add("definition", definition);
 		values.add("deploy", Boolean.toString(deploy));
 
 		StreamDefinitionResource stream = restTemplate.postForObject(resources.get("streams/definitions").expand(),

--- a/spring-xd-ui/src/test/java/org/springframework/xd/dirt/web/SecurityConfigurationTests.java
+++ b/spring-xd-ui/src/test/java/org/springframework/xd/dirt/web/SecurityConfigurationTests.java
@@ -90,7 +90,7 @@ public class SecurityConfigurationTests {
 	public void testThatSecurityIsEnabled() throws Exception {
 		Assert.assertNotNull("'security.basic.enabled' property should not be null",
 				environment.getProperty("security.basic.enabled", Boolean.class));
-		Assert.assertTrue("Security should be anabled",
+		Assert.assertTrue("Security should be enabled",
 				environment.getProperty("security.basic.enabled", Boolean.class));
 	}
 


### PR DESCRIPTION
Previously there were 4 occurrences of the typo ‘defintion’ in the code,
including three that appear in documentation as parameter names. This
change corrects those errors. It does not correct the error in the
CONTRIBUTING.md file, as that is part of a reference to git history.