### PR TITLE
XD-2710 Kafka on-demand queue tests should not assume offset 0

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
@@ -115,7 +115,7 @@ public class RabbitSingleNodeStreamDeploymentIntegrationTests extends
 	}
 
 	@Override
-	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3) {
+	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3, Map<String, Object> initialTransportState) {
 		RabbitTemplate template = new RabbitTemplate(rabbitAvailableRule.getResource());
 		Object y = template.receiveAndConvert("xdbus.queue:y");
 		assertNotNull(y);

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RedisSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RedisSingleNodeStreamDeploymentIntegrationTests.java
@@ -16,6 +16,8 @@ package org.springframework.xd.dirt.stream;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Map;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -58,7 +60,7 @@ public class RedisSingleNodeStreamDeploymentIntegrationTests extends
 	}
 
 	@Override
-	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3) {
+	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3, Map<String, Object> initialTransportState) {
 		StringRedisTemplate template = new StringRedisTemplate(redisAvailableRule.getResource());
 		String y = template.boundListOps("queue.queue:y").rightPop();
 		assertNotNull(y);


### PR DESCRIPTION
- record initial offsets at the beginning of the tests - this ensures that the reading happens after the test has begun writing of the topics;
- this accounts for the case where the topic exists at the beginning of the test and already contains data (typical for CI environment)