### PR TITLE
[Sprint 44] [master + backport] XD-2671 Handle stream/job undeploy when deployment in progress

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/DeploymentListener.java
@@ -57,8 +57,10 @@ import org.springframework.xd.module.core.Module;
 /**
  * @author Mark Fisher
  * @author David Turanski
- * @author Ilayaperumal Gopinathan Listener for deployment requests for a container instance under {@link
- *         org.springframework.xd.dirt.zookeeper.Paths#DEPLOYMENTS}.
+ * @author Ilayaperumal Gopinathan
+ *
+ * Listener for deployment requests for a container instance under
+ * {@link org.springframework.xd.dirt.zookeeper.Paths#DEPLOYMENTS}.
  */
 class DeploymentListener implements PathChildrenCacheListener {
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ModuleRedeployer.java
@@ -496,12 +496,13 @@ public abstract class ModuleRedeployer {
 
 
 	/**
-	 * Predicate used to determine if a container should be returned by {@link #match}.
+	 * Predicate used to determine if a container should be returned by {@link #containerMatcher}.
 	 */
 	private class MatchingPredicate implements Predicate<Container> {
 
 		/**
-		 * Set of container names that should <b>not</b> be returned by {@link #filterContainers}.
+		 * Set of container names that should <b>not</b> be returned by
+		 * {@link #apply(org.springframework.xd.dirt.cluster.Container)}.
 		 */
 		private final Set<String> exclusions;
 


### PR DESCRIPTION
   - Check for `NoNodException` on the stream/job deployment status path
and if the exception is thrown, then the stream/job is considered to
have been un-deployed. Then, proceed with deletion of stream deployment
path and module deployment request paths.