### PR TITLE
[Sprint: 45] [Backport] XD-2761 fix kryo registration issue

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/KryoClassListRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/KryoClassListRegistrar.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus.serializer.kryo;
+
+import java.util.List;
+
+import com.esotericsoftware.kryo.Kryo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.util.Assert;
+
+/**
+ * A {@link org.springframework.xd.dirt.integration.bus.serializer.kryo.KryoRegistrar} used to register a 
+ * list of Java classes. This assigns a sequential registration ID starting with an initial value (50 by default), but
+ * may be configured. This is easiest to set up but requires that every server node be configured with the identical 
+ * list in the same order.
+ *
+ * @author David Turanski
+ * @since 1.1
+ */
+public class KryoClassListRegistrar implements KryoRegistrar {
+	private final static Logger log = LoggerFactory.getLogger(KryoClassListRegistrar.class);
+
+	private final List<Class<?>> registeredClasses;
+
+	private int initialValue = 50;
+
+	/**
+	 *  
+	 * @param classes the list of classes to register
+	 */
+	public KryoClassListRegistrar(List<Class<?>> classes) {
+		this.registeredClasses = classes;
+	}
+
+	/**
+	 * Set the inital ID value. Classes in the list will be sequentially assigned an ID starting with this value
+	 * (default is 50).
+	 * 
+	 *
+	 * @param initialValue the initial value
+	 */
+	public void setInitialValue(int initialValue) {
+		Assert.isTrue(initialValue > 10, "'initialValue' must be a value greater than 10");
+		this.initialValue = initialValue;
+	}
+
+	@Override
+	public void registerTypes(Kryo kryo) {
+		if (registeredClasses == null) {
+			return;
+		}
+		for (int i = 0; i < registeredClasses.size(); i++) {
+			if (log.isDebugEnabled()) {
+				log.debug("registering class {} id = {}", registeredClasses.get(i).getName() , (i + initialValue));
+			}
+			kryo.register(registeredClasses.get(i), i + initialValue);
+		}
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/KryoClassMapRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/KryoClassMapRegistrar.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus.serializer.kryo;
+
+import java.util.Map;
+
+import com.esotericsoftware.kryo.Kryo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link org.springframework.xd.dirt.integration.bus.serializer.kryo.KryoRegistrar } implementation backed by a Map
+ * used to explicitly set the registration ID for each class.
+ *
+ * @author David Turanski
+ * @since 1.1
+ */
+public class KryoClassMapRegistrar implements KryoRegistrar {
+
+	private final static Logger log = LoggerFactory.getLogger(KryoClassMapRegistrar.class);
+
+	final private Map<Integer, Class<?>> kryoRegisteredClasses;
+
+	public KryoClassMapRegistrar(Map<Integer, Class<?>> kryoRegisteredClasses) {
+		this.kryoRegisteredClasses = kryoRegisteredClasses;
+	}
+
+	@Override
+	public void registerTypes(Kryo kryo) {
+		if (kryoRegisteredClasses == null) {
+			return;
+		}
+		for (Map.Entry<Integer, Class<?>> entry : kryoRegisteredClasses.entrySet()) {
+			if (log.isDebugEnabled()) {
+				log.debug("registering class {} id = {}", entry.getValue(), entry.getKey());
+			}
+			kryo.register(entry.getValue(), entry.getKey());
+		}
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/KryoNullRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/KryoNullRegistrar.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus.serializer.kryo;
+
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * @author David Turanski
+ */
+public class KryoNullRegistrar implements FactoryBean<KryoRegistrar> {
+
+	@Override
+	public KryoRegistrar getObject() throws Exception {
+		return null;
+	}
+
+	@Override
+	public Class<?> getObjectType() {
+		return KryoNullRegistrar.class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return true;
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/KryoRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/KryoRegistrar.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus.serializer.kryo;
+
+import com.esotericsoftware.kryo.Kryo;
+
+/**
+ * Strategy interface used by {@link org.springframework.xd.dirt.integration.bus.serializer.kryo.PojoCodec} to register
+ * classes consistently across {@link Kryo} instances. An XD user may register an instance of this type in the Spring XD
+ * Application Context to enable kryo class registration which results in efficiency gains if you know the types your
+ * application needs in advance. Note that Kryo serialization only applies to types used as message payloads in XD
+ * streams.
+ * By default, user defined types are not registered to Kryo. Registration allows a unique ID (small positive integer is
+ * ideal) to represent the type in the byte stream. In a distributed environment, all Kryo instances must maintain the
+ * same registration state in order to properly take advantage of this feature.
+ * This is can result in better performance in demanding situations, but requires some care to maintain. Only use this
+ * if you really need it. Otherwise, it is a great example of premature optimization.
+ * This interface applies a strategy to register a statically configured, one-to-one mapping of a Java type to an
+ * integer. Basic implementations are provided backed by a Map<Integer,Class<?>> or a List<Class<?>>. These are simple
+ * and require the user to manually configure a bean in each XD server and ensure that the configuration is always
+ * consistent.*
+ * The container looks in classpath*:META-INF/spring-xd/xd/bus/ext/*.xml for an instance of this type named
+ * "kryoRegistrar". The KryoRegistrar provides the registration mapping and the strategy to apply the mapping to every
+ * Kryo instance. Note that statically declared Java types must also be present in the XD class path (xd/lib) else the
+ * container will fail to initialize. Only one instance may be registered and identically configured across all
+ * containers.
+ *
+ * @author David Turanski
+ * @since 1.1
+ */
+public interface KryoRegistrar {
+	/**
+	 * This method is invoked by the {@link org.springframework.xd.dirt.integration.bus.serializer.kryo.PojoCodec} and
+	 * applied to the {@link Kryo} instance whenever one is provided. This is currently done using an object pool so it
+	 * is inevitable that this method will be invoked repeatedly on the same instance. Kryo registration is idempotent,
+	 * but this could become inefficient if registering a large amount of types.
+	 *
+	 * @param kryo the provided instance
+	 */
+	void registerTypes(Kryo kryo);
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/PojoCodec.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/serializer/kryo/PojoCodec.java
@@ -28,16 +28,39 @@ import com.esotericsoftware.kryo.io.Output;
  * @since 1.0
  */
 public class PojoCodec extends AbstractKryoMultiTypeCodec<Object> {
+	private final KryoRegistrar kryoRegistrar;
+
+	public PojoCodec() {
+		kryoRegistrar = null;
+	}
+
+	/**
+	 * Use this constructor to register known domain classes to Kryo using a {@link
+	 * org.springframework.xd.dirt.integration.bus.serializer.kryo.KryoRegistrar}. This constructor is used in XDs
+	 * Spring configuration. Null by defaults, users must register a bean of this type to take advantage of this
+	 * feature.
+	 *
+	 * @param kryoRegistrar
+	 */
+	public PojoCodec(KryoRegistrar kryoRegistrar) {
+		this.kryoRegistrar = kryoRegistrar;
+	}
 
 	@Override
 	protected void doSerialize(Kryo kryo, Object object, Output output) {
-		kryo.register(object.getClass());
 		kryo.writeObject(output, object);
 	}
 
 	@Override
 	protected Object doDeserialize(Kryo kryo, Input input, Class<? extends Object> type) {
-		kryo.register(type);
 		return kryo.readObject(input, type);
+	}
+
+	@Override
+	protected void configureKryoInstance(Kryo kryo) {
+		super.configureKryoInstance(kryo);
+		if (kryoRegistrar != null) {
+			kryoRegistrar.registerTypes(kryo);
+		}
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SharedServerContextConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SharedServerContextConfiguration.java
@@ -52,8 +52,9 @@ import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
 @EnableIntegration
 @Import(PropertyPlaceholderAutoConfiguration.class)
 @ImportResource({
-	"classpath*:" + ConfigLocations.XD_CONFIG_ROOT + "bus/${XD_TRANSPORT}-bus.xml",
+	ConfigLocations.XD_CONFIG_ROOT + "bus/${XD_TRANSPORT}-bus.xml",
 	ConfigLocations.XD_CONFIG_ROOT + "bus/codec.xml",
+	"classpath*:" + ConfigLocations.XD_CONFIG_ROOT + "bus/ext/*.xml",
 	ConfigLocations.XD_CONFIG_ROOT + "internal/repositories.xml",
 	ConfigLocations.XD_CONFIG_ROOT + "analytics/${XD_ANALYTICS}-analytics.xml"
 })

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/bus/codec.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/bus/codec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<bean id="codec" class="org.springframework.xd.dirt.integration.bus.serializer.CompositeCodec">
 		<constructor-arg name="delegates">
@@ -14,9 +14,12 @@
 				</entry>
 			</map>
 		</constructor-arg>
-		<constructor-arg name="defaultCodec">
-			<bean class="org.springframework.xd.dirt.integration.bus.serializer.kryo.PojoCodec"/>
-		</constructor-arg>
+		<constructor-arg name="defaultCodec" ref="defaultCodec"/>
 	</bean>
 
+	<bean id="defaultCodec" class="org.springframework.xd.dirt.integration.bus.serializer.kryo.PojoCodec">
+		<constructor-arg ref="kryoRegistrar"/>
+	</bean>
+
+	<bean id="kryoRegistrar" class="org.springframework.xd.dirt.integration.bus.serializer.kryo.KryoNullRegistrar"/>
 </beans>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/ExtensionsTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/ExtensionsTests.java
@@ -26,17 +26,20 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.context.ApplicationContext;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.util.MimeType;
 import org.springframework.xd.dirt.container.initializer.AbstractResourceBeanDefinitionProvider;
 import org.springframework.xd.dirt.integration.bus.converter.CompositeMessageConverterFactory;
+import org.springframework.xd.dirt.integration.bus.serializer.kryo.KryoClassListRegistrar;
+import org.springframework.xd.dirt.integration.bus.serializer.kryo.KryoRegistrar;
 import org.springframework.xd.dirt.plugins.stream.ModuleTypeConversionPlugin;
 import org.springframework.xd.dirt.server.SingleNodeApplication;
 import org.springframework.xd.dirt.server.TestApplicationBootstrap;
+import org.springframework.xd.extensions.test.Bar;
+import org.springframework.xd.extensions.test.Foo;
 import org.springframework.xd.extensions.test.StubPojoToStringConverter;
-
 
 /**
  * @author David Turanski
@@ -79,7 +82,6 @@ public class ExtensionsTests {
 		String extensionsLocation = context.getEnvironment().getProperty("xd.extensions.locations");
 		assertEquals("META-INF/spring-xd/ext/test,META-INF/spring-xd/ext/test2",
 				extensionsLocation);
-
 	}
 
 	@Test
@@ -111,6 +113,17 @@ public class ExtensionsTests {
 		beanDefinitionProvider = new TestResourceBeanDefinitionProvider("classpath*:foo/");
 		resolvedLocations = beanDefinitionProvider.resolveLocations();
 		assertEquals("classpath*:foo/**/*.*", resolvedLocations[0]);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void kryoClassListRegistrar() {
+		KryoRegistrar registrar = context.getBean(KryoClassListRegistrar.class);
+		List<Class<?>> classes = (List<Class<?>>) TestUtils.getPropertyValue(registrar, "registeredClasses");
+		assertEquals(2, classes.size());
+
+		assertEquals(Foo.class, classes.get(0));
+		assertEquals(Bar.class, classes.get(1));
 	}
 
 	@AfterClass

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/Bar.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/Bar.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.extensions.test;
+
+/**
+ * @author David Turanski
+ */
+public class Bar {
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/Foo.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/Foo.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 the original author or authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.extensions.test;
+
+/**
+ * @author David Turanski
+ */
+public class Foo {
+}

--- a/spring-xd-dirt/src/test/resources/META-INF/spring-xd/bus/ext/custom-types.xml
+++ b/spring-xd-dirt/src/test/resources/META-INF/spring-xd/bus/ext/custom-types.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	<beans profile="kryo-test">
+		<bean id="kryoRegistrar"
+			  class="org.springframework.xd.dirt.integration.bus.serializer.kryo.KryoClassListRegistrar">
+		<constructor-arg>
+			<util:list>
+				<value>org.springframework.xd.extensions.test.Foo</value>
+				<value>org.springframework.xd.extensions.test.Bar</value>
+			</util:list>
+		</constructor-arg>
+		</bean>
+	</beans>
+
+</beans>

--- a/spring-xd-dirt/src/test/resources/extensions/extensions-test.yml
+++ b/spring-xd-dirt/src/test/resources/extensions/extensions-test.yml
@@ -1,5 +1,7 @@
+spring:
+  profiles:
+    active: default,kryo-test
 xd:
    extensions:
         basepackages: org.springframework.xd.extensions.test,org.springframework.xd.extensions.test2
         locations: META-INF/spring-xd/ext/test,META-INF/spring-xd/ext/test2
-        


### PR DESCRIPTION
This PR is for 1.1.x. Should be applied to the master as well. 

* PojoCodec does not register classes to Kryo inside ser/deser methods
* An extension to shared server context is enabled. The context imports from `classpath*:/META-INF/spring-xd/bus/ext/*.xml`.  This mechanism enables bean definitions in `codec.xml` (and other beans in the shared context technically) to be added/overriden. 
* A bean named `kryoRegistrar` may be registered and configured by the user if registration is necessary.
* PojoCodec is configured with a KryoRegistrar constructor and no implementation OOTB so it registers 
no classes by default. Two implementations are included, one backed by a List and the other a Map. Another implementation might be Properties based which opens up a range of possibilities, but is not included yet. This mechanism is internal to XD 1.1.x and we will revisit this in relation to other customization features for 1.2.

It is not necessary to register classes targeted for serialization, but it is offered as a performance optimization to reduce the size of the byte stream.  A simple way to register classes is to create a `/META-INF/spring-xd/bus/ext directory` in `$XD_HOME/config` and drop an XML file in there:
````
<beans ...>
   	<bean id="kryoRegistrar" class="org.springframework.xd.dirt.integration.bus.serializer.kryo.KryoClassListRegistrar">
			<constructor-arg>
				<util:list>
					<value>org.springframework.xd.extensions.test.Foo</value>
					<value>org.springframework.xd.extensions.test.Bar</value>
				</util:list>
			</constructor-arg>
		</bean>
</beans>
````
The bean id must be "kryoRegistrar". The name of the XML file does not matter. A Map backed version is also provided to allow the user to specify class IDs for each class. This is initially more effort but may give the user more  control. This also allows the user to implement alternate strategies if necessary.

This resource may also be packaged in a jar and dropped into `xd/lib`. Note that the referenced domain classes must also be on the XD class path (xd/lib) else the context will fail to initialize. 