### PR TITLE
ShellCommandProcessor handles quoted strings

### DIFF
--- a/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellCommandProcessor.java
+++ b/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellCommandProcessor.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -69,6 +68,8 @@ public class ShellCommandProcessor implements Lifecycle, InitializingBean {
 
 	private final static Log log = LogFactory.getLog(ShellCommandProcessor.class);
 
+    private final ShellWordsParser shellWordsParser = new ShellWordsParser();
+
 	private TaskExecutor taskExecutor = new SimpleAsyncTaskExecutor();
 
 	private final String command;
@@ -84,7 +85,7 @@ public class ShellCommandProcessor implements Lifecycle, InitializingBean {
 		Assert.hasLength(command, "A shell command is required");
 		Assert.notNull(serializer, "'serializer' cannot be null");
 		this.command = command;
-		List<String> commandPlusArgs = parse(command);
+		List<String> commandPlusArgs = this.shellWordsParser.parse(command);
 		Assert.notEmpty(commandPlusArgs, "The shell command is invalid: '" + command + "'");
 		this.serializer = serializer;
 		processBuilder = new ProcessBuilder(commandPlusArgs);
@@ -228,19 +229,6 @@ public class ShellCommandProcessor implements Lifecycle, InitializingBean {
 		if (!CollectionUtils.isEmpty(environment)) {
 			processBuilder.environment().putAll(environment);
 		}
-	}
-
-	/**
-	 * Handle extra white space between arguments
-	 */
-	private List<String> parse(String command) {
-		List<String> result = new ArrayList<String>();
-		for (String token : StringUtils.delimitedListToStringArray(command, " ")) {
-			if (token.trim().length() > 0) {
-				result.add(token);
-			}
-		}
-		return result;
 	}
 
 	/**

--- a/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellWordsParser.java
+++ b/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellWordsParser.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.extension.process;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses a string into a collection of words based on the
+ * <a href="http://pubs.opengroup.org/onlinepubs/009695399/toc.htm">POSIX / SUSv3 standard</a>.  The functionality in
+ * this class is ported from the Ruby
+ * <a href="https://github.com/rubysl/rubysl-shellwords/blob/2.0/lib/rubysl/shellwords/shellwords.rb">Shellwords</a>
+ * module.
+ */
+final class ShellWordsParser {
+
+    private static final Pattern SHELLWORDS = Pattern.compile("\\G\\s*(?>([^\\s\\\\'\"]+)|'([^']*)'|\"((?:[^\"\\\\]|\\\\.)*)\"|(\\\\.?)|(\\S))(\\s|\\z)?",
+            Pattern.MULTILINE);
+
+    /**
+     * Parses a string into a collection of words based on POSIX standard
+     *
+     * @param s the string to parse
+     * @return the collection of words
+     */
+    List<String> parse(String s) {
+        List<String> words = new ArrayList<>();
+        String field = "";
+
+        Matcher matcher = SHELLWORDS.matcher(s);
+        while (matcher.find()) {
+            String word = matcher.group(1);
+            String sq = matcher.group(2);
+            String dq = matcher.group(3);
+            String esc = matcher.group(4);
+            String garbage = matcher.group(5);
+            String sep = matcher.group(6);
+
+            if (garbage != null) {
+                throw new IllegalArgumentException("Unmatched double quote: " + s);
+            }
+
+            if (word != null) {
+                field = word;
+            } else if (sq != null) {
+                field = sq;
+            } else if (dq != null) {
+                field = dq.replaceAll("\\\\(?=.)", "");
+            } else if (esc != null) {
+                field = esc.replaceAll("\\\\(?=.)", "");
+            }
+
+            if (sep != null) {
+                words.add(field);
+                field = "";
+            }
+        }
+
+        return words;
+    }
+}

--- a/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/ShellCommandProcessorTests.java
+++ b/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/ShellCommandProcessorTests.java
@@ -70,6 +70,15 @@ public class ShellCommandProcessorTests {
 		latch.await();
 	}
 
+    @Test
+    public void quotedStringTest() throws Exception {
+        scp = new ShellCommandProcessor(serializer, "bash -c 'while read LINE ; do echo $LINE ; done'");
+        scp.afterPropertiesSet();
+        scp.start();
+
+        assertEquals("Test Message", scp.sendAndReceive("Test Message"));
+    }
+
 	static class ShellRunner implements Runnable {
 		private final String message;
 

--- a/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/ShellWordsParserTest.java
+++ b/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/ShellWordsParserTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.extension.process;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public final class ShellWordsParserTest {
+
+    private final ShellWordsParser parser = new ShellWordsParser();
+
+    @Test
+    public void honorsQuotedStrings() {
+        assertParse("a \"b b\" a",
+                "a", "b b", "a");
+    }
+
+    @Test
+    public void honorsEscapedDoubleQuotes() {
+        assertParse("a \"\\\"b\\\" c\" d",
+                "a", "\"b\" c", "d");
+    }
+
+    @Test
+    public void honorsEscapedSingleQuotes() {
+        assertParse("a \"'b' c\" d",
+                "a", "'b' c", "d");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsExceptionWhenDoubleQuotedStringsAreMisQuoted() {
+        this.parser.parse("a \"b c d e");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsExceptionWhenSingleQuotedStringsAreMisQuoted() {
+        this.parser.parse("a 'b c d e");
+    }
+
+    @Test
+    public void bashCommand() {
+        assertParse("bash -c 'while read LINE ; do echo $LINE ; done'",
+                "bash", "-c", "while read LINE ; do echo $LINE ; done");
+    }
+
+    private void assertParse(String s, String... words) {
+        assertEquals(Arrays.asList(words), this.parser.parse(s));
+    }
+
+}


### PR DESCRIPTION
Previously the `ShellCommandProcessor` did not handle quoted strings properly.  If you attempted to pass the string
```
bash -c 'while read LINE ; do echo $LINE ; done'
```

as a `--command`, the processor would naively parse the string into
```
bash
-c
'while
read
LINE
;
do
echo
$LINE
;
done'
```

when it should be parsed into

```
bash
-c
while read LINE ; do echo $LINE ; done
```

This change enhances the parsing algorithm to make it compatible with the [POSIX / SUSv3 standard][1].

[1]: http://pubs.opengroup.org/onlinepubs/009695399/toc.htm