### PR TITLE
XD-2707 Check the payload type for Message

### DIFF
--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/ModuleExecutor.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/ModuleExecutor.java
@@ -25,6 +25,7 @@ import org.apache.spark.api.java.function.VoidFunction;
 import org.apache.spark.streaming.api.java.JavaDStreamLike;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.xd.spark.streaming.SparkMessageSender;
 import org.springframework.xd.spark.streaming.SparkStreamingModuleExecutor;
@@ -72,7 +73,10 @@ public class ModuleExecutor implements SparkStreamingModuleExecutor<JavaDStreamL
 									}
 								}
 								while (results.hasNext()) {
-									messageSender.send(MessageBuilder.withPayload(results.next()).build());
+									Object next = results.next();
+									Message message = (next instanceof Message) ? (Message) next :
+											MessageBuilder.withPayload(next).build();
+									messageSender.send(message);
 								}
 							}
 							sender.stop();

--- a/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
+++ b/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
@@ -18,6 +18,7 @@ package org.springframework.xd.spark.streaming.scala
 import org.apache.spark.streaming.dstream.{DStream, ReceiverInputDStream}
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.integration.support.MessageBuilder
+import org.springframework.messaging.Message
 import org.springframework.xd.spark.streaming.{SparkMessageSender, SparkStreamingModuleExecutor}
 
 /**
@@ -57,7 +58,13 @@ class ModuleExecutor extends SparkStreamingModuleExecutor[ReceiverInputDStream[A
             }
           }
           if (partition.hasNext) {
-            messageSender.send(MessageBuilder.withPayload(partition.next()).build())
+            var message = partition.next()
+            if (message.isInstanceOf[Message[_]]) {
+              messageSender.send(message.asInstanceOf[Message[_]])
+            }
+            else {
+              messageSender.send(MessageBuilder.withPayload(message).build())
+            }
           }
         })
       })

--- a/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
+++ b/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
@@ -58,7 +58,7 @@ class ModuleExecutor extends SparkStreamingModuleExecutor[ReceiverInputDStream[A
             }
           }
           if (partition.hasNext) {
-            var message = partition.next()
+            val message = partition.next()
             if (message.isInstanceOf[Message[_]]) {
               messageSender.send(message.asInstanceOf[Message[_]])
             }


### PR DESCRIPTION
 - When the spark streaming RDD items are iterated, add a check to see if the
item is of type spring `Message` before we proceed with building one.