### PR TITLE
[Sprint: 44] XD-2719: Add Rabbit Bus Cleanup REST Method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1088,6 +1088,7 @@ project('spring-xd-test') {
 		compile "org.springframework:spring-context"
 		compile "org.springframework:spring-context-support"
 		compile "org.springframework:spring-tx"
+		compile "org.springframework:spring-web"
 		compile "org.springframework:spring-test"
 		compile "org.springframework.data:spring-data-hadoop-test"
 		compile "redis.clients:jedis"

--- a/build.gradle
+++ b/build.gradle
@@ -377,6 +377,7 @@ project('spring-xd-dirt') {
 		compile "org.springframework.cloud:spring-cloud-cloudfoundry-connector"
 		compile "org.springframework.boot:spring-boot-autoconfigure"
 		compile "org.springframework.boot:spring-boot-actuator"
+		compile "org.springframework:spring-web"
 		compile("org.springframework.boot:spring-boot-starter-security") {
 			exclude group: 'org.springframework.boot', module: "spring-boot-starter-logging"
 		}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleaner.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleaner.java
@@ -17,6 +17,7 @@
 package org.springframework.xd.dirt.integration.bus;
 
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -30,8 +31,8 @@ public interface BusCleaner {
 	/**
 	 * Clean up all resources for the supplied stream.
 	 * @param stream The stream.
-	 * @return A list of resources removed.
+	 * @return A map of lists of resources removed.
 	 */
-	List<String> clean(String stream);
+	Map<String, List<String>> clean(String stream);
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleaner.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleaner.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus;
+
+import java.util.List;
+
+
+/**
+ * Interface for implementations that perform cleanup for message buses.
+ *
+ * @author Gary Russell
+ */
+public interface BusCleaner {
+
+	/**
+	 * Clean up all resources for the supplied stream.
+	 * @param stream The stream.
+	 * @return A list of resources removed.
+	 */
+	List<String> clean(String stream);
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleaner.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleaner.java
@@ -29,10 +29,11 @@ import java.util.Map;
 public interface BusCleaner {
 
 	/**
-	 * Clean up all resources for the supplied stream.
-	 * @param stream The stream.
-	 * @return A map of lists of resources removed.
+	 * Clean up all resources for the supplied stream/job.
+	 * @param entity the stream or job.
+	 * @param isJob true if the entity is a job.
+	 * @return a map of lists of resources removed.
 	 */
-	Map<String, List<String>> clean(String stream);
+	Map<String, List<String>> clean(String entity, boolean isJob);
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitAdminException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitAdminException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus;
+
+import org.springframework.xd.dirt.XDRuntimeException;
+
+
+/**
+ *
+ * @author Gary Russell
+ */
+public class RabbitAdminException extends XDRuntimeException {
+
+	public RabbitAdminException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public RabbitAdminException(String message) {
+		super(message);
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitBusCleaner.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitBusCleaner.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HttpContext;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+
+/**
+ *
+ * @author Gary Russell
+ */
+public class RabbitBusCleaner implements BusCleaner {
+
+	final static Log logger = LogFactory.getLog(RabbitBusCleaner.class);
+
+	@Override
+	public List<String> clean(String stream) {
+		return clean("http://localhost:15672", "guest", "guest", "/", "xdbus.", stream);
+	}
+
+	@SuppressWarnings("unchecked")
+	public List<String> clean(String adminUri, String user, String pw, String vhost,
+			String busPrefix, String stream) {
+		List<String> results = new ArrayList<>();
+		RestTemplate restTemplate = buildRestTemplate(adminUri, user, pw);
+		int n = 0;
+		while (true) {
+			String queueName = busPrefix + stream + "." + n++;
+			URI uri = UriComponentsBuilder.fromUriString(adminUri + "/api").pathSegment("queues", "{vhost}", "{stream}")
+					.buildAndExpand(vhost, queueName).encode().toUri();
+			try {
+				Map<String, Object> queue = restTemplate.getForObject(uri, Map.class);
+				if (queue.get("consumers") != Integer.valueOf(0)) {
+					throw new RabbitAdminException("Queue " + queueName + " is in use");
+				}
+				results.add(queueName);
+				queueName += ".dlq";
+				uri = UriComponentsBuilder.fromUriString(adminUri + "/api").pathSegment("queues", "{vhost}", "{stream}")
+						.buildAndExpand(vhost, queueName).encode().toUri();
+				try {
+					queue = restTemplate.getForObject(uri, Map.class);
+					if (queue.get("consumers") != Integer.valueOf(0)) {
+						throw new RabbitAdminException("Queue " + queueName + " is in use");
+					}
+					results.add(queueName);
+				}
+				catch (HttpClientErrorException e) {
+					if (e.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
+						continue; // DLQs are not mandatory
+					}
+					throw new RabbitAdminException("Failed to lookup queue", e);
+				}
+			}
+			catch (HttpClientErrorException e) {
+				if (e.getStatusCode().equals(HttpStatus.NOT_FOUND)) {
+					break; // No more for this stream
+				}
+				throw new RabbitAdminException("Failed to lookup queue", e);
+			}
+		}
+		for (String queueName : results) {
+			URI uri = UriComponentsBuilder.fromUriString(adminUri + "/api").pathSegment("queues", "{vhost}", "{stream}")
+					.buildAndExpand(vhost, queueName).encode().toUri();
+			restTemplate.delete(uri);
+			if (logger.isDebugEnabled()) {
+				logger.debug("deleted queue: " + queueName);
+			}
+		}
+		return results;
+	}
+
+	public static RestTemplate buildRestTemplate(String adminUri, String user, String password) {
+		BasicCredentialsProvider credsProvider = new BasicCredentialsProvider();
+		credsProvider.setCredentials(
+				new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT),
+				new UsernamePasswordCredentials(user, password));
+		HttpClient httpClient = HttpClients.custom().setDefaultCredentialsProvider(credsProvider).build();
+		// Set up pre-emptive basic Auth because the rabbit plugin doesn't currently support challenge/response for PUT
+		// Create AuthCache instance
+		AuthCache authCache = new BasicAuthCache();
+		// Generate BASIC scheme object and add it to the local; from the apache docs...
+		// auth cache
+		BasicScheme basicAuth = new BasicScheme();
+		URI uri;
+		try {
+			uri = new URI(adminUri);
+		}
+		catch (URISyntaxException e) {
+			throw new RabbitAdminException("Invalid URI", e);
+		}
+		authCache.put(new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()), basicAuth);
+		// Add AuthCache to the execution context
+		final HttpClientContext localContext = HttpClientContext.create();
+		localContext.setAuthCache(authCache);
+		RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient) {
+
+			@Override
+			protected HttpContext createHttpContext(HttpMethod httpMethod, URI uri) {
+				return localContext;
+			}
+
+		});
+		restTemplate.setMessageConverters(Collections.<HttpMessageConverter<?>> singletonList(
+				new MappingJackson2HttpMessageConverter()));
+		return restTemplate;
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/NothingToDeleteException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/NothingToDeleteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,19 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.bus;
-
-import java.util.List;
+package org.springframework.xd.dirt.integration.bus.rabbit;
 
 
 /**
- * Interface for implementations that perform cleanup for message buses.
+ * Thrown when a delete operation has nothing to delete.
  *
  * @author Gary Russell
  * @since 1.2
  */
-public interface BusCleaner {
+public class NothingToDeleteException extends RabbitAdminException {
 
-	/**
-	 * Clean up all resources for the supplied stream.
-	 * @param stream The stream.
-	 * @return A list of resources removed.
-	 */
-	List<String> clean(String stream);
+	public NothingToDeleteException(String message) {
+		super(message);
+	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/NothingToDeleteException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/NothingToDeleteException.java
@@ -23,6 +23,7 @@ package org.springframework.xd.dirt.integration.bus.rabbit;
  * @author Gary Russell
  * @since 1.2
  */
+@SuppressWarnings("serial")
 public class NothingToDeleteException extends RabbitAdminException {
 
 	public NothingToDeleteException(String message) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitAdminException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitAdminException.java
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.bus;
+package org.springframework.xd.dirt.integration.bus.rabbit;
 
 import org.springframework.xd.dirt.XDRuntimeException;
 
 
 /**
+ * Exceptions thrown while interfacing with the RabbitMQ admin plugin.
  *
  * @author Gary Russell
+ * @since 1.2
  */
 public class RabbitAdminException extends XDRuntimeException {
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitAdminException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitAdminException.java
@@ -25,6 +25,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Gary Russell
  * @since 1.2
  */
+@SuppressWarnings("serial")
 public class RabbitAdminException extends XDRuntimeException {
 
 	public RabbitAdminException(String message, Throwable cause) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/package-info.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Package for classes related to the RabbitMessageBus.
+ */
+
+package org.springframework.xd.dirt.integration.bus.rabbit;
+

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractJobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractJobPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.xd.module.core.Module;
  * job plugins.
  *
  * @author Ilayaperumal Gopinathan
+ * @author Gary Russell
  */
 public class AbstractJobPlugin extends AbstractMessageBusBinderPlugin {
 
@@ -33,9 +34,14 @@ public class AbstractJobPlugin extends AbstractMessageBusBinderPlugin {
 		super(messageBus);
 	}
 
+	public static String getJobChannelName(String jobName) {
+		return JOB_CHANNEL_PREFIX + jobName;
+	}
+
 	@Override
 	protected String getInputChannelName(Module module) {
-		return JOB_CHANNEL_PREFIX + module.getDescriptor().getGroup();
+		String group = module.getDescriptor().getGroup();
+		return getJobChannelName(group);
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.xd.module.core.Module;
  *
  * @author Ilayaperumal Gopinathan
  * @author Mark Fisher
+ * @author Gary Russell
  */
 public abstract class AbstractStreamPlugin extends AbstractMessageBusBinderPlugin {
 
@@ -41,18 +42,32 @@ public abstract class AbstractStreamPlugin extends AbstractMessageBusBinderPlugi
 		super(messageBus, zkConnection);
 	}
 
+	/**
+	 * Construct a pipe name from the group and index.
+	 * @param group the group.
+	 * @param index the index.
+	 * @return the name.
+	 */
+	public static String constructPipeName(String group, int index) {
+		return group + "." + index;
+	}
+
 	@Override
 	protected String getInputChannelName(Module module) {
 		ModuleDescriptor descriptor = module.getDescriptor();
 		String sourceChannel = descriptor.getSourceChannelName();
-		return (sourceChannel != null) ? sourceChannel : descriptor.getGroup() + "." + (descriptor.getIndex() - 1);
+		return (sourceChannel != null)
+				? sourceChannel
+				: constructPipeName(descriptor.getGroup(), descriptor.getIndex() - 1);
 	}
 
 	@Override
 	protected String getOutputChannelName(Module module) {
 		ModuleDescriptor descriptor = module.getDescriptor();
 		String sinkChannel = descriptor.getSinkChannelName();
-		return (sinkChannel != null) ? sinkChannel : descriptor.getGroup() + "." + descriptor.getIndex();
+		return (sinkChannel != null)
+				? sinkChannel
+				: constructPipeName(descriptor.getGroup(), descriptor.getIndex());
 	}
 
 	@Override
@@ -67,7 +82,7 @@ public abstract class AbstractStreamPlugin extends AbstractMessageBusBinderPlugi
 	@Override
 	public boolean supports(Module module) {
 		ModuleType moduleType = module.getType();
-		return (module.shouldBind() &&
-				(moduleType == ModuleType.source || moduleType == ModuleType.processor || moduleType == ModuleType.sink));
+		return (module.shouldBind() && (moduleType == ModuleType.source || moduleType == ModuleType.processor || moduleType == ModuleType.sink));
 	}
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
@@ -52,6 +52,10 @@ public abstract class AbstractStreamPlugin extends AbstractMessageBusBinderPlugi
 		return group + "." + index;
 	}
 
+	public static String constructTapPrefix(String group) {
+		return TAP_CHANNEL_PREFIX + "stream:" + group;
+	}
+
 	@Override
 	protected String getInputChannelName(Module module) {
 		ModuleDescriptor descriptor = module.getDescriptor();
@@ -75,7 +79,7 @@ public abstract class AbstractStreamPlugin extends AbstractMessageBusBinderPlugi
 		Assert.isTrue(module.getType() != ModuleType.job, "Job module type not supported.");
 		ModuleDescriptor descriptor = module.getDescriptor();
 		// for Stream return channel name with indexed elements
-		return String.format("%s%s%s.%s.%s", TAP_CHANNEL_PREFIX, "stream:", descriptor.getGroup(),
+		return String.format("%s.%s.%s", constructTapPrefix(descriptor.getGroup()),
 				module.getName(), descriptor.getIndex());
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobEventsListenerPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobEventsListenerPlugin.java
@@ -45,7 +45,7 @@ public class JobEventsListenerPlugin extends AbstractJobPlugin implements XDJobL
 	@Override
 	public void postProcessModule(Module module) {
 		boolean disableListeners = true;
-		Map<String, String> eventChannels = getEventListenerChannels(module);
+		Map<String, String> eventChannels = getEventListenerChannels(module.getDescriptor().getGroup());
 		for (Map.Entry<String, String> entry : eventChannels.entrySet()) {
 			MessageChannel eventChannel = module.getComponent(entry.getKey(), SubscribableChannel.class);
 			if (eventChannel != null) {
@@ -60,13 +60,12 @@ public class JobEventsListenerPlugin extends AbstractJobPlugin implements XDJobL
 	}
 
 	/**
-	 * @param module
+	 * @param jobName the job name.
 	 * @return the map containing the entries for the channels used by the job listeners with bean name of the channel
 	 *         as the key and channel name as the value.
 	 */
-	private Map<String, String> getEventListenerChannels(Module module) {
+	public static Map<String, String> getEventListenerChannels(String jobName) {
 		Map<String, String> eventListenerChannels = new HashMap<String, String>();
-		String jobName = module.getDescriptor().getGroup();
 		Assert.notNull(jobName, "Job name should not be null");
 		eventListenerChannels.put(XD_JOB_EXECUTION_EVENTS_CHANNEL,
 				getEventListenerChannelName(jobName, JOB_EXECUTION_EVENTS_SUFFIX));
@@ -79,11 +78,15 @@ public class JobEventsListenerPlugin extends AbstractJobPlugin implements XDJobL
 	}
 
 
-	private String getEventListenerChannelName(String jobName, String channelNameSuffix) {
+	private static String getEventListenerChannelName(String jobName, String channelNameSuffix) {
 		return String.format("%s%s.%s", JOB_TAP_CHANNEL_PREFIX, jobName, channelNameSuffix);
 	}
 
-	private String getEventListenerChannelName(String jobName) {
+	/**
+	 * @param jobName the job name.
+	 * @return the aggregated event channel name.
+	 */
+	public static String getEventListenerChannelName(String jobName) {
 		return String.format("%s%s", JOB_TAP_CHANNEL_PREFIX, jobName);
 	}
 
@@ -97,7 +100,7 @@ public class JobEventsListenerPlugin extends AbstractJobPlugin implements XDJobL
 
 	@Override
 	public void removeModule(Module module) {
-		Map<String, String> eventListenerChannels = getEventListenerChannels(module);
+		Map<String, String> eventListenerChannels = getEventListenerChannels(module.getDescriptor().getGroup());
 		for (Map.Entry<String, String> channelEntry : eventListenerChannels.entrySet()) {
 			messageBus.unbindProducers(channelEntry.getValue());
 		}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
@@ -18,6 +18,7 @@ package org.springframework.xd.dirt.rest;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +27,7 @@ import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -99,6 +101,18 @@ public class JobsController extends
 
 		return new PagedResources<JobDefinitionResource>(maskedContents, pagedResources.getMetadata(),
 				pagedResources.getLinks());
+	}
+
+	@ResponseBody
+	@RequestMapping(value = "/clean/rabbit/{job}", method = RequestMethod.DELETE)
+	@ResponseStatus(HttpStatus.OK)
+	public Map<String, List<String>> clean(@PathVariable String job,
+			@RequestParam(required = false) String adminUri,
+			@RequestParam(required = false) String user,
+			@RequestParam(required = false) String pw,
+			@RequestParam(required = false) String vhost,
+			@RequestParam(required = false) String busPrefix) {
+		return cleanRabbitBus(job, adminUri, user, pw, vhost, busPrefix, true);
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
@@ -31,6 +31,7 @@ import org.springframework.xd.dirt.analytics.NoSuchMetricException;
 import org.springframework.xd.dirt.cluster.ContainerShutdownException;
 import org.springframework.xd.dirt.cluster.ModuleMessageRateNotFoundException;
 import org.springframework.xd.dirt.cluster.NoSuchContainerException;
+import org.springframework.xd.dirt.integration.bus.rabbit.NothingToDeleteException;
 import org.springframework.xd.dirt.job.BatchJobAlreadyExistsException;
 import org.springframework.xd.dirt.job.JobExecutionAlreadyRunningException;
 import org.springframework.xd.dirt.job.JobExecutionNotRunningException;
@@ -298,6 +299,14 @@ public class RestControllerAdvice {
 	@ExceptionHandler
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	public VndErrors onNoSuchPageException(PageNotFoundException e) {
+		String logref = logDebug(e);
+		return new VndErrors(logref, e.getMessage());
+	}
+
+	@ResponseBody
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public VndErrors onNothingToDeleteException(NothingToDeleteException e) {
 		String logref = logDebug(e);
 		return new VndErrors(logref, e.getMessage());
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
@@ -32,6 +32,7 @@ import org.springframework.xd.dirt.cluster.ContainerShutdownException;
 import org.springframework.xd.dirt.cluster.ModuleMessageRateNotFoundException;
 import org.springframework.xd.dirt.cluster.NoSuchContainerException;
 import org.springframework.xd.dirt.integration.bus.rabbit.NothingToDeleteException;
+import org.springframework.xd.dirt.integration.bus.rabbit.RabbitAdminException;
 import org.springframework.xd.dirt.job.BatchJobAlreadyExistsException;
 import org.springframework.xd.dirt.job.JobExecutionAlreadyRunningException;
 import org.springframework.xd.dirt.job.JobExecutionNotRunningException;
@@ -307,6 +308,14 @@ public class RestControllerAdvice {
 	@ExceptionHandler
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public VndErrors onNothingToDeleteException(NothingToDeleteException e) {
+		String logref = logDebug(e);
+		return new VndErrors(logref, e.getMessage());
+	}
+
+	@ResponseBody
+	@ExceptionHandler
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public VndErrors onRabbitAdminException(RabbitAdminException e) {
 		String logref = logDebug(e);
 		return new VndErrors(logref, e.getMessage());
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
@@ -25,14 +25,14 @@ import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
-import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.xd.dirt.integration.bus.RabbitBusCleaner;
+import org.springframework.xd.dirt.integration.bus.rabbit.NothingToDeleteException;
+import org.springframework.xd.dirt.integration.bus.rabbit.RabbitBusCleaner;
 import org.springframework.xd.dirt.stream.StreamDefinition;
 import org.springframework.xd.dirt.stream.StreamDefinitionRepository;
 import org.springframework.xd.dirt.stream.StreamDeployer;
@@ -44,6 +44,7 @@ import org.springframework.xd.rest.domain.StreamDefinitionResource;
  * @author Eric Bottard
  * @author Gunnar Hillert
  * @author David Turanski
+ * @author Gary Russell
  *
  * @since 1.0
  */
@@ -77,23 +78,17 @@ public class StreamsController extends
 	}
 
 	@ResponseBody
-	@RequestMapping(value = "/clean/{transport}/{stream}")
+	@RequestMapping(value = "/clean/rabbit/{stream}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
-	public List<String> clean(@PathVariable String transport, @PathVariable String stream,
+	public List<String> clean(@PathVariable String stream,
 			@RequestParam(required = false) String adminUri,
 			@RequestParam(required = false) String user,
 			@RequestParam(required = false) String pw,
 			@RequestParam(required = false) String vhost,
 			@RequestParam(required = false) String busPrefix) {
-		Assert.isTrue("rabbit".equals(transport), "Only rabbit transports can be cleaned");
-		String adminUri2 = adminUri == null ? "http://localhost:15672" : adminUri;
-		String user2 = user == null ? "guest" : user;
-		String pw2 = pw == null ? "guest" : pw;
-		String vhost2 = vhost == null ? "/" : vhost;
-		String busPrefix2 = busPrefix == null ? "xdbus." : busPrefix;
-		List<String> results = busCleaner.clean(adminUri2, user2, pw2, vhost2, busPrefix2, stream);
-		if (results.size() == 0) {
-			results.add("No queues named " + busPrefix2 + stream + ".* found");
+		List<String> results = busCleaner.clean(adminUri, user, pw, vhost, busPrefix, stream);
+		if (results == null || results.size() == 0) {
+			throw new NothingToDeleteException("Nothing to delete for stream " + stream);
 		}
 		return results;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.xd.dirt.integration.bus.rabbit.NothingToDeleteException;
-import org.springframework.xd.dirt.integration.bus.rabbit.RabbitBusCleaner;
 import org.springframework.xd.dirt.stream.StreamDefinition;
 import org.springframework.xd.dirt.stream.StreamDefinitionRepository;
 import org.springframework.xd.dirt.stream.StreamDeployer;
@@ -54,8 +52,6 @@ import org.springframework.xd.rest.domain.StreamDefinitionResource;
 @ExposesResourceFor(StreamDefinitionResource.class)
 public class StreamsController extends
 		XDController<StreamDefinition, StreamDefinitionResourceAssembler, StreamDefinitionResource> {
-
-	private final RabbitBusCleaner busCleaner = new RabbitBusCleaner();
 
 	@Autowired
 	public StreamsController(StreamDeployer streamDeployer, StreamDefinitionRepository streamDefinitionRepository) {
@@ -87,11 +83,7 @@ public class StreamsController extends
 			@RequestParam(required = false) String pw,
 			@RequestParam(required = false) String vhost,
 			@RequestParam(required = false) String busPrefix) {
-		Map<String, List<String>> results = busCleaner.clean(adminUri, user, pw, vhost, busPrefix, stream);
-		if (results == null || results.size() == 0) {
-			throw new NothingToDeleteException("Nothing to delete for stream " + stream);
-		}
-		return results;
+		return cleanRabbitBus(stream, adminUri, user, pw, vhost, busPrefix, false);
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
@@ -16,6 +16,8 @@
 
 package org.springframework.xd.dirt.rest;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
@@ -23,10 +25,14 @@ import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.util.Assert;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.xd.dirt.integration.bus.RabbitBusCleaner;
 import org.springframework.xd.dirt.stream.StreamDefinition;
 import org.springframework.xd.dirt.stream.StreamDefinitionRepository;
 import org.springframework.xd.dirt.stream.StreamDeployer;
@@ -34,11 +40,11 @@ import org.springframework.xd.rest.domain.StreamDefinitionResource;
 
 /**
  * Handles all Stream related interaction.
- * 
+ *
  * @author Eric Bottard
  * @author Gunnar Hillert
  * @author David Turanski
- * 
+ *
  * @since 1.0
  */
 @Controller
@@ -46,6 +52,8 @@ import org.springframework.xd.rest.domain.StreamDefinitionResource;
 @ExposesResourceFor(StreamDefinitionResource.class)
 public class StreamsController extends
 		XDController<StreamDefinition, StreamDefinitionResourceAssembler, StreamDefinitionResource> {
+
+	private final RabbitBusCleaner busCleaner = new RabbitBusCleaner();
 
 	@Autowired
 	public StreamsController(StreamDeployer streamDeployer, StreamDefinitionRepository streamDefinitionRepository) {
@@ -67,4 +75,27 @@ public class StreamsController extends
 	protected StreamDefinition createDefinition(String name, String definition) {
 		return new StreamDefinition(name, definition);
 	}
+
+	@ResponseBody
+	@RequestMapping(value = "/clean/{transport}/{stream}")
+	@ResponseStatus(HttpStatus.OK)
+	public List<String> clean(@PathVariable String transport, @PathVariable String stream,
+			@RequestParam(required = false) String adminUri,
+			@RequestParam(required = false) String user,
+			@RequestParam(required = false) String pw,
+			@RequestParam(required = false) String vhost,
+			@RequestParam(required = false) String busPrefix) {
+		Assert.isTrue("rabbit".equals(transport), "Only rabbit transports can be cleaned");
+		String adminUri2 = adminUri == null ? "http://localhost:15672" : adminUri;
+		String user2 = user == null ? "guest" : user;
+		String pw2 = pw == null ? "guest" : pw;
+		String vhost2 = vhost == null ? "/" : vhost;
+		String busPrefix2 = busPrefix == null ? "xdbus." : busPrefix;
+		List<String> results = busCleaner.clean(adminUri2, user2, pw2, vhost2, busPrefix2, stream);
+		if (results.size() == 0) {
+			results.add("No queues named " + busPrefix2 + stream + ".* found");
+		}
+		return results;
+	}
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
@@ -17,6 +17,7 @@
 package org.springframework.xd.dirt.rest;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -80,13 +81,13 @@ public class StreamsController extends
 	@ResponseBody
 	@RequestMapping(value = "/clean/rabbit/{stream}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
-	public List<String> clean(@PathVariable String stream,
+	public Map<String, List<String>> clean(@PathVariable String stream,
 			@RequestParam(required = false) String adminUri,
 			@RequestParam(required = false) String user,
 			@RequestParam(required = false) String pw,
 			@RequestParam(required = false) String vhost,
 			@RequestParam(required = false) String busPrefix) {
-		List<String> results = busCleaner.clean(adminUri, user, pw, vhost, busPrefix, stream);
+		Map<String, List<String>> results = busCleaner.clean(adminUri, user, pw, vhost, busPrefix, stream);
 		if (results == null || results.size() == 0) {
 			throw new NothingToDeleteException("Nothing to delete for stream " + stream);
 		}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.kafka;
+package org.springframework.xd.dirt.integration.bus.kafka;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
@@ -27,6 +27,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import kafka.api.OffsetRequest;
+
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,6 +41,7 @@ import org.springframework.messaging.Message;
 import org.springframework.xd.dirt.integration.bus.EmbeddedHeadersMessageConverter;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.PartitionCapableBusTests;
+import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
 import org.springframework.xd.test.kafka.KafkaTestSupport;
 
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.kafka;
+package org.springframework.xd.dirt.integration.bus.kafka;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,6 +27,8 @@ import org.springframework.xd.dirt.integration.bus.serializer.CompositeCodec;
 import org.springframework.xd.dirt.integration.bus.serializer.MultiTypeCodec;
 import org.springframework.xd.dirt.integration.bus.serializer.kryo.PojoCodec;
 import org.springframework.xd.dirt.integration.bus.serializer.kryo.TupleCodec;
+import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
+import org.springframework.xd.dirt.integration.kafka.TestKafkaCluster;
 import org.springframework.xd.test.kafka.KafkaTestSupport;
 import org.springframework.xd.tuple.Tuple;
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitMessageBusTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.rabbit;
+package org.springframework.xd.dirt.integration.bus.rabbit;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -69,7 +69,6 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.xd.dirt.integration.bus.Binding;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.PartitionCapableBusTests;
-import org.springframework.xd.dirt.integration.bus.RabbitTestMessageBus;
 import org.springframework.xd.test.rabbit.RabbitTestSupport;
 
 /**

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitTestMessageBus.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.bus;
+package org.springframework.xd.dirt.integration.bus.rabbit;
 
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.xd.dirt.integration.bus.AbstractTestMessageBus;
 import org.springframework.xd.dirt.integration.bus.serializer.MultiTypeCodec;
 import org.springframework.xd.dirt.integration.rabbit.RabbitMessageBus;
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.redis;
+package org.springframework.xd.dirt.integration.bus.redis;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -51,7 +51,7 @@ import org.springframework.xd.dirt.integration.bus.Binding;
 import org.springframework.xd.dirt.integration.bus.EmbeddedHeadersMessageConverter;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.PartitionCapableBusTests;
-import org.springframework.xd.dirt.integration.bus.RedisTestMessageBus;
+import org.springframework.xd.dirt.integration.redis.RedisMessageBus;
 import org.springframework.xd.test.redis.RedisTestSupport;
 
 /**

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisTestMessageBus.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.xd.dirt.integration.bus;
+package org.springframework.xd.dirt.integration.bus.redis;
 
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -24,6 +24,7 @@ import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.xd.dirt.integration.bus.AbstractTestMessageBus;
 import org.springframework.xd.dirt.integration.bus.serializer.MultiTypeCodec;
 import org.springframework.xd.dirt.integration.redis.RedisMessageBus;
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/TestKafkaCluster.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/TestKafkaCluster.java
@@ -23,6 +23,7 @@ import kafka.javaapi.consumer.ConsumerConnector;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServerStartable;
 import kafka.utils.TestUtils;
+
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -34,6 +35,7 @@ import org.apache.curator.test.TestingServer;
 
 import org.springframework.util.Assert;
 import org.springframework.util.SocketUtils;
+import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/RabbitJobPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/RabbitJobPluginTests.java
@@ -26,7 +26,7 @@ import org.junit.Rule;
 
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
-import org.springframework.xd.dirt.integration.bus.RabbitTestMessageBus;
+import org.springframework.xd.dirt.integration.bus.rabbit.RabbitTestMessageBus;
 import org.springframework.xd.dirt.integration.bus.serializer.AbstractCodec;
 import org.springframework.xd.dirt.integration.bus.serializer.CompositeCodec;
 import org.springframework.xd.dirt.integration.bus.serializer.MultiTypeCodec;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/RedisJobPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/RedisJobPluginTests.java
@@ -27,7 +27,7 @@ import org.junit.Rule;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
-import org.springframework.xd.dirt.integration.bus.RedisTestMessageBus;
+import org.springframework.xd.dirt.integration.bus.redis.RedisTestMessageBus;
 import org.springframework.xd.dirt.integration.bus.serializer.AbstractCodec;
 import org.springframework.xd.dirt.integration.bus.serializer.CompositeCodec;
 import org.springframework.xd.dirt.integration.bus.serializer.MultiTypeCodec;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import kafka.api.OffsetRequest;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -42,8 +43,8 @@ import org.springframework.integration.kafka.serializer.common.StringDecoder;
 import org.springframework.integration.kafka.support.ZookeeperConnect;
 import org.springframework.integration.kafka.util.MessageUtils;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.xd.dirt.integration.bus.kafka.KafkaTestMessageBus;
 import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
-import org.springframework.xd.dirt.integration.kafka.KafkaTestMessageBus;
 import org.springframework.xd.test.kafka.KafkaTestSupport;
 
 /**

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
@@ -33,7 +33,7 @@ import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.xd.dirt.integration.bus.Binding;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
-import org.springframework.xd.dirt.integration.bus.RabbitTestMessageBus;
+import org.springframework.xd.dirt.integration.bus.rabbit.RabbitTestMessageBus;
 import org.springframework.xd.dirt.test.sink.NamedChannelSink;
 import org.springframework.xd.dirt.test.sink.SingleNodeNamedChannelSinkFactory;
 import org.springframework.xd.dirt.test.source.NamedChannelSource;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RedisSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RedisSingleNodeStreamDeploymentIntegrationTests.java
@@ -25,7 +25,7 @@ import org.junit.rules.ExternalResource;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.xd.dirt.integration.bus.RedisTestMessageBus;
+import org.springframework.xd.dirt.integration.bus.redis.RedisTestMessageBus;
 import org.springframework.xd.test.redis.RedisTestSupport;
 
 /**

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -364,7 +364,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 			validateConsumerProperties(name, properties, SUPPORTED_CONSUMER_PROPERTIES);
 		}
 		RabbitPropertiesAccessor accessor = new RabbitPropertiesAccessor(properties);
-		String queueName = constructPipeName(accessor.getPrefix(this.defaultPrefix), name);
+		String queueName = applyPrefix(accessor.getPrefix(this.defaultPrefix), name);
 		int partitionIndex = accessor.getPartitionIndex();
 		if (partitionIndex >= 0) {
 			queueName += "-" + partitionIndex;
@@ -384,7 +384,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		RabbitPropertiesAccessor accessor = new RabbitPropertiesAccessor(properties);
 		validateConsumerProperties(name, properties, SUPPORTED_PUBSUB_CONSUMER_PROPERTIES);
 		String prefix = accessor.getPrefix(this.defaultPrefix);
-		FanoutExchange exchange = new FanoutExchange(prefix + "topic." + name);
+		FanoutExchange exchange = new FanoutExchange(applyPrefix(prefix, applyPubSub(name)));
 		declareExchangeIfNotPresent(exchange);
 		String uniqueName = name + "." + UUID.randomUUID().toString();
 		Queue queue = new Queue(prefix + uniqueName, false, true, true);
@@ -489,7 +489,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 
 	private AmqpOutboundEndpoint buildOutboundEndpoint(final String name, RabbitPropertiesAccessor properties,
 			RabbitTemplate rabbitTemplate) {
-		String queueName = constructPipeName(properties.getPrefix(this.defaultPrefix), name);
+		String queueName = applyPrefix(properties.getPrefix(this.defaultPrefix), name);
 		String partitionKeyExtractorClass = properties.getPartitionKeyExtractorClass();
 		Expression partitionKeyExpression = properties.getPartitionKeyExpression();
 		AmqpOutboundEndpoint queue = new AmqpOutboundEndpoint(rabbitTemplate);
@@ -522,7 +522,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 			Properties properties) {
 		validateProducerProperties(name, properties, SUPPORTED_PUBSUB_PRODUCER_PROPERTIES);
 		RabbitPropertiesAccessor accessor = new RabbitPropertiesAccessor(properties);
-		String exchangeName = accessor.getPrefix(this.defaultPrefix) + "topic." + name;
+		String exchangeName = applyPrefix(accessor.getPrefix(this.defaultPrefix), applyPubSub(name));
 		declareExchangeIfNotPresent(new FanoutExchange(exchangeName));
 		AmqpOutboundEndpoint fanout = new AmqpOutboundEndpoint(determineRabbitTemplate(accessor));
 		fanout.setExchangeName(exchangeName);
@@ -657,7 +657,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 	private void autoBindDLQ(final String name, RabbitPropertiesAccessor properties) {
 		if (properties.getAutoBindDLQ(this.defaultAutoBindDLQ)) {
 			String prefix = properties.getPrefix(this.defaultPrefix);
-			String queueName = constructPipeName(prefix, name);
+			String queueName = applyPrefix(prefix, name);
 			String dlqName = constructDLQName(queueName);
 			Queue dlq = new Queue(dlqName);
 			declareQueueIfNotPresent(dlq);

--- a/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -156,8 +156,10 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 				parser.parseExpression("headers['" + ERROR_HEADER + "']"), connectionFactory);
 		if (headersToMap != null && headersToMap.length > 0) {
 			String[] combinedHeadersToMap =
-					Arrays.copyOfRange(XdHeaders.STANDARD_HEADERS, 0, XdHeaders.STANDARD_HEADERS.length + headersToMap.length);
-			System.arraycopy(headersToMap, 0, combinedHeadersToMap, XdHeaders.STANDARD_HEADERS.length, headersToMap.length);
+					Arrays.copyOfRange(XdHeaders.STANDARD_HEADERS, 0, XdHeaders.STANDARD_HEADERS.length
+							+ headersToMap.length);
+			System.arraycopy(headersToMap, 0, combinedHeadersToMap, XdHeaders.STANDARD_HEADERS.length,
+					headersToMap.length);
 			this.headersToMap = combinedHeadersToMap;
 		}
 		else {
@@ -217,7 +219,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		RedisInboundChannelAdapter adapter = new RedisInboundChannelAdapter(this.connectionFactory);
 		adapter.setBeanFactory(this.getBeanFactory());
 		adapter.setSerializer(null);
-		adapter.setTopics("topic." + name);
+		adapter.setTopics(applyPubSub(name));
 		doRegisterConsumer(name, name, moduleInputChannel, adapter, new RedisPropertiesAccessor(properties));
 	}
 
@@ -333,7 +335,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		validateProducerProperties(name, properties, SUPPORTED_PUBSUB_PRODUCER_PROPERTIES);
 		RedisPublishingMessageHandler topic = new RedisPublishingMessageHandler(connectionFactory);
 		topic.setBeanFactory(this.getBeanFactory());
-		topic.setTopic("topic." + name);
+		topic.setTopic(applyPubSub(name));
 		topic.afterPropertiesSet();
 		doRegisterProducer(name, moduleOutputChannel, topic, new RedisPropertiesAccessor(properties));
 	}

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -198,19 +198,32 @@ public abstract class MessageBusSupport
 	protected volatile boolean defaultCompress = false;
 
 	/**
-	 * For bus implementations that support a prefix, create the name of the underlying
-	 * entity that will represent the pipe ('|') between modules.
+	 * For bus implementations that support a prefix, apply the prefix
+	 * to the name.
+	 * @param prefix the prefix.
+	 * @param name the name.
 	 */
-	public static String constructPipeName(String prefix, String name) {
+	public static String applyPrefix(String prefix, String name) {
 		return prefix + name;
+	}
+
+	/**
+	 * For bus implementations that include a pub/sub component in identifiers,
+	 * construct the name.
+	 * @param prefix the prefix.
+	 * @param name the name.
+	 */
+	public static String applyPubSub(String name) {
+		return "topic." + name;
 	}
 
 	/**
 	 * For bus implementations that support dead lettering, construct the name of the
 	 * dead letter entity for the underlying pipe name.
+	 * @param name the name.
 	 */
-	public static String constructDLQName(String pipeName) {
-		return pipeName + ".dlq";
+	public static String constructDLQName(String name) {
+		return name + ".dlq";
 	}
 
 	@Override

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -197,6 +197,22 @@ public abstract class MessageBusSupport
 
 	protected volatile boolean defaultCompress = false;
 
+	/**
+	 * For bus implementations that support a prefix, create the name of the underlying
+	 * entity that will represent the pipe ('|') between modules.
+	 */
+	public static String constructPipeName(String prefix, String name) {
+		return prefix + name;
+	}
+
+	/**
+	 * For bus implementations that support dead lettering, construct the name of the
+	 * dead letter entity for the underlying pipe name.
+	 */
+	public static String constructDLQName(String pipeName) {
+		return pipeName + ".dlq";
+	}
+
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		Assert.isInstanceOf(AbstractApplicationContext.class, applicationContext);
@@ -333,6 +349,7 @@ public abstract class MessageBusSupport
 
 	protected void onInit() {
 	}
+
 	/**
 	 * Dynamically create a producer for the named channel.
 	 * @param name The name.

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ import org.springframework.xd.test.redis.RedisTestSupport;
  * @author Kashyap Parikh
  * @author David Turanski
  * @author Ilayaperumal Gopinathan
+ * @author Gary Russell
  */
 public abstract class AbstractShellIntegrationTest {
 
@@ -81,6 +82,8 @@ public abstract class AbstractShellIntegrationTest {
 
 	protected Random random = new Random();
 
+	protected static int adminPort;
+
 	/**
 	 * Used to capture currently executing test method.
 	 */
@@ -94,7 +97,9 @@ public abstract class AbstractShellIntegrationTest {
 			application = new SingleNodeApplication().run("--transport", "local", "--analytics", "redis");
 			integrationTestSupport = new SingleNodeIntegrationTestSupport(application);
 			integrationTestSupport.addModuleRegistry(new ArchiveModuleRegistry("classpath:/spring-xd/xd/modules"));
-			Bootstrap bootstrap = new Bootstrap(new String[] { "--port", randomConfigSupport.getAdminServerPort() });
+			String adminServerPort = randomConfigSupport.getAdminServerPort();
+			adminPort = Integer.valueOf(adminServerPort);
+			Bootstrap bootstrap = new Bootstrap(new String[] { "--port", adminServerPort });
 			shell = bootstrap.getJLineShellComponent();
 		}
 		if (!shell.isRunning()) {
@@ -185,4 +190,3 @@ public abstract class AbstractShellIntegrationTest {
 	}
 
 }
-

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/bus/RabbitBusCleanerIntegrationTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/bus/RabbitBusCleanerIntegrationTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.shell.bus;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
+import org.springframework.xd.dirt.plugins.AbstractStreamPlugin;
+import org.springframework.xd.shell.AbstractShellIntegrationTest;
+import org.springframework.xd.test.rabbit.RabbitAdminTestSupport;
+import org.springframework.xd.test.rabbit.RabbitTestSupport;
+
+
+/**
+ *
+ * @author Gary Russell
+ * @since 1.2
+ */
+public class RabbitBusCleanerIntegrationTests extends AbstractShellIntegrationTest {
+
+	@Rule
+	public RabbitAdminTestSupport adminTest = new RabbitAdminTestSupport();
+
+	@Rule
+	public RabbitTestSupport test = new RabbitTestSupport();
+
+	@Test
+	public void testClean() throws Exception {
+		RabbitAdmin admin = new RabbitAdmin(test.getResource());
+		final String uuid = UUID.randomUUID().toString();
+		String queueName = MessageBusSupport.constructPipeName("xdbus.",
+				AbstractStreamPlugin.constructPipeName(uuid, 0));
+		admin.declareQueue(new Queue(queueName));
+		RestTemplate template = new RestTemplate();
+		URI uri = new URI("http://localhost:" + adminPort + "/streams/clean/rabbit/" + queueName.substring(6));
+		RequestEntity<String> request = new RequestEntity<>(HttpMethod.DELETE, uri);
+		HttpStatus status = HttpStatus.NO_CONTENT;
+		ResponseEntity<List> reply = null;
+		int n = 0;
+		while (n++ < 100 && !status.equals(HttpStatus.OK)) {
+			reply = template.exchange(request, List.class);
+			status = reply.getStatusCode();
+			Thread.sleep(100);
+		}
+		assertEquals("Didn't get OK after 10 seconds", HttpStatus.OK, reply.getStatusCode());
+		assertEquals(1, reply.getBody().size());
+		assertEquals(queueName, reply.getBody().get(0));
+		reply = template.exchange(request, List.class);
+		assertEquals(HttpStatus.NO_CONTENT, reply.getStatusCode());
+	}
+
+}

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/bus/RabbitBusCleanerTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/bus/RabbitBusCleanerTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.shell.bus;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.ChannelCallback;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.xd.dirt.integration.bus.RabbitAdminException;
+import org.springframework.xd.dirt.integration.bus.RabbitBusCleaner;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DefaultConsumer;
+
+/**
+ *
+ * @author Gary Russell
+ */
+public class RabbitBusCleanerTests {
+
+	@Test
+	@Ignore
+	// requires the rabbit admin plugin
+	public void testClean() {
+		final RabbitBusCleaner cleaner = new RabbitBusCleaner();
+		RestTemplate template = RabbitBusCleaner.buildRestTemplate("http://localhost:15672", "guest", "guest");
+		final String uuid = UUID.randomUUID().toString();
+		for (int i = 0; i < 5; i++) {
+			URI uri = UriComponentsBuilder.fromUriString("http://localhost:15672/api/queues").pathSegment("{vhost}",
+					"{queue}")
+					.buildAndExpand("/", "xdbus." + uuid + "." + i).encode().toUri();
+			template.put(uri, new Queue(false, true));
+			uri = UriComponentsBuilder.fromUriString("http://localhost:15672/api/queues").pathSegment("{vhost}",
+					"{queue}")
+					.buildAndExpand("/", "xdbus." + uuid + "." + i + ".dlq").encode().toUri();
+			template.put(uri, new Queue(false, true));
+		}
+		CachingConnectionFactory connectionFactory = new CachingConnectionFactory("localhost");
+		new RabbitTemplate(connectionFactory).execute(new ChannelCallback<Void>() {
+
+			@Override
+			public Void doInRabbit(Channel channel) throws Exception {
+				String consumerTag = channel.basicConsume("xdbus." + uuid + ".4", new DefaultConsumer(channel));
+				try {
+					Thread.sleep(5000); // wait for consumer to show up in rest API
+					cleaner.clean(uuid);
+					fail("Expected exception");
+				}
+				catch (RabbitAdminException e) {
+					assertEquals("Queue xdbus." + uuid + ".4 is in use", e.getMessage());
+				}
+				channel.basicCancel(consumerTag);
+				Thread.sleep(5000); // wait for consumer to go away in rest API
+				return null;
+			}
+
+		});
+		connectionFactory.destroy();
+		List<String> cleaned = cleaner.clean(uuid);
+		assertEquals(10, cleaned.size());
+		for (int i = 0; i < 5; i++) {
+			assertEquals("xdbus." + uuid + "." + i, cleaned.get(i * 2));
+			assertEquals("xdbus." + uuid + "." + i + ".dlq", cleaned.get(i * 2 + 1));
+		}
+	}
+
+	public class Queue {
+
+		private boolean autoDelete;
+
+		private boolean durable;
+
+		public Queue(boolean autoDelete, boolean durable) {
+			this.autoDelete = autoDelete;
+			this.durable = durable;
+		}
+
+
+		@JsonProperty("auto_delete")
+		protected boolean isAutoDelete() {
+			return autoDelete;
+		}
+
+
+		protected void setAutoDelete(boolean autoDelete) {
+			this.autoDelete = autoDelete;
+		}
+
+
+		protected boolean isDurable() {
+			return durable;
+		}
+
+
+		protected void setDurable(boolean durable) {
+			this.durable = durable;
+		}
+
+	}
+}

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/rabbit/RabbitAdminTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/rabbit/RabbitAdminTestSupport.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.test.rabbit;
+
+
+import org.junit.Rule;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.xd.test.AbstractExternalResourceTestSupport;
+
+import com.sun.javafx.collections.MappingChange.Map;
+
+/**
+ * JUnit {@link Rule} that detects the fact that RabbitMQ is available on localhost with
+ * the management plugin enabled.
+ *
+ * @author Gary Russell
+ * @since 1.2
+ */
+public class RabbitAdminTestSupport extends AbstractExternalResourceTestSupport<RestTemplate> {
+
+	public RabbitAdminTestSupport() {
+		super("RABBITADMIN");
+	}
+
+	@Override
+	protected void obtainResource() throws Exception {
+		resource = new RestTemplate();
+		try {
+			resource.getForObject("http://localhost:15672/api/overview", Map.class);
+		}
+		catch (HttpClientErrorException e) {
+			if (e.getStatusCode() != HttpStatus.UNAUTHORIZED) {
+				throw e;
+			}
+		}
+	}
+
+	@Override
+	protected void cleanupResource() throws Exception {
+	}
+
+}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2719

    curl -X DELETE 'http://localhost:9393/streams/clean/rabbit/foo\
         ?user=guest&pw=guest&vhost=/&busPrefix=xdbus.&adminUri=http://localhost:15672'

Query params are optional (defaults as shown).

Looks for queues named xdbus.<stream>.0, 1, 2, 3 etc and possibly their associated
.dlq companions.

Verifies that none of the queues are currently in use (but does not check if they are empty.

If no queues have consumers, all that were found are deleted.