### PR TITLE
[Sprint: 45] [Backport] Remove rehydrating the ExecutionContext when launching a job.

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/RuntimeBatchConfigurer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/RuntimeBatchConfigurer.java
@@ -28,11 +28,14 @@ import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.batch.core.repository.support.SimpleJobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.Assert;
+import org.springframework.xd.dirt.plugins.job.support.JobLaunchingJobRepository;
+import org.springframework.xd.dirt.plugins.job.support.JobLaunchingJobRepositoryFactoryBean;
 
 /**
  * Spring XD runtime specific {@link BatchConfigurer}.
@@ -124,9 +127,28 @@ public class RuntimeBatchConfigurer implements BatchConfigurer {
 
 	private JobLauncher createJobLauncher() throws Exception {
 		SimpleJobLauncher jobLauncher = new SimpleJobLauncher();
-		jobLauncher.setJobRepository(jobRepository);
+		jobLauncher.setJobRepository(createLaunchingJobRepository());
 		jobLauncher.afterPropertiesSet();
 		return jobLauncher;
+	}
+
+	private JobRepository createLaunchingJobRepository() throws Exception {
+		JobLaunchingJobRepositoryFactoryBean factory = new JobLaunchingJobRepositoryFactoryBean();
+		factory.setDataSource(dataSource);
+		if (dbType != null) {
+			factory.setDatabaseType(dbType);
+		}
+		if (clobType != null) {
+			factory.setClobType(clobType);
+		}
+		factory.setTransactionManager(transactionManager);
+		factory.setIsolationLevelForCreate(isolationLevel);
+		factory.setMaxVarCharLength(maxVarCharLength);
+		factory.setTablePrefix(tablePrefix);
+		factory.setValidateTransactionState(validateTransactionState);
+		factory.afterPropertiesSet();
+
+		return factory.getObject();
 	}
 
 	protected JobRepository createJobRepository() throws Exception {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepository.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.plugins.job.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.repository.dao.ExecutionContextDao;
+import org.springframework.batch.core.repository.dao.JobExecutionDao;
+import org.springframework.batch.core.repository.dao.JobInstanceDao;
+import org.springframework.batch.core.repository.dao.StepExecutionDao;
+import org.springframework.batch.core.repository.support.SimpleJobRepository;
+
+/**
+ * This {@link org.springframework.batch.core.repository.JobRepository} implementation
+ * provides the same functionality as Spring Batch's
+ * {@link org.springframework.batch.core.repository.support.SimpleJobRepository} however
+ * it does not re-hydrate a {@link org.springframework.batch.item.ExecutionContext} when
+ * querying for a {@link org.springframework.batch.core.JobExecution} or a
+ * {@link org.springframework.batch.core.StepExecution}.  This is done to prevent class
+ * loading issues when launching jobs within Spring XD.
+ *
+ * @author Michael Minella
+ */
+public class JobLaunchingJobRepository extends SimpleJobRepository {
+
+	private JobInstanceDao jobInstanceDao;
+	private JobExecutionDao jobExecutionDao;
+	private StepExecutionDao stepExecutionDao;
+
+	public JobLaunchingJobRepository(JobInstanceDao jobInstanceDao,
+			JobExecutionDao jobExecutionDao, StepExecutionDao stepExecutionDao,
+			ExecutionContextDao executionContextDao) {
+		super(jobInstanceDao, jobExecutionDao, stepExecutionDao, executionContextDao);
+		this.jobInstanceDao = jobInstanceDao;
+		this.jobExecutionDao = jobExecutionDao;
+		this.stepExecutionDao = stepExecutionDao;
+	}
+
+	/**
+	 * Returns the last {@link JobExecution} for the requested job <em>without</em>
+	 * rehydrating the related {@link org.springframework.batch.item.ExecutionContext}.
+	 *
+	 * @param jobName The name of the job
+	 * @param jobParameters The parameters of the job
+	 * @return The related JobExecution
+	 */
+	@Override
+	public JobExecution getLastJobExecution(String jobName, JobParameters jobParameters) {
+		JobInstance jobInstance = jobInstanceDao.getJobInstance(jobName, jobParameters);
+
+		if (jobInstance == null) {
+			return null;
+		}
+
+		JobExecution jobExecution = jobExecutionDao.getLastJobExecution(jobInstance);
+
+		if (jobExecution != null) {
+			stepExecutionDao.addStepExecutions(jobExecution);
+		}
+
+		return jobExecution;
+
+	}
+
+	/**
+	 * Returns the last {@link org.springframework.batch.core.StepExecution} for the
+	 * requested step <em>without</em> rehydrating the related
+	 * {@link org.springframework.batch.item.ExecutionContext}.
+	 *
+	 * @param jobInstance The {@link org.springframework.batch.core.JobInstance} the step
+	 * 					  should come from
+	 * @param stepName The name of the step to find
+	 * @return The related StepExecution
+	 */
+	@Override
+	public StepExecution getLastStepExecution(JobInstance jobInstance, String stepName) {
+		List<JobExecution> jobExecutions = jobExecutionDao.findJobExecutions(jobInstance);
+		List<StepExecution> stepExecutions = new ArrayList<StepExecution>(jobExecutions.size());
+
+		for (JobExecution jobExecution : jobExecutions) {
+			stepExecutionDao.addStepExecutions(jobExecution);
+			for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
+				if (stepName.equals(stepExecution.getStepName())) {
+					stepExecutions.add(stepExecution);
+				}
+			}
+		}
+
+		StepExecution latest = null;
+		for (StepExecution stepExecution : stepExecutions) {
+			if (latest == null) {
+				latest = stepExecution;
+			}
+			if (latest.getStartTime().getTime() < stepExecution.getStartTime().getTime()) {
+				latest = stepExecution;
+			}
+		}
+
+		return latest;
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryFactoryBean.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryFactoryBean.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.plugins.job.support;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.batch.support.PropertiesConverter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.interceptor.TransactionInterceptor;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link org.springframework.beans.factory.FactoryBean} for creating an instance of
+ * {@link org.springframework.xd.dirt.plugins.job.support.JobLaunchingJobRepository}
+ *
+ * @author Michael Minella
+ */
+public class JobLaunchingJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
+
+	private PlatformTransactionManager transactionManager;
+	private static final String DEFAULT_ISOLATION_LEVEL = "ISOLATION_SERIALIZABLE";
+	private String isolationLevelForCreate = DEFAULT_ISOLATION_LEVEL;
+	private boolean validateTransactionState = true;
+	private ProxyFactory proxyFactory;
+
+	private void initializeProxy() throws Exception {
+		if (proxyFactory == null) {
+			proxyFactory = new ProxyFactory();
+			TransactionInterceptor advice = new TransactionInterceptor(transactionManager,
+					PropertiesConverter.stringToProperties(
+							"create*=PROPAGATION_REQUIRES_NEW,"
+							+ isolationLevelForCreate
+							+ "\ngetLastJobExecution*=PROPAGATION_REQUIRES_NEW,"
+							+ isolationLevelForCreate
+							+ "\n*=PROPAGATION_REQUIRED"));
+			if (validateTransactionState) {
+				DefaultPointcutAdvisor advisor = new DefaultPointcutAdvisor(
+						new MethodInterceptor() {
+					@Override
+					public Object invoke(MethodInvocation invocation) throws Throwable {
+						if (TransactionSynchronizationManager.isActualTransactionActive()) {
+							throw new IllegalStateException(
+									"Existing transaction detected in JobRepository. "
+											+ "Please fix this and try again (e.g. "
+											+ "remove @Transactional annotations from "
+											+ "client).");
+						}
+						return invocation.proceed();
+					}
+				});
+				NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+				pointcut.addMethodName("create*");
+				advisor.setPointcut(pointcut);
+				proxyFactory.addAdvisor(advisor);
+			}
+			proxyFactory.addAdvice(advice);
+			proxyFactory.setProxyTargetClass(false);
+			proxyFactory.addInterface(JobRepository.class);
+			proxyFactory.setTarget(getTarget());
+		}
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		super.afterPropertiesSet();
+		Assert.notNull(transactionManager, "TransactionManager must not be null.");
+
+		initializeProxy();
+	}
+
+	private Object getTarget() throws Exception {
+		return new JobLaunchingJobRepository(createJobInstanceDao(),
+				createJobExecutionDao(), createStepExecutionDao(),
+				createExecutionContextDao());
+	}
+
+	@Override
+	public JobRepository getObject() throws Exception {
+		if (proxyFactory == null) {
+			afterPropertiesSet();
+		}
+		return (JobRepository) proxyFactory.getProxy();
+	}
+
+	/**
+	 * public setter for the isolation level to be used for the transaction when
+	 * job execution entities are initially created. The default is
+	 * ISOLATION_SERIALIZABLE, which prevents accidental concurrent execution of
+	 * the same job (ISOLATION_REPEATABLE_READ would work as well).
+	 *
+	 * @param isolationLevelForCreate the isolation level name to set
+	 *
+	 * @see org.springframework.batch.core.repository.support.SimpleJobRepository#createJobExecution(String,
+	 * org.springframework.batch.core.JobParameters)
+	 */
+	public void setIsolationLevelForCreate(String isolationLevelForCreate) {
+		this.isolationLevelForCreate = isolationLevelForCreate;
+		super.setIsolationLevelForCreate(isolationLevelForCreate);
+	}
+
+	/**
+	 * Flag to determine whether to check for an existing transaction when a
+	 * JobExecution is created. Defaults to true because it is usually a
+	 * mistake, and leads to problems with restartability and also to deadlocks
+	 * in multi-threaded steps.
+	 *
+	 * @param validateTransactionState the flag to set
+	 */
+	public void setValidateTransactionState(boolean validateTransactionState) {
+		this.validateTransactionState = validateTransactionState;
+		super.setValidateTransactionState(validateTransactionState);
+	}
+
+	/**
+	 * Public setter for the {@link PlatformTransactionManager}.
+	 * @param transactionManager the transactionManager to set
+	 */
+	public void setTransactionManager(PlatformTransactionManager transactionManager) {
+		this.transactionManager = transactionManager;
+		super.setTransactionManager(transactionManager);
+	}
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.plugins.job.support;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Michael Minella
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = "/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryTests-context.xml")
+public class JobLaunchingJobRepositoryTests {
+
+	@Autowired
+	private JobLaunchingJobRepository jobRepository;
+
+	private JobSupport job = new JobSupport("JobLaunchingJobRepositoryTestsJob");
+
+	private JobParameters jobParameters = new JobParameters();
+
+	@Transactional
+	@Test
+	public void testGetLastJobExecution() throws Exception {
+		JobExecution jobExecution =
+				jobRepository.createJobExecution(job.getName(), jobParameters);
+		jobExecution.setStatus(BatchStatus.FAILED);
+		jobExecution.setEndTime(new Date());
+		jobExecution.getExecutionContext().put("foo", "bar");
+		jobRepository.update(jobExecution);
+		jobRepository.updateExecutionContext(jobExecution);
+		Thread.sleep(10);
+		jobExecution = jobRepository.createJobExecution(job.getName(), jobParameters);
+		StepExecution stepExecution = new StepExecution("step1", jobExecution);
+		jobRepository.add(stepExecution);
+		jobExecution.addStepExecutions(Arrays.asList(stepExecution));
+		JobExecution lastJobExecution =
+				jobRepository.getLastJobExecution(job.getName(), jobParameters);
+		assertEquals(jobExecution, lastJobExecution);
+		assertEquals(stepExecution, jobExecution.getStepExecutions().iterator().next());
+		assertEquals(0, lastJobExecution.getExecutionContext().size());
+	}
+
+
+	/*
+	 * Save multiple StepExecutions for the same step and check the returned
+	 * count and last execution are correct.
+	 */
+	@Transactional
+	@Test
+	public void testGetStepExecutionCountAndLastStepExecution() throws Exception {
+		job.setRestartable(true);
+		StepSupport step = new StepSupport("restartedStep");
+
+		// first execution
+		JobExecution firstJobExec =
+				jobRepository.createJobExecution(job.getName(), jobParameters);
+		StepExecution firstStepExec = new StepExecution(step.getName(), firstJobExec);
+		firstStepExec.getExecutionContext().put("foo", "bar");
+		jobRepository.add(firstStepExec);
+
+		assertEquals(1, jobRepository.getStepExecutionCount(firstJobExec.getJobInstance(),
+															step.getName()));
+		StepExecution lastStepExecution =
+				jobRepository.getLastStepExecution(firstJobExec.getJobInstance(),
+						                           step.getName());
+		assertEquals(firstStepExec, lastStepExecution);
+		assertEquals(0, lastStepExecution.getExecutionContext().size());
+
+		// first execution failed
+		firstJobExec.setStartTime(new Date(4));
+		firstStepExec.setStartTime(new Date(5));
+		firstStepExec.setStatus(BatchStatus.FAILED);
+		firstStepExec.setEndTime(new Date(6));
+		jobRepository.update(firstStepExec);
+		firstJobExec.setStatus(BatchStatus.FAILED);
+		firstJobExec.setEndTime(new Date(7));
+		jobRepository.update(firstJobExec);
+
+		// second execution
+		JobExecution secondJobExec =
+				jobRepository.createJobExecution(job.getName(), jobParameters);
+		StepExecution secondStepExec = new StepExecution(step.getName(), secondJobExec);
+		secondStepExec.getExecutionContext().put("baz", "qux");
+		jobRepository.add(secondStepExec);
+
+		assertEquals(2, jobRepository.getStepExecutionCount(secondJobExec.getJobInstance(),
+														    step.getName()));
+		StepExecution lastStepExecution1 =
+				jobRepository.getLastStepExecution(secondJobExec.getJobInstance(),
+						                           step.getName());
+		assertEquals(secondStepExec, lastStepExecution1);
+		assertEquals(0, lastStepExecution1.getExecutionContext().size());
+	}
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/JobSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/JobSupport.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.plugins.job.support;
+
+/**
+ * @author Michael Minella
+ */
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParametersIncrementer;
+import org.springframework.batch.core.JobParametersValidator;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.UnexpectedJobExecutionException;
+import org.springframework.batch.core.job.DefaultJobParametersValidator;
+import org.springframework.batch.core.step.NoSuchStepException;
+import org.springframework.batch.core.step.StepLocator;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Batch domain object representing a job. Job is an explicit abstraction
+ * representing the configuration of a job specified by a developer. It should
+ * be noted that restart policy is applied to the job as a whole and not to a
+ * step.
+ *
+ * @author Lucas Ward
+ * @author Dave Syer
+ */
+public class JobSupport implements BeanNameAware, Job, StepLocator {
+
+	private Map<String, Step> steps = new HashMap<String, Step>();
+
+	private String name;
+
+	private boolean restartable = false;
+
+	private int startLimit = Integer.MAX_VALUE;
+
+	private DefaultJobParametersValidator jobParametersValidator = new DefaultJobParametersValidator();
+
+	/**
+	 * Default constructor.
+	 */
+	public JobSupport() {
+		super();
+	}
+
+	/**
+	 * Convenience constructor to immediately add name (which is mandatory but
+	 * not final).
+	 *
+	 * @param name
+	 */
+	public JobSupport(String name) {
+		super();
+		this.name = name;
+	}
+
+	/**
+	 * Set the name property if it is not already set. Because of the order of
+	 * the callbacks in a Spring container the name property will be set first
+	 * if it is present. Care is needed with bean definition inheritance - if a
+	 * parent bean has a name, then its children need an explicit name as well,
+	 * otherwise they will not be unique.
+	 *
+	 * @see org.springframework.beans.factory.BeanNameAware#setBeanName(java.lang.String)
+	 */
+	@Override
+	public void setBeanName(String name) {
+		if (this.name == null) {
+			this.name = name;
+		}
+	}
+
+	/**
+	 * Set the name property. Always overrides the default value if this object
+	 * is a Spring bean.
+	 *
+	 * @see #setBeanName(java.lang.String)
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.springframework.batch.core.domain.IJob#getName()
+	 */
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @param jobParametersValidator the jobParametersValidator to set
+	 */
+	public void setJobParametersValidator(DefaultJobParametersValidator jobParametersValidator) {
+		this.jobParametersValidator = jobParametersValidator;
+	}
+
+	public void setSteps(List<Step> steps) {
+		this.steps.clear();
+		for (Step step : steps) {
+			this.steps.put(step.getName(), step);
+		}
+	}
+
+	public void addStep(Step step) {
+		this.steps.put(step.getName(), step);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.springframework.batch.core.domain.IJob#getStartLimit()
+	 */
+	public int getStartLimit() {
+		return startLimit;
+	}
+
+	public void setStartLimit(int startLimit) {
+		this.startLimit = startLimit;
+	}
+
+	public void setRestartable(boolean restartable) {
+		this.restartable = restartable;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.springframework.batch.core.domain.IJob#isRestartable()
+	 */
+	@Override
+	public boolean isRestartable() {
+		return restartable;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see
+	 * org.springframework.batch.core.domain.Job#run(org.springframework.batch
+	 * .core.domain.JobExecution)
+	 */
+	@Override
+	public void execute(JobExecution execution) throws UnexpectedJobExecutionException {
+		throw new UnsupportedOperationException(
+				"JobSupport does not provide an implementation of execute().  Use a smarter subclass.");
+	}
+
+	@Override
+	public String toString() {
+		return ClassUtils.getShortName(getClass()) + ": [name=" + name + "]";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 *
+	 * @see org.springframework.batch.core.Job#getJobParametersIncrementer()
+	 */
+	@Override
+	public JobParametersIncrementer getJobParametersIncrementer() {
+		return null;
+	}
+
+	@Override
+	public JobParametersValidator getJobParametersValidator() {
+		return jobParametersValidator;
+	}
+
+	@Override
+	public Collection<String> getStepNames() {
+		return steps.keySet();
+	}
+
+	@Override
+	public Step getStep(String stepName) throws NoSuchStepException {
+		final Step step = steps.get(stepName);
+		if (step == null) {
+			throw new NoSuchStepException("Step ["+stepName+"] does not exist for job with name ["+getName()+"]");
+		}
+		return step;
+	}
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/StepSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/StepSupport.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.plugins.job.support;
+
+import org.springframework.batch.core.JobInterruptedException;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.UnexpectedJobExecutionException;
+import org.springframework.beans.factory.BeanNameAware;
+
+/**
+ * Basic no-op support implementation for use as base class for {@link Step}. Implements {@link BeanNameAware} so that
+ * if no name is provided explicitly it will be inferred from the bean definition in Spring configuration.
+ *
+ * @author Dave Syer
+ *
+ */
+public class StepSupport implements Step, BeanNameAware {
+
+	private String name;
+
+	private int startLimit = Integer.MAX_VALUE;
+
+	private boolean allowStartIfComplete;
+
+	/**
+	 * Default constructor for {@link StepSupport}.
+	 */
+	public StepSupport() {
+		super();
+	}
+
+	/**
+	 * @param string
+	 */
+	public StepSupport(String string) {
+		super();
+		this.name = string;
+	}
+
+	@Override
+	public String getName() {
+		return this.name;
+	}
+
+	/**
+	 * Set the name property if it is not already set. Because of the order of the callbacks in a Spring container the
+	 * name property will be set first if it is present. Care is needed with bean definition inheritance - if a parent
+	 * bean has a name, then its children need an explicit name as well, otherwise they will not be unique.
+	 *
+	 * @see org.springframework.beans.factory.BeanNameAware#setBeanName(java.lang.String)
+	 */
+	@Override
+	public void setBeanName(String name) {
+		if (this.name == null) {
+			this.name = name;
+		}
+	}
+
+	/**
+	 * Set the name property. Always overrides the default value if this object is a Spring bean.
+	 *
+	 * @see #setBeanName(java.lang.String)
+	 */
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public int getStartLimit() {
+		return this.startLimit;
+	}
+
+	/**
+	 * Public setter for the startLimit.
+	 *
+	 * @param startLimit the startLimit to set
+	 */
+	public void setStartLimit(int startLimit) {
+		this.startLimit = startLimit;
+	}
+
+	@Override
+	public boolean isAllowStartIfComplete() {
+		return this.allowStartIfComplete;
+	}
+
+	/**
+	 * Public setter for the shouldAllowStartIfComplete.
+	 *
+	 * @param allowStartIfComplete the shouldAllowStartIfComplete to set
+	 */
+	public void setAllowStartIfComplete(boolean allowStartIfComplete) {
+		this.allowStartIfComplete = allowStartIfComplete;
+	}
+
+	/**
+	 * Not supported but provided so that tests can easily create a step.
+	 *
+	 * @throws UnsupportedOperationException always
+	 *
+	 * @see org.springframework.batch.core.Step#execute(org.springframework.batch.core.StepExecution)
+	 */
+	@Override
+	public void execute(StepExecution stepExecution) throws JobInterruptedException, UnexpectedJobExecutionException {
+		throw new UnsupportedOperationException(
+				"Cannot process a StepExecution.  Use a smarter subclass of StepSupport.");
+	}
+}

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryTests-context.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryTests-context.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+
+	<jdbc:initialize-database data-source="dataSource">
+		<jdbc:script location="classpath:org/springframework/batch/core/schema-drop-hsqldb.sql"/>
+		<jdbc:script location="classpath:org/springframework/batch/core/schema-hsqldb.sql"/>
+	</jdbc:initialize-database>
+
+	<bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource">
+		<property name="driverClassName" value="org.hsqldb.jdbcDriver" />
+		<property name="url" value="jdbc:hsqldb:mem:testdb;sql.enforce_strict_size=true;hsqldb.tx=mvcc" />
+		<property name="username" value="sa" />
+		<property name="password" value="" />
+	</bean>
+
+	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+		<property name="dataSource" ref="dataSource" />
+	</bean>
+
+	<bean id="incrementerParent" class="org.springframework.jdbc.support.incrementer.HsqlMaxValueIncrementer"
+		  abstract="true">
+		<property name="dataSource" ref="dataSource" />
+		<property name="columnName" value="ID" />
+	</bean>
+
+	<bean id="jobIncrementer" parent="incrementerParent">
+		<property name="incrementerName" value="BATCH_JOB_SEQ" />
+	</bean>
+
+	<bean id="jobExecutionIncrementer" parent="incrementerParent">
+		<property name="incrementerName" value="BATCH_JOB_EXECUTION_SEQ" />
+	</bean>
+
+	<bean id="stepIncrementer" parent="incrementerParent">
+		<property name="incrementerName" value="BATCH_STEP_SEQ" />
+	</bean>
+
+	<bean id="stepExecutionIncrementer" parent="incrementerParent">
+		<property name="incrementerName" value="BATCH_STEP_EXECUTION_SEQ" />
+	</bean>
+
+	<bean id="jobRepository" class="org.springframework.xd.dirt.plugins.job.support.JobLaunchingJobRepository">
+		<constructor-arg ref="jobInstanceDao" />
+		<constructor-arg ref="jobExecutionDao" />
+		<constructor-arg ref="stepExecutionDao" />
+		<constructor-arg ref="executionContextDao" />
+	</bean>
+
+	<bean id="executionContextDao" class="org.springframework.batch.core.repository.dao.JdbcExecutionContextDao">
+		<property name="jdbcTemplate" ref="jdbcTemplate" />
+		<property name="serializer" ref="serializer"/>
+	</bean>
+
+	<bean id="jobInstanceDao" class="org.springframework.batch.core.repository.dao.JdbcJobInstanceDao">
+		<property name="jdbcTemplate" ref="jdbcTemplate" />
+		<property name="jobIncrementer" ref="jobIncrementer" />
+	</bean>
+
+	<bean id="jobExecutionDao" class="org.springframework.batch.core.repository.dao.JdbcJobExecutionDao">
+		<property name="jdbcTemplate" ref="jdbcTemplate" />
+		<property name="jobExecutionIncrementer" ref="jobExecutionIncrementer" />
+	</bean>
+
+	<bean id="stepExecutionDao" class="org.springframework.batch.core.repository.dao.JdbcStepExecutionDao">
+		<property name="jdbcTemplate" ref="jdbcTemplate" />
+		<property name="stepExecutionIncrementer" ref="stepExecutionIncrementer" />
+	</bean>
+
+	<bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
+		<constructor-arg ref="dataSource" />
+	</bean>
+
+	<bean id="serializer" class="org.springframework.batch.core.repository.dao.XStreamExecutionContextStringSerializer"/>
+</beans>


### PR DESCRIPTION
When a custom job is launched, the classpath for the custom job is not
available to the JobLauncher.  Because of this, if there are custom
classes that have been serialzied in the EC, a ClassNotFoundException is
thrown.  Since the EC isn't needed to launch a job, this fix removes the
rehydration of the EC by the launcher.

XD-2486