### PR TITLE
Properly read initial offset from partitions

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
@@ -142,7 +142,7 @@ public class KafkaSingleNodeStreamDeploymentIntegrationTests extends
 			Partition partition = new Partition(KafkaMessageBus.escapeTopicName(topicName), 0);
 			BrokerAddress leader = template.getConnectionFactory().getLeader(partition);
 			return template.getConnectionFactory().connect(leader)
-					.fetchInitialOffset(OffsetRequest.LatestTime()).getResult(partition);
+					.fetchInitialOffset(OffsetRequest.LatestTime(), partition).getResult(partition);
 		}
 		catch (PartitionNotFoundException e) {
 			return 0;


### PR DESCRIPTION
Fixes an issue if the test partition already exists