### PR TITLE
[Sprint: 44] XD-2759: Make Local Bus Task Executor Configurable

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -16,6 +16,11 @@
 #    local:
 #      queueSize:                   2147483647
 #      polling:                     1000
+#      executor:
+#        corePoolSize:              0
+#        maxPoolSize:               200
+#        queueSize:                 2147483647
+#        keepAliveSeconds:          60
 #    rabbit:
 #      compressionLevel:            1
             # bus-level property, applies only when 'compress=true' for a stream module

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests.java
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,6 +126,7 @@ public class RemoteFileToTmpTests {
 		this.bus.setApplicationContext(BusTestUtils.MOCK_AC);
 		this.bus.bindRequestor("foo", this.requestsOut, this.repliesIn, null);
 		this.bus.bindReplier("foo", this.requestsIn, this.repliesOut, null);
+		this.bus.afterPropertiesSet();
 	}
 
 	@After

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -95,6 +95,11 @@ xd:
   messagebus:
     local:
       polling:                     1000
+      executor:
+        corePoolSize:              0
+        maxPoolSize:               200
+#       queueSize:                 # defaults to Integer.MAX_VALUE
+        keepAliveSeconds:          60
     rabbit:
       compressionLevel:            1
             # bus-level property, applies only when 'compress=true' for a stream module

--- a/spring-xd-messagebus-local/src/main/resources/META-INF/spring-xd/bus/local-bus.xml
+++ b/spring-xd-messagebus-local/src/main/resources/META-INF/spring-xd/bus/local-bus.xml
@@ -10,6 +10,10 @@
 		<property name="poller">
 			<int:poller fixed-rate="${xd.messagebus.local.polling}" />
 		</property>
+		<property name="executorCorePoolSize" value="${xd.messagebus.local.executor.corePoolSize}" />
+		<property name="executorMaxPoolSize" value="${xd.messagebus.local.executor.maxPoolSize}" />
+		<property name="executorQueueSize" value="${xd.messagebus.local.executor.queueSize: #{T(Integer).MAX_VALUE}}" />
+		<property name="executorKeepAliveSeconds" value="${xd.messagebus.local.executor.keepAliveSeconds}" />
 	</bean>
 
 </beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2759

Change the TE to a `ThreadPoolTaskExecutor`.
Add `executorCorePoolSize`, `executorMaxPoolSize`, `executorKeepAliveSeconds` and `executorQueueSize` properties.

__cherry-pick to 1.1.x__