### PR TITLE
[Sprint: 43] XD-2735 Make local messagebus props configurable

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -13,6 +13,9 @@
 #  transport: rabbit
 
 #  messagebus:
+#    local:
+#      queueSize:                   2147483647
+#      polling:                     1000
 #    rabbit:
 #      compressionLevel:            1
             # bus-level property, applies only when 'compress=true' for a stream module

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -93,6 +93,8 @@ xd:
   messageRateMonitoring:
     enabled: false
   messagebus:
+    local:
+      polling:                     1000
     rabbit:
       compressionLevel:            1
             # bus-level property, applies only when 'compress=true' for a stream module

--- a/spring-xd-messagebus-local/src/main/resources/META-INF/spring-xd/bus/local-bus.xml
+++ b/spring-xd-messagebus-local/src/main/resources/META-INF/spring-xd/bus/local-bus.xml
@@ -6,9 +6,9 @@
 
 	<bean id="messageBus" class="org.springframework.xd.dirt.integration.bus.local.LocalMessageBus">
 		<property name="queueSize"
-			value="${xd.local.transport.named.queueSize: #{T(Integer).MAX_VALUE}}" />
+			value="${xd.messagebus.local.queueSize: #{T(Integer).MAX_VALUE}}" />
 		<property name="poller">
-			<int:poller fixed-rate="${xd.local.transport.named.polling:1000}" />
+			<int:poller fixed-rate="${xd.messagebus.local.polling}" />
 		</property>
 	</bean>
 


### PR DESCRIPTION
 - Add property keys in servers.yml so that they can be configurable via servers.yml
 - Fix the prefix to align with other messagebus property keys.