### PR TITLE
XD-2828 Fix distributed tests

### DIFF
--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/ContainerRedeploymentTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/ContainerRedeploymentTests.java
@@ -18,6 +18,7 @@ package org.springframework.xd.distributed.test;
 
 import static org.junit.Assert.*;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +61,7 @@ public class ContainerRedeploymentTests extends AbstractDistributedTests {
 				false);
 		verifyStreamCreated(streamName);
 
-		template.streamOperations().deploy(streamName, null);
+		template.streamOperations().deploy(streamName, Collections.<String, String> emptyMap());
 		verifyStreamState(streamName, DeploymentUnitStatus.State.failed);
 
 		for (int i = 0; i < 3; i++) {

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/JobStateTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/JobStateTests.java
@@ -25,6 +25,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 
@@ -80,7 +81,7 @@ public class JobStateTests extends AbstractDistributedTests {
 			verifyJobCreated(jobName);
 			verifyJobState(jobName, DeploymentUnitStatus.State.undeployed);
 
-			template.jobOperations().deploy(jobName, null);
+			template.jobOperations().deploy(jobName, Collections.<String, String>emptyMap());
 			verifyJobState(jobName, DeploymentUnitStatus.State.failed);
 
 			startContainer();

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/StreamDeploymentTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/StreamDeploymentTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Test;
@@ -58,7 +59,7 @@ public class StreamDeploymentTests extends AbstractDistributedTests {
 		template.streamOperations().createStream(streamName, "time|log", false);
 		verifyStreamCreated(streamName);
 
-		template.streamOperations().deploy(streamName, null);
+		template.streamOperations().deploy(streamName, Collections.<String, String> emptyMap());
 		verifyStreamDeployed(streamName);
 
 		ModuleRuntimeContainers moduleContainers = retrieveModuleRuntimeContainers(streamName);


### PR DESCRIPTION
 - Replace `null` values with empty map for deployment properties