### PR TITLE
[Sprint: 44] XD-2731: Remove use of dummy() resources in production code

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -114,9 +114,7 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 	private List<ModuleDefinition> createModuleDefinitions(List<ModuleDescriptor> moduleDescriptors) {
 		List<ModuleDefinition> moduleDefinitions = new ArrayList<ModuleDefinition>(moduleDescriptors.size());
 		for (ModuleDescriptor moduleDescriptor : moduleDescriptors) {
-			ModuleDefinition moduleDefinition = ModuleDefinitions.dummy(moduleDescriptor.getModuleName(),
-					moduleDescriptor.getType());
-			moduleDefinitions.add(moduleDefinition);
+			moduleDefinitions.add(moduleDescriptor.getModuleDefinition());
 		}
 		return moduleDefinitions;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDeployer.java
@@ -86,36 +86,4 @@ public class StreamDeployer extends AbstractInstancePersistingDeployer<StreamDef
 		return Paths.build(Paths.STREAM_DEPLOYMENTS, definition.getName());
 	}
 
-	/**
-	 * {@inheritDoc}
-	 * <p/>
-	 * Before deleting the stream, perform an undeploy. This causes a graceful shutdown of the
-	 * modules in the stream before it is deleted from the repository.
-	 */
-	@Override
-	protected void beforeDelete(StreamDefinition definition) {
-		super.beforeDelete(definition);
-
-		// Load module definitions and set them on StreamDefinition; this is used by
-		// StreamDefinitionRepositoryUtils.deleteDependencies to delete dependent modules
-
-		// todo: this parsing and setting of ModuleDefinitions should not be needed once we refactor the
-		// ModuleDependencyRepository so that the dependencies are also stored in ZooKeeper.
-		List<ModuleDefinition> moduleDefinitions = new ArrayList<ModuleDefinition>();
-		try {
-			for (ModuleDescriptor request : parser.parse(definition.getName(), definition.getDefinition(),
-					ParsingContext.stream)) {
-				moduleDefinitions.add(ModuleDefinitions.dummy(request.getModuleName(), request.getType()));
-			}
-		}
-		catch (StreamDefinitionException e) {
-			// we can ignore an exception for a tap whose stream no longer exists
-			if (!(XDDSLMessages.UNRECOGNIZED_STREAM_REFERENCE.equals(e.getMessageCode())
-			&& definition.getDefinition().trim().startsWith("tap:"))) {
-				throw e;
-			}
-		}
-		definition.setModuleDefinitions(moduleDefinitions);
-	}
-
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/ModuleDeploymentTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/ModuleDeploymentTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.xd.dirt.plugins;
 
+import static org.springframework.xd.module.ModuleType.*;
+
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +28,7 @@ import org.springframework.integration.redis.outbound.RedisQueueOutboundChannelA
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.xd.dirt.integration.bus.BusTestUtils;
+import org.springframework.xd.module.ModuleDefinitions;
 import org.springframework.xd.module.ModuleDescriptor;
 import org.springframework.xd.module.ModuleType;
 import org.springframework.xd.test.redis.RedisTestSupport;
@@ -53,8 +56,7 @@ public class ModuleDeploymentTests {
 		adapter.afterPropertiesSet();
 		ModuleDescriptor request = new ModuleDescriptor.Builder()
 				.setGroup("test")
-				.setType(ModuleType.processor)
-				.setModuleName("filter")
+				.setModuleDefinition(ModuleDefinitions.dummy("filter", processor))
 				.setIndex(0)
 				.build();
 		Message<?> message = MessageBuilder.withPayload(request.toString()).build();
@@ -71,16 +73,14 @@ public class ModuleDeploymentTests {
 		adapter.afterPropertiesSet();
 		ModuleDescriptor sinkRequest = new ModuleDescriptor.Builder()
 				.setGroup("teststream")
-				.setType(ModuleType.sink)
-				.setModuleName("log")
+				.setModuleDefinition(ModuleDefinitions.dummy("log", sink))
 				.setIndex(1)
 				.build();
 		Message<?> sinkMessage = MessageBuilder.withPayload(sinkRequest.toString()).build();
 		adapter.handleMessage(sinkMessage);
 		ModuleDescriptor sourceRequest = new ModuleDescriptor.Builder()
 				.setGroup("teststream")
-				.setType(ModuleType.source)
-				.setModuleName("time")
+				.setModuleDefinition(ModuleDefinitions.dummy("time", source))
 				.setIndex(0)
 				.build();
 		Message<?> sourceMessage = MessageBuilder.withPayload(sourceRequest.toString()).build();

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
@@ -575,10 +575,6 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
 		}
 
 		public ModuleDefinition getModuleDefinition() {
-			// todo: setName and setType on this builder should be removed
-			if (moduleDefinition == null) {
-				moduleDefinition = ModuleDefinitions.dummy(moduleName, type);
-			}
 			return moduleDefinition;
 		}
 	}


### PR DESCRIPTION
"dummy" definitions should not be used in the real runtime.
This PR removes the last remaining uses, serializing the module definitions in the stream definition.