### PR TITLE
Fix spring-xd-exec task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -379,12 +379,15 @@ project('spring-xd-dirt') {
 		compile "org.springframework.boot:spring-boot-actuator"
 		compile("org.springframework.boot:spring-boot-starter-security") {
 			exclude group: 'org.springframework.boot', module: "spring-boot-starter-logging"
+                        exclude module: 'log4j-over-slf4j'
 		}
 		compile("org.springframework.security:spring-security-ldap") {
 			exclude group: 'org.springframework', module: 'spring-beans'
 			exclude group: 'org.springframework', module: 'spring-core'
 		}
-		compile project(":spring-xd-ui")
+		compile(project(":spring-xd-ui")) {
+                        exclude module: 'log4j-over-slf4j'
+                }
 		compile("org.springframework.data:spring-data-redis") {
 			exclude group: 'org.springframework', module: 'spring-core'
 		}
@@ -592,7 +595,11 @@ project('spring-xd-exec') {
 		into('.') { from '../spring-xd-dirt/src/main/resources/log4j.properties' }
 		into('modules') { from '../modules' }
 		into('config') { from '../config' }
+                into('lib/messagebus') { from '../lib/messagebus' }
 	}
+        bootRepackage {
+                enabled = true
+        }
 	moduleProjects.each { moduleProject ->
 		project.jar.dependsOn moduleProject.copyLibs
 	}
@@ -983,6 +990,7 @@ project('spring-xd-messagebus-kafka') {
 	description = 'Spring XD MessageBus (Kafka implementation)'
 	dependencies {
 		compile project(':spring-xd-messagebus-spi')
+                compile "org.apache.zookeeper:zookeeper:$zookeeperVersion"
 		compile("org.springframework.integration:spring-integration-kafka:$springIntegrationKafkaVersion") {
 			exclude group: 'org.apache.velocity', module: 'velocity'
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -379,15 +379,15 @@ project('spring-xd-dirt') {
 		compile "org.springframework.boot:spring-boot-actuator"
 		compile("org.springframework.boot:spring-boot-starter-security") {
 			exclude group: 'org.springframework.boot', module: "spring-boot-starter-logging"
-                        exclude module: 'log4j-over-slf4j'
+			exclude module: 'log4j-over-slf4j'
 		}
 		compile("org.springframework.security:spring-security-ldap") {
 			exclude group: 'org.springframework', module: 'spring-beans'
 			exclude group: 'org.springframework', module: 'spring-core'
 		}
 		compile(project(":spring-xd-ui")) {
-                        exclude module: 'log4j-over-slf4j'
-                }
+			exclude module: 'log4j-over-slf4j'
+		}
 		compile("org.springframework.data:spring-data-redis") {
 			exclude group: 'org.springframework', module: 'spring-core'
 		}
@@ -595,11 +595,12 @@ project('spring-xd-exec') {
 		into('.') { from '../spring-xd-dirt/src/main/resources/log4j.properties' }
 		into('modules') { from '../modules' }
 		into('config') { from '../config' }
-                into('lib/messagebus') { from '../lib/messagebus' }
+		into('lib/messagebus') { from '../lib/messagebus' }
+		into('.') { from '../spring-xd-dirt/src/main/resources/application.yml'; filter { it ==~ /XD_HOME: .+/ ? it.replaceAll(/\.\./, /\./) : it }}
 	}
-        bootRepackage {
-                enabled = true
-        }
+	bootRepackage {
+		enabled = true
+	}
 	moduleProjects.each { moduleProject ->
 		project.jar.dependsOn moduleProject.copyLibs
 	}

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -68,7 +68,7 @@ endpoints:
 
 XD_ANALYTICS: ${analytics:redis}
 XD_TRANSPORT: ${xd.transport:${transport:redis}}
-XD_HOME: ${xdHomeDir:..}
+XD_HOME: ${xdHomeDir:.}
 XD_JMX_ENABLED: true
 
 xd:

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -68,7 +68,7 @@ endpoints:
 
 XD_ANALYTICS: ${analytics:redis}
 XD_TRANSPORT: ${xd.transport:${transport:redis}}
-XD_HOME: ${xdHomeDir:.}
+XD_HOME: ${xdHomeDir:..}
 XD_JMX_ENABLED: true
 
 xd:


### PR DESCRIPTION
The spring-xd-exec task was not doing what it was supposed to, so I've added the necessary code to fix it (for now - I imagine later releases may break it).

Also fixed up some issues with SLF4J complaining about both log4j-over-slf4j and slf4j-log4j12 being on the classpath, and Kafka using a different version of ZooKeeper to everything else.