### PR TITLE
XD-2755 Fix scala spark stream executor

### DIFF
--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
@@ -24,6 +24,7 @@ import static org.springframework.xd.shell.command.fixtures.XDMatchers.fileConte
 import java.io.File;
 import java.util.Random;
 
+import org.hamcrest.core.StringContains;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,7 +50,9 @@ import org.springframework.xd.test.fixtures.FileSink;
  */
 public abstract class AbstractSparkStreamingTests {
 
-	protected static final String TEST_MESSAGE = "foo foo foo";
+	private static final String TEST_MESSAGE = "foo foo foo";
+
+	protected static final String TEST_LONG_MESSAGE = "foo foo foo foo bar bar bar foo bar bar test1 test1 test2 foo";
 
 	private SingleNodeApplication singleNodeApplication;
 
@@ -100,8 +103,11 @@ public abstract class AbstractSparkStreamingTests {
 		try {
 			String stream = String.format("%s | spark-word-count | %s --inputType=text/plain", source, sink);
 			createStream(streamName, stream);
-			source.ensureReady().postData(TEST_MESSAGE);
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(equalTo("(foo,3)"))));
+			source.ensureReady().postData(TEST_LONG_MESSAGE);
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(foo,6)"))));
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(bar,5)"))));
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test1,2)"))));
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test2,1)"))));
 		}
 		finally {
 			streamOps.destroyStream(streamName);
@@ -152,8 +158,11 @@ public abstract class AbstractSparkStreamingTests {
 		try {
 			String stream = String.format("%s | spark-scala-word-count | %s --inputType=text/plain", source, sink);
 			createStream(streamName, stream);
-			source.ensureReady().postData(TEST_MESSAGE);
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(equalTo("(foo,3)"))));
+			source.ensureReady().postData(TEST_LONG_MESSAGE);
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(foo,6)"))));
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(bar,5)"))));
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test1,2)"))));
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test2,1)"))));
 		}
 		finally {
 			streamOps.destroyStream(streamName);

--- a/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
+++ b/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
@@ -43,7 +43,7 @@ class ModuleExecutor extends SparkStreamingModuleExecutor[ReceiverInputDStream[A
             messageSender = sender
             messageSender.start()
           }
-          if (partition.hasNext) {
+          while (partition.hasNext) {
             val message = partition.next()
             if (message.isInstanceOf[Message[_]]) {
               messageSender.send(message.asInstanceOf[Message[_]])


### PR DESCRIPTION
 - The loop should iterate over RDD partitions
 - Update tests to test long test messages