### PR TITLE
Upgrade spark to 1.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ ext {
 	kafkaVersion = '0.8.1.1'
 	springShellVersion = '1.1.0.RELEASE'
 	zookeeperVersion = '3.4.6'
-	sparkVersion = '1.2.0'
+	sparkVersion = '1.2.1'
 	sparkScalaVersion = '2.10'
 	sqoopVersion = '1.4.5'
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
@@ -64,7 +64,8 @@ class MessageBusConfiguration {
 								new PropertiesPropertySource("executorEnvironment", properties));
 					}
 				})
-				.web(false);
+				.web(false)
+				.showBanner(false);
 		if (transport.equals("rabbit")) {
 			application.sources(RabbitAutoConfiguration.class);
 		}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
@@ -85,7 +85,6 @@ class MessageBusReceiver extends Receiver {
 		if (contentType != null) {
 			messageStoringChannel.configureMessageConverter(contentType);
 		}
-		MessageBus messageBus;
 		if (messageBusHolder != null) {
 			messageBus = messageBusHolder.get();
 		}
@@ -99,7 +98,9 @@ class MessageBusReceiver extends Receiver {
 	@Override
 	public void onStop() {
 		logger.info("stopping MessageBusReceiver");
-		messageBus.unbindConsumers(channelName);
+		if (messageBus != null) {
+			messageBus.unbindConsumers(channelName);
+		}
 		if (applicationContext != null) {
 			applicationContext.close();
 		}

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/FileLogger.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/FileLogger.java
@@ -26,18 +26,18 @@ import java.util.Properties;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.VoidFunction;
-import org.apache.spark.streaming.api.java.JavaDStreamLike;
+import org.apache.spark.streaming.api.java.JavaDStream;
 
-import org.springframework.xd.spark.streaming.java.Processor;
 import org.springframework.xd.spark.streaming.SparkConfig;
+import org.springframework.xd.spark.streaming.java.Processor;
 
 /**
  * @author Mark Fisher
  * @author Ilayaperumal Gopinathan
  * @since 1.1
  */
-@SuppressWarnings({ "unchecked", "rawtypes", "serial" })
-public class FileLogger implements Processor {
+@SuppressWarnings({ "serial" })
+public class FileLogger implements Processor<JavaDStream<String>, JavaDStream<String>> {
 
 	private File file;
 
@@ -61,15 +61,15 @@ public class FileLogger implements Processor {
 	}
 
 	@Override
-	public JavaDStreamLike process(JavaDStreamLike input) {
-		input.foreachRDD(new Function<JavaRDD, Void>() {
+	public JavaDStream<String> process(JavaDStream<String> input) {
+		input.foreachRDD(new Function<JavaRDD<String>, Void>() {
 
 			@Override
-			public Void call(JavaRDD rdd) {
-				rdd.foreachPartition(new VoidFunction<Iterator<?>>() {
+			public Void call(JavaRDD<String> rdd) {
+				rdd.foreachPartition(new VoidFunction<Iterator<String>>() {
 
 					@Override
-					public void call(Iterator<?> items) throws Exception {
+					public void call(Iterator<String> items) throws Exception {
 						FileWriter fw;
 						BufferedWriter bw = null;
 						try {

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/WordCount.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/WordCount.java
@@ -23,11 +23,10 @@ import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFunction;
 import org.apache.spark.streaming.api.java.JavaDStream;
-import org.apache.spark.streaming.api.java.JavaDStreamLike;
 import org.apache.spark.streaming.api.java.JavaPairDStream;
 
-import org.springframework.xd.spark.streaming.java.Processor;
 import org.springframework.xd.spark.streaming.SparkConfig;
+import org.springframework.xd.spark.streaming.java.Processor;
 
 import scala.Tuple2;
 
@@ -35,11 +34,11 @@ import scala.Tuple2;
  * @author Mark Fisher
  * @since 1.1
  */
-@SuppressWarnings({ "serial", "rawtypes", "unchecked" })
-public class WordCount implements Processor {
+@SuppressWarnings({ "serial" })
+public class WordCount implements Processor<JavaDStream<String>, JavaPairDStream<String, Integer>> {
 
 	@Override
-	public JavaDStreamLike process(JavaDStreamLike input) {
+	public JavaPairDStream<String, Integer> process(JavaDStream<String> input) {
 		JavaDStream<String> words = input.flatMap(new FlatMapFunction<String, String>() {
 
 			@Override

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/ModuleExecutor.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/ModuleExecutor.java
@@ -23,6 +23,7 @@ import org.apache.spark.api.java.JavaRDDLike;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.VoidFunction;
 import org.apache.spark.streaming.api.java.JavaDStreamLike;
+import org.apache.spark.streaming.api.java.JavaReceiverInputDStream;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.messaging.Message;
@@ -39,12 +40,12 @@ import org.springframework.xd.spark.streaming.SparkStreamingModuleExecutor;
  * @since 1.1
  */
 @SuppressWarnings({"unchecked", "rawtypes", "serial"})
-public class ModuleExecutor implements SparkStreamingModuleExecutor<JavaDStreamLike, Processor> , Serializable {
+public class ModuleExecutor implements SparkStreamingModuleExecutor<JavaReceiverInputDStream, Processor> , Serializable {
 
 	private static SparkMessageSender messageSender;
 
 	@SuppressWarnings("rawtypes")
-	public void execute(JavaDStreamLike input, Processor processor, final SparkMessageSender sender) {
+	public void execute(JavaReceiverInputDStream input, Processor processor, final SparkMessageSender sender) {
 		JavaDStreamLike output = processor.process(input);
 		if (output != null) {
 			output.foreachRDD(new Function<JavaRDDLike, Void>() {


### PR DESCRIPTION
 - Use `JavaStreamingContext` for both java/scala based streaming modules
 - Use 'JavaReceiverInputDStream` for java based module input
 - Use `ReceiverInputDStream` (obtained from javaInputDStream.receiverInputDStream())
   for scala based input
    - This makes sure to set the ClassTag set for streamContext