### PR TITLE
[XD-2769] Making receive() and receivePayload() consistent with Spring Integration

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChain.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChain.java
@@ -57,7 +57,6 @@ public class SingleNodeProcessingChain extends AbstractSingleNodeProcessingChain
 		return sink.receivePayload(timeout);
 	}
 
-
 	@Override
 	public void send(Message<?> message) {
 		source.send(message);
@@ -77,4 +76,5 @@ public class SingleNodeProcessingChain extends AbstractSingleNodeProcessingChain
 	protected boolean createSource() {
 		return true;
 	}
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/AbstractSingleNodeNamedChannelSink.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/AbstractSingleNodeNamedChannelSink.java
@@ -23,7 +23,6 @@ import org.springframework.xd.dirt.test.AbstractSingleNodeNamedChannelModule;
  * Base class for SingleNode named channel sink types.
  * 
  * @author David Turanski
- * 
  */
 public abstract class AbstractSingleNodeNamedChannelSink extends AbstractSingleNodeNamedChannelModule<QueueChannel>
 		implements NamedChannelSink {
@@ -34,28 +33,29 @@ public abstract class AbstractSingleNodeNamedChannelSink extends AbstractSingleN
 
 	@Override
 	public Message<?> receive() {
-		return this.receive(0);
+		return messageChannel.receive();
 	}
 
 	@Override
 	public Message<?> receive(int timeout) {
-		return this.messageChannel.receive(timeout);
+		return messageChannel.receive(timeout);
 	}
 
 	@Override
 	public Object receivePayload() {
-		return this.receivePayload(0);
+        Message<?> message = receive();
+        return message == null ? null : message.getPayload();
 	}
 
 	@Override
 	public Object receivePayload(int timeout) {
-		Message<?> message = this.messageChannel.receive(timeout);
+		Message<?> message = receive(timeout);
 		return message == null ? null : message.getPayload();
 	}
 
 	@Override
 	public void unbind() {
-		this.messageBus.unbindConsumer(this.sharedChannelName, this.messageChannel);
+		messageBus.unbindConsumer(sharedChannelName, messageChannel);
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/NamedChannelSink.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/NamedChannelSink.java
@@ -27,52 +27,52 @@ import org.springframework.xd.dirt.test.NamedChannelModule;
  */
 public interface NamedChannelSink extends NamedChannelModule {
 
-    /**
-     * Receive the first available message from this sink.
-     * <p>
-     * If the sink contains no messages, this method will block.
-     *
-     * @return the first available message or <code>null</code> if the receiving
-     * thread is interrupted.
-     */
+	/**
+	 * Receive the first available message from this sink.
+	 * <p>
+	 * If the sink contains no messages, this method will block.
+	 *
+	 * @return the first available message or <code>null</code> if the receiving
+	 * thread is interrupted.
+	 */
 	Message<?> receive();
 
-    /**
-     * Receive the first available message from this sink.
-     * <p>
-     * If the channel contains no messages, this method will block until the allotted timeout elapses.
-     * If the specified timeout is 0, the method will return immediately.
-     * If less than zero, it will block indefinitely (see {@link #receive()}).
-     *
-     * @param timeout the timeout in milliseconds
-     *
-     * @return the first available message or <code>null</code> if no message is available within the
-     * allotted time or the receiving thread is interrupted.
-     */
+	/**
+	 * Receive the first available message from this sink.
+	 * <p>
+	 * If the channel contains no messages, this method will block until the allotted timeout elapses.
+	 * If the specified timeout is 0, the method will return immediately.
+	 * If less than zero, it will block indefinitely (see {@link #receive()}).
+	 *
+	 * @param timeout the timeout in milliseconds
+	 *
+	 * @return the first available message or <code>null</code> if no message is available within the
+	 * allotted time or the receiving thread is interrupted.
+	 */
 	Message<?> receive(int timeout);
 
-    /**
-     * Receive the first available payload from this sink.
-     * <p>
-     * If the sink contains no messages, this method will block.
-     *
-     * @return the first available payload or <code>null</code> if the receiving
-     * thread is interrupted.
-     */
+	/**
+	 * Receive the first available payload from this sink.
+	 * <p>
+	 * If the sink contains no messages, this method will block.
+	 *
+	 * @return the first available payload or <code>null</code> if the receiving
+	 * thread is interrupted.
+	 */
 	Object receivePayload();
 
-    /**
-     * Receive the first available payload from this sink.
-     * <p>
-     * If the channel contains no messages, this method will block until the allotted timeout elapses.
-     * If the specified timeout is 0, the method will return immediately.
-     * If less than zero, it will block indefinitely (see {@link #receivePayload()}).
-     *
-     * @param timeout the timeout in milliseconds
-     *
-     * @return the first available message or <code>null</code> if no message is available within the
-     * allotted time or the receiving thread is interrupted.
-     */
+	/**
+	 * Receive the first available payload from this sink.
+	 * <p>
+	 * If the channel contains no messages, this method will block until the allotted timeout elapses.
+	 * If the specified timeout is 0, the method will return immediately.
+	 * If less than zero, it will block indefinitely (see {@link #receivePayload()}).
+	 *
+	 * @param timeout the timeout in milliseconds
+	 *
+	 * @return the first available message or <code>null</code> if no message is available within the
+	 * allotted time or the receiving thread is interrupted.
+	 */
 	Object receivePayload(int timeout);
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/NamedChannelSink.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/NamedChannelSink.java
@@ -32,8 +32,7 @@ public interface NamedChannelSink extends NamedChannelModule {
 	 * <p>
 	 * If the sink contains no messages, this method will block.
 	 *
-	 * @return the first available message or <code>null</code> if the receiving
-	 * thread is interrupted.
+	 * @return the first available message or <code>null</code> if the receiving thread is interrupted.
 	 */
 	Message<?> receive();
 
@@ -56,8 +55,7 @@ public interface NamedChannelSink extends NamedChannelModule {
 	 * <p>
 	 * If the sink contains no messages, this method will block.
 	 *
-	 * @return the first available payload or <code>null</code> if the receiving
-	 * thread is interrupted.
+	 * @return the first available payload or <code>null</code> if the receiving thread is interrupted.
 	 */
 	Object receivePayload();
 
@@ -70,7 +68,7 @@ public interface NamedChannelSink extends NamedChannelModule {
 	 *
 	 * @param timeout the timeout in milliseconds
 	 *
-	 * @return the first available message or <code>null</code> if no message is available within the
+	 * @return the first available payload or <code>null</code> if no message is available within the
 	 * allotted time or the receiving thread is interrupted.
 	 */
 	Object receivePayload(int timeout);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/NamedChannelSink.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/NamedChannelSink.java
@@ -27,11 +27,52 @@ import org.springframework.xd.dirt.test.NamedChannelModule;
  */
 public interface NamedChannelSink extends NamedChannelModule {
 
-	public Message<?> receive();
+    /**
+     * Receive the first available message from this sink.
+     * <p>
+     * If the sink contains no messages, this method will block.
+     *
+     * @return the first available message or <code>null</code> if the receiving
+     * thread is interrupted.
+     */
+	Message<?> receive();
 
-	public Message<?> receive(int timeout);
+    /**
+     * Receive the first available message from this sink.
+     * <p>
+     * If the channel contains no messages, this method will block until the allotted timeout elapses.
+     * If the specified timeout is 0, the method will return immediately.
+     * If less than zero, it will block indefinitely (see {@link #receive()}).
+     *
+     * @param timeout the timeout in milliseconds
+     *
+     * @return the first available message or <code>null</code> if no message is available within the
+     * allotted time or the receiving thread is interrupted.
+     */
+	Message<?> receive(int timeout);
 
-	public Object receivePayload();
+    /**
+     * Receive the first available payload from this sink.
+     * <p>
+     * If the sink contains no messages, this method will block.
+     *
+     * @return the first available payload or <code>null</code> if the receiving
+     * thread is interrupted.
+     */
+	Object receivePayload();
 
-	public Object receivePayload(int timeout);
+    /**
+     * Receive the first available payload from this sink.
+     * <p>
+     * If the channel contains no messages, this method will block until the allotted timeout elapses.
+     * If the specified timeout is 0, the method will return immediately.
+     * If less than zero, it will block indefinitely (see {@link #receivePayload()}).
+     *
+     * @param timeout the timeout in milliseconds
+     *
+     * @return the first available message or <code>null</code> if no message is available within the
+     * allotted time or the receiving thread is interrupted.
+     */
+	Object receivePayload(int timeout);
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/SingleNodeNamedQueueSink.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/SingleNodeNamedQueueSink.java
@@ -28,11 +28,9 @@ public class SingleNodeNamedQueueSink extends AbstractSingleNodeNamedChannelSink
 		super(messageBus, sharedChannelName);
 	}
 
-
 	@Override
 	protected void bind() {
 		this.messageBus.bindConsumer(this.sharedChannelName, this.messageChannel, null);
 	}
-
 
 }


### PR DESCRIPTION
Should tests for changed classes be provided with this pull request? I searched the project but I haven't found existing tests for NamedChannelSink, please point me in the right direction.