### PR TITLE
[Sprint 44] XD-2764 Avoid escaping topic name twice

### DIFF
--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -313,7 +313,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 			byte[] utf8 = original.getBytes("UTF-8");
 			for (byte b : utf8) {
 				if ((b >= 'a') && (b <= 'z') || (b >= 'A') && (b <= 'Z') || (b >= '0') && (b <= '9') || (b == '.')
-						|| (b == '-')) {
+						|| (b == '-') || (b == '_')) {
 					result.append((char) b);
 				}
 				else {


### PR DESCRIPTION
Due to a bug in KafkaMessageBus.escapeTopicName(), "_" is re-converted on already escaped topic names (even if it is a valid character). This causes the initialization of the topic states to read the wrong initial offsets, subsequently causing the test to fail. This behaviour is observable only on already cleaned (pruned) topics.