### PR TITLE
[Sprint: 45] [Backport] XD-2767: JMS Source Recovery

### DIFF
--- a/modules/source/jms/config/jms.xml
+++ b/modules/source/jms/config/jms.xml
@@ -11,16 +11,36 @@
 
 	<import resource="../../../common/jms-${provider}-infrastructure-context.xml"/>
 
-	<int-jms:message-driven-channel-adapter id="jmsSource"
-		auto-startup="false"
-		destination-name="${destination}"
-		pub-sub-domain="${pubSub}"
-		subscription-durable="${durableSubscription}"
-		durable-subscription-name="${subscriptionName:#{null}}"
-		client-id="${clientId:#{null}}"
-		channel="output"
-		connection-factory="connectionFactory"/>
-
 	<int:channel id="output"/>
+
+	<!-- profiles required because container-class cannot be variable; see INT-3677/SPR-12817 -->
+
+	<beans profile="dmlc">
+		<int-jms:message-driven-channel-adapter id="jmsSource"
+			auto-startup="false"
+			destination-name="${destination}"
+			pub-sub-domain="${pubSub}"
+			subscription-durable="${durableSubscription}"
+			durable-subscription-name="${subscriptionName:#{null}}"
+			client-id="${clientId:#{null}}"
+			channel="output"
+			acknowledge="${acknowledge}"
+			container-class="org.springframework.jms.listener.DefaultMessageListenerContainer"
+			connection-factory="connectionFactory"/>
+	</beans>
+
+	<beans profile="smlc">
+		<int-jms:message-driven-channel-adapter id="jmsSource"
+			auto-startup="false"
+			destination-name="${destination}"
+			pub-sub-domain="${pubSub}"
+			subscription-durable="${durableSubscription}"
+			durable-subscription-name="${subscriptionName:#{null}}"
+			client-id="${clientId:#{null}}"
+			channel="output"
+			acknowledge="${acknowledge}"
+			container-class="org.springframework.jms.listener.SimpleMessageListenerContainer"
+			connection-factory="connectionFactory"/>
+	</beans>
 
 </beans>

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/JmsSourceModuleOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/JmsSourceModuleOptionsMetadata.java
@@ -19,6 +19,7 @@ package org.springframework.xd.dirt.modules.metadata;
 import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_STREAM_NAME;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 import org.springframework.xd.module.options.spi.ModuleOption;
 import org.springframework.xd.module.options.spi.ProfileNamesProvider;
@@ -76,6 +77,7 @@ public class JmsSourceModuleOptionsMetadata implements ProfileNamesProvider {
 		return clientId;
 	}
 
+	@Pattern(regexp = "(auto|transacted|dups-ok|client)")
 	public String getAcknowledge() {
 		return acknowledge;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/JmsSourceModuleOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/JmsSourceModuleOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,16 @@ import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_ST
 import javax.validation.constraints.NotNull;
 
 import org.springframework.xd.module.options.spi.ModuleOption;
+import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 
 
 /**
  * Captures options for the {@code jms} source module.
- * 
- * @author Eric Bottard 
+ *
+ * @author Eric Bottard
+ * @author Gary Russell
  */
-public class JmsSourceModuleOptionsMetadata {
+public class JmsSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
 	private String provider = "activemq";
 
@@ -41,6 +43,8 @@ public class JmsSourceModuleOptionsMetadata {
 	private String subscriptionName = null;
 
 	private String clientId = null;
+
+	private String acknowledge = "auto";
 
 	@NotNull
 	public String getProvider() {
@@ -70,6 +74,10 @@ public class JmsSourceModuleOptionsMetadata {
 
 	public String getClientId() {
 		return clientId;
+	}
+
+	public String getAcknowledge() {
+		return acknowledge;
 	}
 
 	@ModuleOption("the JMS provider")
@@ -102,5 +110,19 @@ public class JmsSourceModuleOptionsMetadata {
 		this.clientId = clientId;
 	}
 
+	@ModuleOption("the session acknowledge mode")
+	public void setAcknowledge(String acknowledge) {
+		this.acknowledge = acknowledge.toLowerCase();
+	}
+
+	@Override
+	public String[] profilesToActivate() {
+		if ("transacted".equals(this.acknowledge)) {
+			return new String[] { "dmlc" };
+		}
+		else {
+			return new String[] { "smlc" };
+		}
+	}
 
 }


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2767

Previously, the JMS source could lose messages.

Expose the `acknowledge` property to enable transactions.

Also, when not using transactions, use a `SimpleMessageListenerContainer`
instead of a `DefaultMessageListenerContainer` so that acknowledgement
occurs after the listener completes instead of before.

Tested with a local bus and:

    xd:>stream create jmstest --definition "jms | transform --expression='headers[jms_redelivered] ? payload : 1/0' | log --expression=#root" --deploy

    10:20:23,498  INFO ActiveMQ Session Task-1 sink.jmstest - GenericMessage [payload=foo, headers={jms_redelivered=true, JMSXDeliveryCount=2, id=db7d4d51-8e25-4b0e-0217-ab6c26c195a3, priority=0, jms_timestamp=1426515616699, jms_messageId=ID:arwen4-39565-1426346536573-15:1:1:1:1, timestamp=1426515623497}]

and

    xd:>stream create jmstest --definition "jms --acknowledge=transacted | transform --expression='headers[jms_redelivered] ? payload : 1/0' | log --expression=#root" --deploy

    10:21:47,231  INFO org.springframework.jms.listener.DefaultMessageListenerContainer#0-1 sink.jmstest - GenericMessage [payload=foo, headers={jms_redelivered=true, JMSXDeliveryCount=2, id=8a63d421-7059-53bc-a352-3426427b2d23, priority=0, jms_timestamp=1426515700437, jms_messageId=ID:arwen4-39565-1426346536573-17:1:1:1:1, timestamp=1426515707231}]

showing that in both cases, the failed message (due to the divide by zero) is successfully recovered.