### PR TITLE
[Sprint 44 + backport] XD-2706 Fix Redis bus error logging

### DIFF
--- a/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -277,8 +277,8 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 							@Override
 							public Boolean recover(RetryContext context) throws Exception {
 								logger.error(
-										"Failed to deliver message; retries exhausted; message sent to queue 'ERRORS:name'",
-										context.getLastThrowable());
+										"Failed to deliver message; retries exhausted; message sent to queue 'ERRORS:"
+												+ name + "' " + context.getLastThrowable());
 								errorAdapter.handleMessage(getMessageBuilderFactory().fromMessage(message)
 										.setHeader(ERROR_HEADER, "ERRORS:" + name)
 										.build());


### PR DESCRIPTION
 - specify error channel name