### PR TITLE
[Sprint: 44] XD-2719: More Rabbit Job Cleanup

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -110,6 +110,16 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 		}
 	}
 
+	/**
+	 * Construct a pipe name from the group and index.
+	 * @param group the group.
+	 * @param index the index.
+	 * @return the name.
+	 */
+	public static String constructPipeName(String group, int index) {
+		return group + "." + index;
+	}
+
 	private void startTapListener(CuratorFramework client) {
 		String tapPath = Paths.build(Paths.TAPS);
 		Paths.ensurePath(client, tapPath);
@@ -175,11 +185,11 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 
 	private void track(final Module module, MessageChannel channel, final Map<String, Object> historyProps) {
 		final MessageBuilderFactory messageBuilderFactory = module.getComponent(
-					IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
-						MessageBuilderFactory.class) == null
+				IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
+				MessageBuilderFactory.class) == null
 				? new DefaultMessageBuilderFactory()
 				: module.getComponent(
-					IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
+						IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME,
 						MessageBuilderFactory.class);
 		if (channel instanceof ChannelInterceptorAware) {
 			((ChannelInterceptorAware) channel).addInterceptor(new ChannelInterceptorAdapter() {
@@ -200,9 +210,9 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 					map.put("thread", Thread.currentThread().getName());
 					history.add(map);
 					Message<?> out = messageBuilderFactory
-										.fromMessage(message)
-										.setHeader(XdHeaders.XD_HISTORY, history)
-										.build();
+							.fromMessage(message)
+							.setHeader(XdHeaders.XD_HISTORY, history)
+							.build();
 					return out;
 				}
 			});

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
@@ -42,16 +42,6 @@ public abstract class AbstractStreamPlugin extends AbstractMessageBusBinderPlugi
 		super(messageBus, zkConnection);
 	}
 
-	/**
-	 * Construct a pipe name from the group and index.
-	 * @param group the group.
-	 * @param index the index.
-	 * @return the name.
-	 */
-	public static String constructPipeName(String group, int index) {
-		return group + "." + index;
-	}
-
 	public static String constructTapPrefix(String group) {
 		return TAP_CHANNEL_PREFIX + "stream:" + group;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPartitionerPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPartitionerPlugin.java
@@ -65,7 +65,7 @@ public class JobPartitionerPlugin extends AbstractJobPlugin {
 		MessageChannel partitionsIn = module.getComponent(JOB_PARTIONER_REPLY_CHANNEL, MessageChannel.class);
 		Assert.notNull(partitionsIn, "Partitioned jobs must have a " + JOB_PARTIONER_REPLY_CHANNEL);
 		ModuleDescriptor descriptor = module.getDescriptor();
-		String name = descriptor.getGroup() + "." + descriptor.getIndex();
+		String name = getJobChannelName(constructPipeName(descriptor.getGroup(), descriptor.getIndex()));
 		messageBus.bindRequestor(name, partitionsOut, partitionsIn, properties[0]);
 
 		MessageChannel stepExecutionsIn = module.getComponent(JOB_STEP_EXECUTION_REQUEST_CHANNEL, MessageChannel.class);
@@ -82,7 +82,7 @@ public class JobPartitionerPlugin extends AbstractJobPlugin {
 		}
 		MessageChannel partitionsOut = module.getComponent(JOB_PARTIONER_REQUEST_CHANNEL, MessageChannel.class);
 		ModuleDescriptor descriptor = module.getDescriptor();
-		String name = descriptor.getGroup() + "." + descriptor.getIndex();
+		String name = getJobChannelName(constructPipeName(descriptor.getGroup(), descriptor.getIndex()));
 		if (partitionsOut != null) {
 			messageBus.unbindProducer(name, partitionsOut);
 		}

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -582,7 +582,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		validateProducerProperties(name, properties, SUPPORTED_REQUESTING_PRODUCER_PROPERTIES);
 		Assert.isInstanceOf(SubscribableChannel.class, requests);
 		RabbitPropertiesAccessor accessor = new RabbitPropertiesAccessor(properties);
-		String queueName = name + ".requests";
+		String queueName = applyRequests(name);
 		AmqpOutboundEndpoint queue = this.buildOutboundEndpoint(queueName, accessor, this.rabbitTemplate);
 		queue.setBeanFactory(this.getBeanFactory());
 
@@ -604,7 +604,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		}
 		validateConsumerProperties(name, properties, SUPPORTED_REPLYING_CONSUMER_PROPERTIES);
 		RabbitPropertiesAccessor accessor = new RabbitPropertiesAccessor(properties);
-		Queue requestQueue = new Queue(accessor.getPrefix(this.defaultPrefix) + name + ".requests");
+		Queue requestQueue = new Queue(applyPrefix(accessor.getPrefix(this.defaultPrefix), applyRequests(name)));
 		declareQueueIfNotPresent(requestQueue);
 		this.doRegisterConsumer(name, requests, requestQueue, accessor, false);
 

--- a/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -366,7 +366,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		}
 		Assert.isInstanceOf(SubscribableChannel.class, requests);
 		validateProducerProperties(name, properties, SUPPORTED_REQUESTING_PRODUCER_PROPERTIES);
-		RedisQueueOutboundChannelAdapter queue = new RedisQueueOutboundChannelAdapter("queue." + name + ".requests",
+		RedisQueueOutboundChannelAdapter queue = new RedisQueueOutboundChannelAdapter("queue." + applyRequests(name),
 				this.connectionFactory);
 		queue.setBeanFactory(this.getBeanFactory());
 		queue.afterPropertiesSet();
@@ -385,7 +385,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		}
 		validateConsumerProperties(name, properties, SUPPORTED_REPLYING_CONSUMER_PROPERTIES);
 		RedisPropertiesAccessor accessor = new RedisPropertiesAccessor(properties);
-		MessageProducerSupport adapter = createInboundAdapter(accessor, "queue." + name + ".requests");
+		MessageProducerSupport adapter = createInboundAdapter(accessor, "queue." + applyRequests(name));
 		this.doRegisterConsumer(name, name, requests, adapter, accessor);
 
 		RedisQueueOutboundChannelAdapter replyQueue = new RedisQueueOutboundChannelAdapter(

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -218,6 +218,15 @@ public abstract class MessageBusSupport
 	}
 
 	/**
+	 * Build the requests entity name.
+	 * @param name the name.
+	 * @return the request entity name.
+	 */
+	public static String applyRequests(String name) {
+		return name + ".requests";
+	}
+
+	/**
 	 * For bus implementations that support dead lettering, construct the name of the
 	 * dead letter entity for the underlying pipe name.
 	 * @param name the name.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2719

Partitioned jobs add another queue

`xdbus.job:<jobName>.requests`

Previously, this had an incorrect name (the `job:` part was omitted).

The `.replies` queue is auto-deleted.

Clean up this additional queue if it's present.