### PR TITLE
[Sprint 45] XD-2804: Remove trailing spaces in module properties file

### DIFF
--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolver.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolver.java
@@ -136,7 +136,7 @@ public class DefaultModuleOptionsMetadataResolver implements ModuleOptionsMetada
 				String type = props.getProperty(String.format("options.%s.type", optionName));
 				Class<?> clazz = null;
 				if (type != null) {
-                    String typeTrimmed = type.trim();
+					String typeTrimmed = type.trim();
 					if (SHORT_CLASSNAMES.containsKey(typeTrimmed)) {
 						clazz = SHORT_CLASSNAMES.get(typeTrimmed);
 					}

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolver.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolver.java
@@ -136,17 +136,18 @@ public class DefaultModuleOptionsMetadataResolver implements ModuleOptionsMetada
 				String type = props.getProperty(String.format("options.%s.type", optionName));
 				Class<?> clazz = null;
 				if (type != null) {
-					if (SHORT_CLASSNAMES.containsKey(type)) {
-						clazz = SHORT_CLASSNAMES.get(type);
+                    String typeTrimmed = type.trim();
+					if (SHORT_CLASSNAMES.containsKey(typeTrimmed)) {
+						clazz = SHORT_CLASSNAMES.get(typeTrimmed);
 					}
 					else {
 						try {
-							clazz = Class.forName(type);
+							clazz = Class.forName(typeTrimmed);
 						}
 						catch (ClassNotFoundException e) {
 							throw new IllegalStateException("Can't find class used for type of option '"
 									+ optionName
-									+ "': " + type);
+									+ "': " + typeTrimmed);
 						}
 					}
 				}
@@ -195,7 +196,7 @@ public class DefaultModuleOptionsMetadataResolver implements ModuleOptionsMetada
 				String pojoClass = props.getProperty(OPTIONS_CLASS);
 				if (pojoClass != null) {
 					List<ModuleOptionsMetadata> mixins = new ArrayList<ModuleOptionsMetadata>();
-					createPojoOptionsMetadata(classLoaderToUse, pojoClass, mixins);
+					createPojoOptionsMetadata(classLoaderToUse, pojoClass.trim(), mixins);
 					return mixins.size() == 1 ? mixins.get(0) : new FlattenedCompositeModuleOptionsMetadata(mixins);
 				}
 				else {

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolverTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolverTests.java
@@ -86,26 +86,26 @@ public class DefaultModuleOptionsMetadataResolverTests {
 		metadataResolver.resolve(definition);
 	}
 
-    @Test
-    public void testNormalMetadataTypeValueTrimmed() {
-        String resource = "classpath:/DefaultModuleOptionsMetadataResolverTests-modules/source/module5/";
-        ModuleDefinition definition = ModuleDefinitions.simple("module5", source, resource);
-        ModuleOptionsMetadata metadata = metadataResolver.resolve(definition);
-        assertThat(metadata, hasItem(moduleOptionNamed("foo")));
+	@Test
+	public void testNormalMetadataTypeValueTrimmed() {
+		String resource = "classpath:/DefaultModuleOptionsMetadataResolverTests-modules/source/module5/";
+		ModuleDefinition definition = ModuleDefinitions.simple("module5", source, resource);
+		ModuleOptionsMetadata metadata = metadataResolver.resolve(definition);
+		assertThat(metadata, hasItem(moduleOptionNamed("foo")));
 
-        ModuleOption foo = metadata.iterator().next();
-        assertThat(foo.getType(), equalTo((Class) String.class));
-    }
+		ModuleOption foo = metadata.iterator().next();
+		assertThat(foo.getType(), equalTo((Class) String.class));
+	}
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testOptionClassValueTrimmed() {
-        String resource = "classpath:/DefaultModuleOptionsMetadataResolverTests-modules/source/module6/";
-        ModuleDefinition definition = ModuleDefinitions.simple("module6", source, resource);
-        ModuleOptionsMetadata metadata = metadataResolver.resolve(definition);
-        assertThat(
-                metadata,
-                containsInAnyOrder(moduleOptionNamed("bar"), moduleOptionNamed("foo")));
-    }
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testOptionClassValueTrimmed() {
+		String resource = "classpath:/DefaultModuleOptionsMetadataResolverTests-modules/source/module6/";
+		ModuleDefinition definition = ModuleDefinitions.simple("module6", source, resource);
+		ModuleOptionsMetadata metadata = metadataResolver.resolve(definition);
+		assertThat(
+				metadata,
+				containsInAnyOrder(moduleOptionNamed("bar"), moduleOptionNamed("foo")));
+	}
 
 }

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolverTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolverTests.java
@@ -45,7 +45,6 @@ public class DefaultModuleOptionsMetadataResolverTests {
 		assertThat(
 				metadata,
 				containsInAnyOrder(moduleOptionNamed("bar"), moduleOptionNamed("foo")));
-
 	}
 
 	@Test
@@ -86,4 +85,27 @@ public class DefaultModuleOptionsMetadataResolverTests {
 		ModuleDefinition definition = ModuleDefinitions.simple("module4", source, resource);
 		metadataResolver.resolve(definition);
 	}
+
+    @Test
+    public void testNormalMetadataTypeValueTrimmed() {
+        String resource = "classpath:/DefaultModuleOptionsMetadataResolverTests-modules/source/module5/";
+        ModuleDefinition definition = ModuleDefinitions.simple("module5", source, resource);
+        ModuleOptionsMetadata metadata = metadataResolver.resolve(definition);
+        assertThat(metadata, hasItem(moduleOptionNamed("foo")));
+
+        ModuleOption foo = metadata.iterator().next();
+        assertThat(foo.getType(), equalTo((Class) String.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testOptionClassValueTrimmed() {
+        String resource = "classpath:/DefaultModuleOptionsMetadataResolverTests-modules/source/module6/";
+        ModuleDefinition definition = ModuleDefinitions.simple("module6", source, resource);
+        ModuleOptionsMetadata metadata = metadataResolver.resolve(definition);
+        assertThat(
+                metadata,
+                containsInAnyOrder(moduleOptionNamed("bar"), moduleOptionNamed("foo")));
+    }
+
 }

--- a/spring-xd-module/src/test/resources/DefaultModuleOptionsMetadataResolverTests-modules/source/module5/config/module5.properties
+++ b/spring-xd-module/src/test/resources/DefaultModuleOptionsMetadataResolverTests-modules/source/module5/config/module5.properties
@@ -1,0 +1,2 @@
+options.foo.description = this is foo field
+options.foo.type = String 

--- a/spring-xd-module/src/test/resources/DefaultModuleOptionsMetadataResolverTests-modules/source/module5/config/module5.xml
+++ b/spring-xd-module/src/test/resources/DefaultModuleOptionsMetadataResolverTests-modules/source/module5/config/module5.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:beans="http://www.springframework.org/schema/beans"
+             xmlns:file="http://www.springframework.org/schema/integration/file"
+             xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration
+		http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/file
+		http://www.springframework.org/schema/integration/file/spring-integration-file.xsd">
+</beans:beans>

--- a/spring-xd-module/src/test/resources/DefaultModuleOptionsMetadataResolverTests-modules/source/module6/config/module6.properties
+++ b/spring-xd-module/src/test/resources/DefaultModuleOptionsMetadataResolverTests-modules/source/module6/config/module6.properties
@@ -1,0 +1,1 @@
+options_class =   org.springframework.xd.module.options.BackingPojo 

--- a/spring-xd-module/src/test/resources/DefaultModuleOptionsMetadataResolverTests-modules/source/module6/config/module6.xml
+++ b/spring-xd-module/src/test/resources/DefaultModuleOptionsMetadataResolverTests-modules/source/module6/config/module6.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:file="http://www.springframework.org/schema/integration/file"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration
+		http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/file
+		http://www.springframework.org/schema/integration/file/spring-integration-file.xsd">
+</beans:beans>


### PR DESCRIPTION
Removing trailing whitespaces on user supplied class names (options.***.type and options_class). 
Other user supplied values unchanged assuming that in some cases whitespaces are desired e.g. storing a common prefix in property.