### PR TITLE
[Sprint 45] [master + backport] XD-2748 Reliable spark streaming receiver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ allprojects {
 		mavenCentral()
 		maven { url 'http://repo.spring.io/milestone' }
 		maven { url 'http://repo.spring.io/libs-milestone' }
+		maven { url 'http://repo.spring.io/libs-snapshot' }
 		maven { url 'http://repo.spring.io/plugins-release' }
 		maven { url 'https://repo.eclipse.org/content/repositories/paho-releases' }
 	}
@@ -95,7 +96,7 @@ ext {
 	splunkVersion = '1.3.0'
 	springBatchAdminMgrVersion = '1.3.0.RELEASE'
 	springIntegrationSplunkVersion = '1.1.0.RELEASE'
-	springIntegrationKafkaVersion = '1.0.0.RELEASE'
+	springIntegrationKafkaVersion = '1.0.1.BUILD-SNAPSHOT'
 	kafkaVersion = '0.8.1.1'
 	springShellVersion = '1.1.0.RELEASE'
 	zookeeperVersion = '3.4.6'

--- a/config/servers.yml
+++ b/config/servers.yml
@@ -73,6 +73,7 @@
 #        batchingEnabled:           false
 #        batchSize:                 200
 #        batchTimeout:              5000
+#        autoCommitEnabled:         true
 
 #Disable batch database initialization
 #spring:

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
@@ -43,6 +43,8 @@ import org.springframework.xd.dirt.util.ConfigLocations;
 		ConfigLocations.XD_CONFIG_ROOT + "bus/codec.xml"})
 class MessageBusConfiguration {
 
+	private static final String RABBIT_ACKMODE_PROPERTY = "xd.messagebus.rabbit.default.ackMode";
+
 	/**
 	 * This method called by {@link MessageBusReceiver} and {@link MessageBusSender} to setup
 	 * message bus configuration at the spark module executor process. This configuration
@@ -54,6 +56,10 @@ class MessageBusConfiguration {
 	 */
 	static ConfigurableApplicationContext createApplicationContext(final Properties properties) {
 		String transport = properties.getProperty("XD_TRANSPORT");
+		if (properties.getProperty(RABBIT_ACKMODE_PROPERTY) != null) {
+			properties.setProperty(RABBIT_ACKMODE_PROPERTY, "MANUAL");
+		}
+		properties.setProperty("isKafkaAutoCommitEnabled", "false");
 		SpringApplicationBuilder application = new SpringApplicationBuilder()
 				.sources(MessageBusConfiguration.class)
 				// ensure the properties are added at the first precedence level

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
@@ -56,9 +56,8 @@ class MessageBusConfiguration {
 	 */
 	static ConfigurableApplicationContext createApplicationContext(final Properties properties) {
 		String transport = properties.getProperty("XD_TRANSPORT");
-		if (properties.getProperty(RABBIT_ACKMODE_PROPERTY) != null) {
-			properties.setProperty(RABBIT_ACKMODE_PROPERTY, "MANUAL");
-		}
+		// Set Rabbit message bus acknowledgement mode to 'MANUAL'
+		properties.setProperty(RABBIT_ACKMODE_PROPERTY, "MANUAL");
 		properties.setProperty("isKafkaAutoCommitEnabled", "false");
 		SpringApplicationBuilder application = new SpringApplicationBuilder()
 				.sources(MessageBusConfiguration.class)

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
@@ -45,6 +45,8 @@ class MessageBusConfiguration {
 
 	private static final String RABBIT_ACKMODE_PROPERTY = "xd.messagebus.rabbit.default.ackMode";
 
+	private static final String KAFKA_AUTOCOMMIT_PROPERTY = "xd.messagebus.kafka.default.autoCommitEnabled";
+
 	/**
 	 * This method called by {@link MessageBusReceiver} and {@link MessageBusSender} to setup
 	 * message bus configuration at the spark module executor process. This configuration
@@ -58,7 +60,7 @@ class MessageBusConfiguration {
 		String transport = properties.getProperty("XD_TRANSPORT");
 		// Set Rabbit message bus acknowledgement mode to 'MANUAL'
 		properties.setProperty(RABBIT_ACKMODE_PROPERTY, "MANUAL");
-		properties.setProperty("isKafkaAutoCommitEnabled", "false");
+		properties.setProperty(KAFKA_AUTOCOMMIT_PROPERTY, "false");
 		SpringApplicationBuilder application = new SpringApplicationBuilder()
 				.sources(MessageBusConfiguration.class)
 				// ensure the properties are added at the first precedence level

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
@@ -145,7 +145,7 @@ class MessageBusReceiver extends Receiver {
 					headersListToAck.add(headersList.take());
 				}
 				catch (InterruptedException ie) {
-					logger.error("Interrupted exception while getting message headers from the local blocking queue.");
+					Thread.currentThread().interrupt();
 				}
 			}
 			((MessageBusSupport) messageBus).doManualAck(headersListToAck);
@@ -175,7 +175,7 @@ class MessageBusReceiver extends Receiver {
 				headersList.put(message.getHeaders());
 			}
 			catch (InterruptedException ie) {
-				logger.error("Interrupted exception while adding message headers to local blocking queue.");
+				Thread.currentThread().interrupt();
 			}
 			blockGenerator.addDataWithCallback(message.getPayload(), message.getHeaders());
 			return true;

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -155,6 +155,7 @@ xd:
         concurrency:               1
         requiredAcks:              1
         compressionCodec:          default
+        autoCommitEnabled:         true
   security:
     authorization:
       rules:

--- a/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
+++ b/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
@@ -25,6 +25,7 @@
 		<property name="defaultConcurrency" value="${xd.messagebus.kafka.default.concurrency}"/>
 		<property name="defaultRequiredAcks" value="${xd.messagebus.kafka.default.requiredAcks}"/>
 		<property name="defaultCompressionCodec" value="${xd.messagebus.kafka.default.compressionCodec}"/>
+		<property name="defaultAutoCommitEnabled" value="${xd.messagebus.kafka.default.autoCommitEnabled}"/>
 		<property name="offsetStoreTopic" value="${xd.messagebus.kafka.offsetStoreTopic}"/>
 	</bean>
 

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -696,8 +696,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		}
 		for (Map.Entry<Object, Long> entry : channelsToAck.entrySet()) {
 			try {
-				Channel channel = (Channel) entry.getKey();
-				channel.basicAck(entry.getValue(), true);
+				((Channel) entry.getKey()).basicAck(entry.getValue(), true);
 			}
 			catch (IOException e) {
 				logger.error("Exception while manually acknowledging " + e);

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -691,8 +691,6 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 			if (messageHeaders.containsKey(AmqpHeaders.CHANNEL)) {
 				Channel channel = (com.rabbitmq.client.Channel) messageHeaders.get(AmqpHeaders.CHANNEL);
 				Long deliveryTag = (Long) messageHeaders.get(AmqpHeaders.DELIVERY_TAG);
-				// todo: If the order of messages isn't preserved in spite of storing the incoming
-				// todo: messages into LinkedList, how do we handle the deliveryTag?
 				channelsToAck.put(channel, deliveryTag);
 			}
 		}

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -71,6 +71,7 @@ import org.springframework.xd.dirt.integration.bus.serializer.SerializationExcep
 /**
  * @author David Turanski
  * @author Gary Russell
+ * @author Ilayaperumal Gopinathan
  */
 public abstract class MessageBusSupport
 		implements MessageBus, ApplicationContextAware, InitializingBean, IntegrationEvaluationContextAware {
@@ -122,7 +123,7 @@ public abstract class MessageBusSupport
 
 	protected static final Set<Object> PRODUCER_STANDARD_PROPERTIES = new HashSet<Object>(Arrays.asList(
 			BusProperties.NEXT_MODULE_COUNT
-			));
+	));
 
 
 	protected static final Set<Object> CONSUMER_RETRY_PROPERTIES = new HashSet<Object>(Arrays.asList(new String[] {
@@ -1101,6 +1102,21 @@ public abstract class MessageBusSupport
 			this.outputChannel.send(message);
 		}
 
+	}
+
+	/**
+	 * No op method that can be implemented by specific message bus to store message headers to acknowledge
+	 * the messages manually later.
+	 *
+	 * @param messageHeaders the message headers
+	 */
+	public void storeForManualAck(MessageHeaders messageHeaders) {
+	}
+
+	/**
+	 * Perform manual acknowledgement based on the metadata stored in message bus.
+	 */
+	public void doManualAck() {
 	}
 
 }

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -1105,18 +1107,9 @@ public abstract class MessageBusSupport
 	}
 
 	/**
-	 * No op method that can be implemented by specific message bus to store message headers to acknowledge
-	 * the messages manually later.
-	 *
-	 * @param messageHeaders the message headers
-	 */
-	public void storeForManualAck(MessageHeaders messageHeaders) {
-	}
-
-	/**
 	 * Perform manual acknowledgement based on the metadata stored in message bus.
 	 */
-	public void doManualAck() {
+	public void doManualAck(LinkedList<MessageHeaders> messageHeaders) {
 	}
 
 }


### PR DESCRIPTION
 - Acknowledge the messages only after they are stored/replicated in spark storage
   - For Rabbit messagebus set acknowledgement mode to `MANUAL` at `MessageBusConfiguration` for spark streaming
module. This way, it is the responsibility of the `MessageBusReceiver` to acknowledge the messages
after the data blocks are persisted in spark storage.
   - For kafka messagebus,  update offset only after the messages are persisted
   - Add message headers that can be used to send acknowledgement into temporary object in the messagebus
   - Implement a `BlockGeneratorListener` and acknowledge the messages after the data is pushed
to spark storage