### PR TITLE
[Sprint 45] [Backport] XD-2798 Fix bean definitions for Redis and In-Memory profiles

### DIFF
--- a/modules/source/kafka/config/kafka.xml
+++ b/modules/source/kafka/config/kafka.xml
@@ -76,11 +76,10 @@
 
 		<bean id="offsetManager" class="org.springframework.integration.kafka.listener.MetadataStoreOffsetManager">
 			<constructor-arg index="0" ref="connectionFactory"/>
-			<constructor-arg index="1" value="${topic}"/>
-			<constructor-arg index="2" ref="initialOffsetsMap"/>
+			<constructor-arg index="1" ref="initialOffsetsMap"/>
 			<property name="consumerId" value="${groupId}"/>
 			<property name="metadataStore" ref="namespaceMetadataStore"/>
-			<property name="referenceTimestamp" value="#{autoOffsetReset.code}"/>
+			<property name="referenceTimestamp" value="${autoOffsetResetValue}"/>
 		</bean>
 	</beans>
 


### PR DESCRIPTION
To test, start the built Spring XD, start a Kafka broker that has data in a topic (use perf-test to populate), an create the stream:

`stream create drain --definition "kafka --zkconnect=localhost:2181 --topic=test-simple --offsetStorage=inmemory | log" --deploy`