### PR TITLE
[Sprint 44] 1.1.x fix kafka existing topic tests

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
@@ -18,6 +18,7 @@ package org.springframework.xd.dirt.stream;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.xd.dirt.integration.kafka.KafkaMessageBus.escapeTopicName;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,7 +43,6 @@ import org.springframework.integration.kafka.serializer.common.StringDecoder;
 import org.springframework.integration.kafka.support.ZookeeperConnect;
 import org.springframework.integration.kafka.util.MessageUtils;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
 import org.springframework.xd.dirt.integration.kafka.KafkaTestMessageBus;
 import org.springframework.xd.test.kafka.KafkaTestSupport;
 
@@ -83,9 +83,9 @@ public class KafkaSingleNodeStreamDeploymentIntegrationTests extends
 	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3, Map<String, Object> initialTransportState) {
 		DefaultConnectionFactory defaultConnectionFactory = getDefaultConnectionFactory();
 		KafkaTemplate template = new KafkaTemplate(defaultConnectionFactory);
-		String y = receiveFromTopicForQueue(template, "queue:y", initialTransportState);
+		String y = receiveFromTopicForQueue(template, escapeTopicName("queue:y"), initialTransportState);
 		assertTrue(y.endsWith("y")); // bus headers
-		String z = receiveFromTopicForQueue(template, "queue:z", initialTransportState);
+		String z = receiveFromTopicForQueue(template, escapeTopicName("queue:z"), initialTransportState);
 		assertNotNull(z);
 		assertTrue(z.endsWith("z")); // bus headers
 		try {
@@ -116,7 +116,7 @@ public class KafkaSingleNodeStreamDeploymentIntegrationTests extends
 		KafkaTemplate template = new KafkaTemplate(getDefaultConnectionFactory());
 		Map<String, Object> initialOffsets = new HashMap<String, Object>();
 		for (String queueName : queueNames) {
-			String escapedTopicName = KafkaMessageBus.escapeTopicName(queueName);
+			String escapedTopicName = escapeTopicName(queueName);
 			initialOffsets.put(escapedTopicName, getInitialOffset(template, escapedTopicName));
 		}
 		try {
@@ -130,16 +130,15 @@ public class KafkaSingleNodeStreamDeploymentIntegrationTests extends
 
 	private String receiveFromTopicForQueue(KafkaTemplate template, String topicName,
 			Map<String, Object> initialTransportState) {
-		String escapedTopicName = KafkaMessageBus.escapeTopicName(topicName);
-		Partition partition = new Partition(escapedTopicName, 0);
+		Partition partition = new Partition(topicName, 0);
 		Result<KafkaMessageBatch> receive = template.receive(Collections.singleton(new FetchRequest(partition,
-				(Long) initialTransportState.get(escapedTopicName), 1000)));
+				(Long) initialTransportState.get(topicName), 1000)));
 		return MessageUtils.decodePayload(receive.getResult(partition).getMessages().get(0), new StringDecoder());
 	}
 
 	private long getInitialOffset(KafkaTemplate template, String topicName) {
 		try {
-			Partition partition = new Partition(KafkaMessageBus.escapeTopicName(topicName), 0);
+			Partition partition = new Partition(topicName, 0);
 			BrokerAddress leader = template.getConnectionFactory().getLeader(partition);
 			return template.getConnectionFactory().connect(leader)
 					.fetchInitialOffset(OffsetRequest.LatestTime(), partition).getResult(partition);

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
@@ -142,7 +142,7 @@ public class KafkaSingleNodeStreamDeploymentIntegrationTests extends
 			Partition partition = new Partition(KafkaMessageBus.escapeTopicName(topicName), 0);
 			BrokerAddress leader = template.getConnectionFactory().getLeader(partition);
 			return template.getConnectionFactory().connect(leader)
-					.fetchInitialOffset(OffsetRequest.LatestTime()).getResult(partition);
+					.fetchInitialOffset(OffsetRequest.LatestTime(), partition).getResult(partition);
 		}
 		catch (PartitionNotFoundException e) {
 			return 0;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
@@ -115,7 +115,7 @@ public class RabbitSingleNodeStreamDeploymentIntegrationTests extends
 	}
 
 	@Override
-	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3) {
+	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3, Map<String, Object> initialTransportState) {
 		RabbitTemplate template = new RabbitTemplate(rabbitAvailableRule.getResource());
 		Object y = template.receiveAndConvert("xdbus.queue:y");
 		assertNotNull(y);

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RedisSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RedisSingleNodeStreamDeploymentIntegrationTests.java
@@ -16,6 +16,8 @@ package org.springframework.xd.dirt.stream;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Map;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -58,7 +60,7 @@ public class RedisSingleNodeStreamDeploymentIntegrationTests extends
 	}
 
 	@Override
-	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3) {
+	protected void verifyOnDemandQueues(MessageChannel y3, MessageChannel z3, Map<String, Object> initialTransportState) {
 		StringRedisTemplate template = new StringRedisTemplate(redisAvailableRule.getResource());
 		String y = template.boundListOps("queue.queue:y").rightPop();
 		assertNotNull(y);


### PR DESCRIPTION
This is a PR for backporting fixes to Kafka tests to the 1.1 branch

The corresponding commits in the main branch are:

https://github.com/spring-projects/spring-xd/commit/8598f48265c5b5e8fe744869b3ab1c5e7cd420da

https://github.com/spring-projects/spring-xd/commit/a9de9a0ac2006e163433978da067ee5a052bf027

https://github.com/spring-projects/spring-xd/commit/683e35e6e71a3ff77908455cdf811df1caff8f6b

