### PR TITLE
[Sprint: 45] [Backport] XD-2704: Have documentation reside in the main repo

### DIFF
--- a/302.asciidoc
+++ b/302.asciidoc
@@ -1,0 +1,8 @@
+This wiki has moved!
+
+The documentation for Spring XD is now managed in the main git repository.
+
+To read the latest version online, browse to http://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/
+
+If you'd like to contribute to the documentation (even fixing a minor typo), just issue a regular PR against the main repository.
+The documentation sources are written in Asciidoc and reside https://github.com/spring-projects/spring-xd/tree/master/src/docs/asciidoc[here].

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,11 @@ buildscript {
 	}
 }
 
+task version << {
+	println "Gradle version: " + project.getGradle().getGradleVersion()
+	println "Groovy version: " + GroovySystem.getVersion()
+}
+
 ext {
 	linkHomepage = 'https://github.com/spring-projects/spring-xd'
 	linkCi = 'https://build.spring.io/browse/XD'

--- a/convertDocs.sh
+++ b/convertDocs.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+git clone https://github.com/spring-projects/spring-xd.wiki.git docs-temp
+mkdir -p src/docs/asciidoc
+cp -r docs-temp/guide/*  src/docs/asciidoc
+cp -r docs-temp/images/* src/docs/asciidoc/images
+
+
+# FullGuide -> index
+mv src/docs/asciidoc/FullGuide.adoc src/docs/asciidoc/index.asciidoc
+mv src/docs/asciidoc/FullGuide-docinfo.xml src/docs/asciidoc/index-docinfo.xml
+
+# Get rid of GitHub wiki specific 'pages'
+rm src/docs/asciidoc/_*
+
+
+groovy -p -i -e '( line =~ /link:(?!http)(.*?\])/ ).replaceAll("xref:\$1")' `find src/docs/asciidoc/*.asciidoc`
+
+rm -fR docs-temp

--- a/documentation-toolchain/src/main/java/org/springframework/xd/documentation/AsciidocLinkChecker.java
+++ b/documentation-toolchain/src/main/java/org/springframework/xd/documentation/AsciidocLinkChecker.java
@@ -48,7 +48,7 @@ public class AsciidocLinkChecker {
 
 	private static final Pattern ANCHOR_PATTERN = Pattern.compile("^\\[\\[([a-zA-Z_0-9\\-]+)\\]\\]");
 
-	private static final Pattern LINK_PATTERN = Pattern.compile("link:([a-zA-Z_0-9\\-]+)#([a-zA-Z_0-9\\-]+)");
+	private static final Pattern LINK_PATTERN = Pattern.compile("xref:([a-zA-Z_0-9\\-]+)#([a-zA-Z_0-9\\-]+)");
 
 	private Set<Link> links = new HashSet<AsciidocLinkChecker.Link>();
 

--- a/gradle/build-dist.gradle
+++ b/gradle/build-dist.gradle
@@ -153,7 +153,7 @@ task docsZip(type: Zip) {
 	from ("$buildDir/html") { into "reference/html" }
 }
 
-task distZip(type: Zip, dependsOn: [asciidoctorHtml, copyInstall], overwrite: true) {
+task distZip(type: Zip, dependsOn: [asciidoctor, copyInstall], overwrite: true) {
 	group = 'Application'
 	classifier = 'dist'
 	description = "Bundles the XD project and associated installs with libs and OS specific scripts as a zip file."
@@ -165,7 +165,7 @@ task distZip(type: Zip, dependsOn: [asciidoctorHtml, copyInstall], overwrite: tr
 	from ("$buildDir/html") { into "${baseDir}/docs" }
 }
 
-task distTar(type: Tar, dependsOn: [asciidoctorHtml, copyInstall], overwrite: true) {
+task distTar(type: Tar, dependsOn: [asciidoctor, copyInstall], overwrite: true) {
 	group = 'Application'
 	classifier = ''
 	description = "Bundles the XD project and associated installs with libs and OS specific scripts as a tar file."

--- a/gradle/build-docs.gradle
+++ b/gradle/build-docs.gradle
@@ -9,211 +9,78 @@ buildscript {
 	dependencies {
 		classpath 'io.spring.gradle:docbook-reference-plugin:0.3.0'
 		classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.0'
-		classpath 'org.ajoberstar:gradle-git:0.8.0'
+		//classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.6' // asciidoctor pdf still has issues with callouts, etc. Still relying on docbook+pdf for now
 	}
 
 }
 
-import org.ajoberstar.grgit.*
-import org.ajoberstar.grgit.auth.AuthConfig
-import org.apache.tools.ant.filters.TokenFilter
-import org.asciidoctor.gradle.*
+def docsDir = 'src/docs/asciidoc' // Will be default with newer asciidoctor plugin
 
-task(pullDocs) {
-	if (project.gradle.startParameter.offline) {
-		enabled = false
-	}
-	ext.cloneDestination = file("$buildDir/asciidoc-raw")
-}
-
-pullDocs << {
-
-	def xdGit = Grgit.open(rootProject.projectDir)
-	def springXdBranchName = xdGit.branch.getCurrent().name
-
-	println "Spring XD Branch: $springXdBranchName"
-	println "Spring XD Version: $version"
-
-	if (rootProject.hasProperty('wikiBranch')) {
-		ext.wikiBranch = rootProject.getProperty('wikiBranch')
-		println "Using custom wiki branch: ${ext.wikiBranch}"
-	}
-	else {
-		ext.wikiBranch = 'origin/' + springXdBranchName;
-		println "Using default wiki branch: ${ext.wikiBranch}"
-	}
-
-	def uri = "https://github.com/spring-projects/spring-xd.wiki.git"
-
-	if (cloneDestination.exists()) {
-		cloneDestination.deleteDir()
-		file("$buildDir/asciidoc").deleteDir()
-	}
-
-	println "Cloning docs: $uri to ${ext.cloneDestination}"
-	def repo = Grgit.clone(dir: cloneDestination, uri: uri)
-	println "Switching to wiki branch: ${ext.wikiBranch}"
-
-	try {
-		repo.checkout(branch: ext.wikiBranch, createBranch: false)
-	}
-	catch (org.ajoberstar.grgit.exception.GrgitException e) {
-		throw new GradleException("Error while switching to branch: ${ext.wikiBranch}. Cause: "
-			+ e.getCause().getMessage(), e)
-	}
-}
-
-task moduleOptionsReferenceDoc(type: JavaExec, dependsOn: [":spring-xd-dirt:build", ":spring-xd-shell:compileTestJava", pullDocs]) {
+task moduleOptionsReferenceDoc(type: JavaExec, dependsOn: [":spring-xd-dirt:build", ":spring-xd-shell:compileTestJava"]) {
 	classpath = project(':spring-xd-shell').sourceSets.test.runtimeClasspath
 	main = 'org.springframework.xd.shell.util.ModuleOptionsReferenceDoc'
 	args = [
-		"${pullDocs.cloneDestination}/guide/Sources.asciidoc",
-		"${pullDocs.cloneDestination}/guide/Processors.asciidoc",
-		"${pullDocs.cloneDestination}/guide/Sinks.asciidoc",
-		"${pullDocs.cloneDestination}/guide/Batch-Jobs.asciidoc",
-		"${pullDocs.cloneDestination}/guide/Analytics.asciidoc",
+		"$docsDir/Sources.asciidoc",
+		"$docsDir/Processors.asciidoc",
+		"$docsDir/Sinks.asciidoc",
+		"$docsDir/Batch-Jobs.asciidoc",
+		"$docsDir/Analytics.asciidoc",
 	]
 }
 
-task shellReferenceDoc(type: JavaExec, dependsOn: [":spring-xd-shell:compileTestJava", pullDocs]) {
+task shellReferenceDoc(type: JavaExec, dependsOn: [":spring-xd-shell:compileTestJava"]) {
 	classpath = project(':spring-xd-shell').sourceSets.test.runtimeClasspath
 	main = 'org.springframework.xd.shell.util.ReferenceDoc'
 	args = [
-		"$rootDir/build/asciidoc-raw/guide/ShellReference.asciidoc"
+		"$docsDir/ShellReference.asciidoc"
 	]
 }
 
-task pushGeneratedDocs(dependsOn: [moduleOptionsReferenceDoc, shellReferenceDoc]) << {
-	def docsRepo = Grgit.open(pullDocs.cloneDestination)
-
-	try {
-		docsRepo.checkout(branch: pullDocs.wikiBranch, createBranch: false)
-	}
-	catch (org.ajoberstar.grgit.exception.GrgitException e) {
-		throw new GradleException("Error while switching to branch: ${pullDocs.wikiBranch}. Cause: "
-			+ e.getCause().getMessage(), e)
-	}
-
-	println("Pushing docs to ${pullDocs.cloneDestination}, Branch: ${pullDocs.wikiBranch}")
-
-	def xdRepo = Grgit.open(file("$rootDir"))
-	docsRepo.add(patterns: ['.'])
-	docsRepo.commit(message: "Automated doc generation in synch with XD ${xdRepo.head().id}")
-
-	try {
-		docsRepo.push()
-	}
-	catch (org.ajoberstar.grgit.exception.GrgitException e) {
-		throw new GradleException("Error while pushing to branch: ${pullDocs.wikiBranch}. Cause: "
-			+ e.getCause().getMessage(), e)
-	}
-
-	println("Pushed docs to ${pullDocs.cloneDestination}, Branch: ${pullDocs.wikiBranch}")
-}
-
-task transformDocs(type: Copy, dependsOn: [pullDocs, shellReferenceDoc, moduleOptionsReferenceDoc]) {
-	from(pullDocs.cloneDestination) {
-		include  "**/*.asciidoc"
-		filter { line ->
-			// TODO: refine regex to only match local documents
-			def match = (line =~ /link:(.*?)#(.*?)\[(.*?)\]/)
-			if (match) match.replaceAll('xref:$2[$3]') else line
-		}
-	}
-	from(pullDocs.cloneDestination) { exclude "**/*.asciidoc" }
-	into("$buildDir/asciidoc")
-
-	doLast {
-		new File("$buildDir/asciidoc/guide/FullGuide.adoc")
-			.renameTo(new File("$buildDir/asciidoc/guide/index.adoc"))
-		new File("$buildDir/asciidoc/guide/FullGuide-docinfo.xml")
-			.renameTo(new File("$buildDir/asciidoc/guide/index-docinfo.xml"))
-
-	}
-}
-
-task checkDocsLinks(type: JavaExec, dependsOn: [":documentation-toolchain:compileJava", pullDocs, shellReferenceDoc, moduleOptionsReferenceDoc]) {
+task checkDocsLinks(type: JavaExec, dependsOn: [":documentation-toolchain:compileJava", shellReferenceDoc, moduleOptionsReferenceDoc]) {
 	classpath = project(':documentation-toolchain').sourceSets.main.runtimeClasspath
 	main = 'org.springframework.xd.documentation.AsciidocLinkChecker'
 	args = [
-		"file:${pullDocs.cloneDestination}/guide/*.asciidoc"
+		"file:$docsDir/*.asciidoc"
 	]
 }
+
 
 apply plugin: org.asciidoctor.gradle.AsciidoctorPlugin
 
-task asciidoctorDocbook(type: AsciidoctorTask, dependsOn: [	transformDocs, shellReferenceDoc, moduleOptionsReferenceDoc] ) {
-	classpath = project.configurations.asciidoctor
-	sourceDocumentName = file("$buildDir/asciidoc/guide/index.adoc")
-	sourceDir = file("$buildDir/asciidoc/guide")
-	baseDir = sourceDir
-	outputDir = file("$buildDir/docbook")
-	backend = "docbook"
+asciidoctor {
+	sourceDir file("$docsDir")
+	sourceDocumentNames = files("$docsDir/index.asciidoc") // Change in >= 1.5.1
+	outputDir file("$buildDir/html")
+	backends = ['html5', 'docbook']
+	logDocuments = true
 	options = [
-		attributes: [
-			docinfo: '',
-			'compat-mode': '',
-			appversion: "$version"
-		]
-	]
-
-	doLast {
-		copy {
-			from "$buildDir/asciidoc/images"
-			into "$buildDir/docbook/images"
-		}
-	}
-}
-
-task asciidoctorHtml(type: AsciidoctorTask, dependsOn: [transformDocs, shellReferenceDoc, moduleOptionsReferenceDoc ]) {
-	group = 'Documentation'
-	description = 'Generate the HTML documentation using Asciidoctor'
-
-	classpath = project.configurations.asciidoctor
-	sourceDocumentName = file("$buildDir/asciidoc/guide/index.adoc")
-	sourceDir = file("$buildDir/asciidoc/guide")
-	baseDir = sourceDir
-	outputDir = file("$buildDir/html")
-	backend = "html5"
-	options = [
+		doctype: 'book',
 		attributes: [
 			docinfo: '',
 			toc2: '',
 			'compat-mode': '',
-			imagesdir: 'images/',
-			stylesdir: "$baseDir/stylesheets/",
+			imagesdir: '',
+			stylesdir: "stylesheets/",
 			stylesheet: 'golo.css',
 			appversion: "$version",
 			'source-highlighter': 'highlightjs'
 		]
 	]
-
-	doFirst {
-		copy {
-			from "$buildDir/asciidoc/guide/images"
-			into "$buildDir/html/images"
-		}
-		copy {
-			from "$buildDir/asciidoc/images"
-			into "$buildDir/html/images/images"
-		}
-		copy {
-			from "$buildDir/asciidoc/guide/stylesheets"
-			into "$buildDir/html/stylesheets"
-		}
-	}
 }
+
+asciidoctor.dependsOn ([checkDocsLinks, shellReferenceDoc, moduleOptionsReferenceDoc])
 
 apply plugin: DocbookReferencePlugin
 
 reference {
 	sourceFileName = 'index.xml'
-	sourceDir = file("$buildDir/docbook")
+	sourceDir = file("$buildDir/html")
 	pdfFilename = 'spring-xd-reference.pdf'
 	expandPlaceholders = ''
 }
 
-reference.dependsOn asciidoctorDocbook
+reference.dependsOn asciidoctor
+
 
 task api(type: Javadoc) {
 	group = 'Documentation'
@@ -241,3 +108,4 @@ task api(type: Javadoc) {
 		}
 	}
 }
+

--- a/migrateWiki.sh
+++ b/migrateWiki.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+rm -fR /tmp/spring-xd.wiki
+
+cd /tmp
+git clone https://github.com/spring-projects/spring-xd.wiki.git /tmp/spring-xd.wiki
+rm /tmp/spring-xd.wiki/guide/_*.asciidoc
+rm /tmp/spring-xd.wiki/guide/*.adoc
+rm /tmp/spring-xd.wiki/guide/*.xml
+find /tmp/spring-xd.wiki/guide -name '*.asciidoc' -exec cp 302.asciidoc {} \;
+


### PR DESCRIPTION
This PR does the following:
- remove everything related to pulling the docs from the wiki repo
- use a single asciidoctor task, configured with two backends, expecting to find the asciidoctor files in `src/docs/asciidoc`
- provide a shell script that automates the following, which the poor soul merging this PR should run:
 1. clone the latest version of the docs
 2. rename `FullGuide` to `index`
 3. rewrite all `link`s to `xref:`
 4. put images directly inside `images`, where they are correctly picked up in all settings, including live-preview in the browser with extensions, for example
- re-installs the link checking task, which somehow got lost previously :(

I've also explored the following:
  1. upgrading the asciidoctor plugin. Sadly, this requires newer groovy (ie newer gradle, even the compat package does not work). In turn, this requires changes to https://github.com/spring-projects/spring-xd/blob/master/spring-xd-starters/spring-xd-module-parent/publish-maven.gradle#L70 
  2. so I looked into https://gradle.org/docs/current/userguide/publishing_maven.html, seems like a big change
  3. Also looked into getting rid of the docbook toolchain altogether. There are still some issues, but this could be worth it

To merge this PR:
 1. run `./convertDocs.sh`
 2. verify
 3. check in src/docs under source control
 4. convertDocs.sh can be deleted
 5. I suggest pasting in this PR comments the sha1 of the wiki repo at the time of merging, as the wiki should then be considered decommissioned

I have already fixed quite a few issues on the wiki directly (master), so this should pass properly