### PR TITLE
[Sprint 45][Backport] XD-2799-2800-2842 Offset management performance improvements

### DIFF
--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaConsumerOptionsMixin.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaConsumerOptionsMixin.java
@@ -20,6 +20,9 @@ import static org.springframework.integration.x.kafka.AutoOffsetResetStrategy.sm
 
 import javax.validation.constraints.NotNull;
 
+import kafka.serializer.Decoder;
+import kafka.serializer.DefaultDecoder;
+
 import org.springframework.xd.module.options.spi.ModuleOption;
 
 
@@ -33,9 +36,9 @@ public class KafkaConsumerOptionsMixin {
 
 	private int socketTimeout = 30000;
 
-	private int socketBufferBytes = 64 * 1024;
+	private int socketBufferBytes = 2 * 1024 * 1024;
 
-	private int fetchMaxBytes = 300 * 1024;
+	private int fetchMaxBytes = 1024 * 1024;
 
 	private int fetchMinBytes = 1;
 

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaOffsetTopicOptionsMixin.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaOffsetTopicOptionsMixin.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.x.kafka;
+
+import org.springframework.xd.module.options.spi.ModuleOption;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class KafkaOffsetTopicOptionsMixin {
+
+	private int kafkaOffsetTopicSegmentSize = 250 * 1024 * 1024;
+
+	private String kafkaOffsetTopicName = "${xd.stream.name}-${xd.module.name}-offsets";
+
+	private int kafkaOffsetTopicRetentionTime = 60000;
+
+	private int kafkaOffsetTopicRequiredAcks = 1;
+
+	private int kafkaOffsetTopicMaxSize = 1024*1024;
+
+	private int kafkaOffsetTopicBatchSize = 200;
+
+	private int kafkaOffsetTopicBatchTime = 1000;
+
+	private boolean kafkaOffsetTopicBatchingEnabled = false;
+
+	public int getKafkaOffsetTopicSegmentSize() {
+		return kafkaOffsetTopicSegmentSize;
+	}
+
+	@ModuleOption(value = "segment size of the offset topic, if Kafka offset strategy is chosen")
+	public void setKafkaOffsetTopicSegmentSize(int kafkaOffsetTopicSegmentSize) {
+		this.kafkaOffsetTopicSegmentSize = kafkaOffsetTopicSegmentSize;
+	}
+
+	public String getKafkaOffsetTopicName() {
+		return kafkaOffsetTopicName;
+	}
+
+	@ModuleOption(value = "name of the offset topic, if Kafka offset strategy is chosen")
+	public void setKafkaOffsetTopicName(String kafkaOffsetTopicName) {
+		this.kafkaOffsetTopicName = kafkaOffsetTopicName;
+	}
+
+	public int getKafkaOffsetTopicRetentionTime() {
+		return kafkaOffsetTopicRetentionTime;
+	}
+
+	@ModuleOption(value = "retention time for dead records (tombstones), if Kafka offset strategy is chosen", hidden = true)
+	public void setKafkaOffsetTopicRetentionTime(int kafkaOffsetTopicRetentionTime) {
+		this.kafkaOffsetTopicRetentionTime = kafkaOffsetTopicRetentionTime;
+	}
+
+	public int getKafkaOffsetTopicRequiredAcks() {
+		return kafkaOffsetTopicRequiredAcks;
+	}
+
+	@ModuleOption(value = "required acks for writing to the Kafka offset topic, if Kafka offset strategy is chosen", hidden = true)
+	public void setKafkaOffsetTopicRequiredAcks(int kafkaOffsetTopicRequiredAcks) {
+		this.kafkaOffsetTopicRequiredAcks = kafkaOffsetTopicRequiredAcks;
+	}
+
+	public int getKafkaOffsetTopicMaxSize() {
+		return kafkaOffsetTopicMaxSize;
+	}
+
+	@ModuleOption(value = "maximum size of reads from offset topic, if Kafka offset strategy is chosen", hidden = true)
+	public void setKafkaOffsetTopicMaxSize(int kafkaOffsetTopicMaxSize) {
+		this.kafkaOffsetTopicMaxSize = kafkaOffsetTopicMaxSize;
+	}
+
+	public int getKafkaOffsetTopicBatchSize() {
+		return kafkaOffsetTopicBatchSize;
+	}
+
+	@ModuleOption(value = "maximum batched writes to offset topic, if Kafka offset strategy is chosen", hidden = true)
+	public void setKafkaOffsetTopicBatchSize(int kafkaOffsetTopicBatchSize) {
+		this.kafkaOffsetTopicBatchSize = kafkaOffsetTopicBatchSize;
+	}
+
+	public int getKafkaOffsetTopicBatchTime() {
+		return kafkaOffsetTopicBatchTime;
+	}
+
+	@ModuleOption(value = "maximum time for batching writes to offset topic, if Kafka offset strategy is chosen", hidden = true)
+	public void setKafkaOffsetTopicBatchTime(int kafkaOffsetTopicBatchTime) {
+		this.kafkaOffsetTopicBatchTime = kafkaOffsetTopicBatchTime;
+	}
+
+	public boolean getKafkaOffsetTopicBatchingEnabled() {
+		return kafkaOffsetTopicBatchingEnabled;
+	}
+
+	@ModuleOption(value = "enables batching writes to offset topic, if Kafka offset strategy is chosen", hidden = true)
+	public void setKafkaOffsetTopicBatchingEnabled(boolean kafkaOffsetTopicBatchingEnabled) {
+		this.kafkaOffsetTopicBatchingEnabled = kafkaOffsetTopicBatchingEnabled;
+	}
+}

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
@@ -28,7 +28,7 @@ import org.springframework.xd.module.options.spi.ProfileNamesProvider;
  * @author Ilayaperumal Gopinathan
  * @author Marius Bogoevici
  */
-@Mixin({KafkaZKOptionMixin.class, KafkaConsumerOptionsMixin.class})
+@Mixin({KafkaZKOptionMixin.class, KafkaConsumerOptionsMixin.class, KafkaOffsetTopicOptionsMixin.class})
 public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
 	private String topic = ModulePlaceholders.XD_STREAM_NAME;
@@ -44,6 +44,14 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 	private String groupId = ModulePlaceholders.XD_STREAM_NAME;
 
 	private String encoding = "UTF8";
+
+	private int offsetUpdateTimeWindow = 10000;
+
+	private int offsetUpdateCount = 0;
+
+	private int offsetUpdateShutdownTimeout = 2000;
+
+	private int queueSize = 1000;
 
 	@ModuleOption("kafka topic name")
 	public void setTopic(String topic) {
@@ -109,6 +117,45 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 		return this.encoding;
 	}
 
+	@ModuleOption("frequency (in milliseconds) with which offsets are persisted " +
+			"mutually exclusive with the count-based offset update option (use 0 to disable either)")
+	public void setOffsetUpdateTimeWindow(int offsetUpdateTimeWindow) {
+		this.offsetUpdateTimeWindow = offsetUpdateTimeWindow;
+	}
+
+	public int getOffsetUpdateTimeWindow() {
+		return offsetUpdateTimeWindow;
+	}
+
+	@ModuleOption("frequency, in number of messages, with which offsets are persisted, per concurrent processor, " +
+			"mutually exclusive with the time-based offset update option (use 0 to disable either)")
+	public void setOffsetUpdateCount(int offsetUpdateCount) {
+		this.offsetUpdateCount = offsetUpdateCount;
+	}
+
+	public int getOffsetUpdateCount() {
+		return offsetUpdateCount;
+	}
+
+	@ModuleOption(value = "timeout for ensuring that all offsets have been written, on shutdown", hidden = true)
+	public void setOffsetUpdateShutdownTimeout(int offsetUpdateShutdownTimeout) {
+		this.offsetUpdateShutdownTimeout = offsetUpdateShutdownTimeout;
+	}
+
+	public int getOffsetUpdateShutdownTimeout() {
+		return offsetUpdateShutdownTimeout;
+	}
+
+	@ModuleOption(value = "the maximum number of messages held internally and waiting for processing, " +
+			"per concurrent handler")
+	public void setQueueSize(int queueSize) {
+		this.queueSize = queueSize;
+	}
+
+	public int getQueueSize() {
+		return queueSize;
+	}
+
 	public enum OffsetStorageStrategy {
 		inmemory,
 		redis,
@@ -119,8 +166,9 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 	public String[] profilesToActivate() {
 		if (offsetStorage != null) {
 			return new String[] {String.format("%s-offset-manager", offsetStorage)};
-		} else {
+		}
+		else {
 			throw new IllegalStateException("An offset storage strategy must be configured");
 		}
- 	}
+	}
 }

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/WindowingOffsetManager.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/WindowingOffsetManager.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.x.kafka;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import rx.Observable;
+import rx.Scheduler;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.functions.Action1;
+import rx.functions.Func1;
+import rx.functions.Func2;
+import rx.observables.GroupedObservable;
+import rx.observables.MathObservable;
+import rx.schedulers.Schedulers;
+import rx.subjects.PublishSubject;
+import rx.subjects.SerializedSubject;
+import rx.subjects.Subject;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.integration.kafka.core.Partition;
+import org.springframework.integration.kafka.listener.OffsetManager;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link OffsetManager} that aggregates writes over a time or count window, using an underlying delegate to
+ * do the actual operations. Its purpose is to reduce the performance impact of writing operations
+ * wherever this is desirable.
+ *
+ * Either a time window or a number of writes can be specified, but not both.
+ *
+ * @author Marius Bogoevici
+ */
+public class WindowingOffsetManager implements OffsetManager, InitializingBean, DisposableBean {
+
+	private final CreatePartitionAndOffsetFunction createPartitionAndOffsetFunction = new CreatePartitionAndOffsetFunction();
+
+	private final GetOffsetFunction getOffsetFunction = new GetOffsetFunction();
+
+	private final ComputeMaximumOffsetByPartitionFunction findHighestOffsetInPartitionGroup = new ComputeMaximumOffsetByPartitionFunction();
+
+	private final GetPartitionFunction getPartition = new GetPartitionFunction();
+
+	private final FindHighestOffsetsByPartitionFunction findHighestOffsetsByPartition = new FindHighestOffsetsByPartitionFunction();
+
+	private final DelegateUpdateOffsetAction delegateUpdateOffsetAction = new DelegateUpdateOffsetAction();
+
+	private final NotifyObservableClosedAction notifyObservableClosed = new NotifyObservableClosedAction();
+
+	private OffsetManager delegate;
+
+	private long timespan = 10 * 1000;
+
+	private int count = 0;
+
+	private Subject<PartitionAndOffset, PartitionAndOffset> offsets;
+
+	private Subscription subscription;
+
+	private int shutdownTimeout = 2000;
+
+	private CountDownLatch shutdownLatch;
+
+	public WindowingOffsetManager(OffsetManager offsetManager) {
+		this.delegate = offsetManager;
+	}
+
+	/**
+	 * The timespan for aggregating write operations, before invoking the underlying {@link OffsetManager}.
+	 *
+	 * @param timespan duration in milliseconds
+	 */
+	public void setTimespan(long timespan) {
+		Assert.isTrue(timespan >= 0, "Timespan must be a positive value");
+		this.timespan = timespan;
+	}
+
+	/**
+	 * How many writes should be aggregated, before invoking the underlying {@link OffsetManager}. Setting this value
+	 * to 1 effectively disables windowing.
+	 *
+	 * @param count number of writes
+	 */
+	public void setCount(int count) {
+		Assert.isTrue(count >= 0, "Count must be a positive value");
+		this.count = count;
+	}
+
+	/**
+	 * The timeout that {@link #close()} and {@link #destroy()} operations will wait for receving a confirmation that the
+	 * underlying writes have been processed.
+	 *
+	 * @param shutdownTimeout duration in milliseconds
+	 */
+	public void setShutdownTimeout(int shutdownTimeout) {
+		this.shutdownTimeout = shutdownTimeout;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		Assert.isTrue(timespan > 0 ^ count > 0, "Only one of the timespan or count must be set");
+		// create the stream if windowing is set, and count is higher than 1
+		if (timespan > 0 || count > 1) {
+			offsets = new SerializedSubject(PublishSubject.<PartitionAndOffset>create());
+			// window by either count or time
+			Observable<Observable<PartitionAndOffset>> window =
+					timespan > 0 ? offsets.window(timespan, TimeUnit.MILLISECONDS) : offsets.window(count);
+			Observable<PartitionAndOffset> maximumOffsetsByWindow = window
+					.flatMap(findHighestOffsetsByPartition)
+					.doOnCompleted(notifyObservableClosed);
+			subscription = maximumOffsetsByWindow.subscribe(delegateUpdateOffsetAction);
+		}
+		else {
+			offsets = null;
+		}
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		this.flush();
+		this.close();
+		if (delegate instanceof DisposableBean) {
+			((DisposableBean) delegate).destroy();
+		}
+	}
+
+	@Override
+	public void updateOffset(Partition partition, long offset) {
+		if (offsets != null) {
+			offsets.onNext(new PartitionAndOffset(partition, offset));
+		}
+		else {
+			delegate.updateOffset(partition, offset);
+		}
+	}
+
+	@Override
+	public long getOffset(Partition partition) {
+		return delegate.getOffset(partition);
+	}
+
+	@Override
+	public void deleteOffset(Partition partition) {
+		delegate.deleteOffset(partition);
+	}
+
+	@Override
+	public void resetOffsets(Collection<Partition> partition) {
+		delegate.resetOffsets(partition);
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (offsets != null) {
+			shutdownLatch = new CountDownLatch(1);
+			offsets.onCompleted();
+			try {
+				shutdownLatch.await(shutdownTimeout, TimeUnit.MILLISECONDS);
+			}
+			catch (InterruptedException e) {
+				// ignore
+			}
+			subscription.unsubscribe();
+		}
+		delegate.close();
+	}
+
+	@Override
+	public void flush() throws IOException {
+		delegate.flush();
+	}
+
+	class PartitionAndOffset {
+
+		private Partition partition;
+
+		private Long offset;
+
+		public PartitionAndOffset(Partition partition, Long offset) {
+			this.partition = partition;
+			this.offset = offset;
+		}
+
+		public Partition getPartition() {
+			return partition;
+		}
+
+		public Long getOffset() {
+			return offset;
+		}
+	}
+
+	private class DelegateUpdateOffsetAction implements Action1<PartitionAndOffset> {
+		@Override
+		public void call(PartitionAndOffset partitionAndOffset) {
+			delegate.updateOffset(partitionAndOffset.getPartition(), partitionAndOffset.getOffset());
+		}
+	}
+
+	private class NotifyObservableClosedAction implements Action0 {
+		@Override
+		public void call() {
+			if (shutdownLatch != null) {
+				shutdownLatch.countDown();
+			}
+		}
+	}
+
+	private class CreatePartitionAndOffsetFunction implements Func2<Partition, Long, PartitionAndOffset> {
+		@Override
+		public PartitionAndOffset call(Partition partition, Long offset) {
+			return new PartitionAndOffset(partition, offset);
+		}
+	}
+
+	private class GetOffsetFunction implements Func1<PartitionAndOffset, Long> {
+		@Override
+		public Long call(PartitionAndOffset partitionAndOffset) {
+			return partitionAndOffset.getOffset();
+		}
+	}
+
+	private class ComputeMaximumOffsetByPartitionFunction implements Func1<GroupedObservable<Partition, PartitionAndOffset>, Observable<PartitionAndOffset>> {
+		@Override
+		public Observable<PartitionAndOffset> call(GroupedObservable<Partition, PartitionAndOffset> group) {
+			return Observable.zip(Observable.just(group.getKey()),
+					MathObservable.max(group.map(getOffsetFunction)),
+					createPartitionAndOffsetFunction);
+		}
+	}
+
+	private class GetPartitionFunction implements Func1<PartitionAndOffset, Partition> {
+		@Override
+		public Partition call(PartitionAndOffset partitionAndOffset) {
+			return partitionAndOffset.getPartition();
+		}
+	}
+
+	private class FindHighestOffsetsByPartitionFunction implements Func1<Observable<PartitionAndOffset>, Observable<PartitionAndOffset>> {
+		@Override
+		public Observable<PartitionAndOffset> call(Observable<PartitionAndOffset> windowBuffer) {
+			return windowBuffer.groupBy(getPartition).flatMap(findHighestOffsetInPartitionGroup);
+		}
+	}
+}

--- a/gradle/build-extensions.gradle
+++ b/gradle/build-extensions.gradle
@@ -50,6 +50,8 @@ project('spring-xd-extension-kafka') {
         }
         provided( "com.fasterxml.jackson.core:jackson-databind")
         provided("org.apache.zookeeper:zookeeper:$zookeeperVersion")
+		compile "io.reactivex:rxjava"
+		compile "io.reactivex:rxjava-math:1.0.0"
         compile project(':spring-xd-module-spi')
         testCompile project(':spring-xd-test')
         compile "javax.validation:validation-api"

--- a/modules/source/kafka/config/kafka.xml
+++ b/modules/source/kafka/config/kafka.xml
@@ -49,12 +49,20 @@
 		<constructor-arg index="0" ref="connectionFactory"/>
 		<constructor-arg index="1" ref="partitions"/>
 		<property name="maxFetch" value="${fetchMaxBytes}"/>
-		<property name="offsetManager" ref="offsetManager"/>
+		<property name="offsetManager">
+			<bean class="org.springframework.integration.x.kafka.WindowingOffsetManager">
+				<constructor-arg ref="offsetManager"/>
+				<property name="timespan" value="${offsetUpdateTimeWindow}"/>
+				<property name="count" value="${offsetUpdateCount}"/>
+				<property name="shutdownTimeout" value="${offsetUpdateShutdownTimeout}" />
+			</bean>
+		</property>
 		<property name="concurrency" value="${streams}"/>
+		<property name="queueSize" value="${queueSize}"/>
 	</bean>
 
-	<bean id="stringDecoder" class="org.springframework.integration.kafka.serializer.common.StringDecoder">
-		<constructor-arg index="0" value="${encoding}"/>
+	<bean id="stringDecoder" class="kafka.serializer.DefaultDecoder">
+		<constructor-arg index="0" value="#{null}"/>
 	</bean>
 
 	<bean id="kafkaInboundChannelAdapter"
@@ -107,8 +115,15 @@
 	<beans profile="kafka-offset-manager">
 		<bean id="offsetManager" class="org.springframework.integration.kafka.listener.KafkaTopicOffsetManager">
 			<constructor-arg index="0" ref="kafkaSourceZookeeperConnect"/>
-			<constructor-arg index="1" value="${xd.stream.name}-${xd.module.name}-offsets"/>
+			<constructor-arg index="1" value="${kafkaOffsetTopicName}"/>
 			<constructor-arg index="2" ref="initialOffsetsMap"/>
+			<property name="segmentSize" value="${kafkaOffsetTopicSegmentSize}"/>
+			<property name="retentionTime" value="${kafkaOffsetTopicRetentionTime}"/>
+			<property name="batchWrites" value="${kafkaOffsetTopicBatchingEnabled}"/>
+			<property name="maxSize" value="${kafkaOffsetTopicMaxSize}"/>
+			<property name="maxBatchSize" value="${kafkaOffsetTopicBatchSize}"/>
+			<property name="maxQueueBufferingTime" value="${kafkaOffsetTopicBatchTime}"/>
+			<property name="requiredAcks" value="${kafkaOffsetTopicRequiredAcks}"/>
 			<property name="consumerId" value="${groupId}"/>
 			<property name="referenceTimestamp" value="${autoOffsetResetValue}"/>
 		</bean>

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -146,7 +146,18 @@ xd:
       brokers:                                 localhost:9092
       zkAddress:                               localhost:2181
       numOfKafkaPartitionsForCountEqualsZero:  10
+      socketBufferSize:                        2097152
       offsetStoreTopic:                        SpringXdOffsets
+      offsetStoreSegmentSize:                  25000000
+      offsetStoreRetentionTime:                60000
+      offsetStoreRequiredAcks:                 1
+      offsetStoreMaxFetchSize:                 1048576
+      offsetStoreBatchSize:                    200
+      offsetStoreBatchEnabled:                 false
+      offsetStoreBatchTime:                    1000
+      offsetUpdateTimeWindow:                  10000
+      offsetUpdateCount:                       0
+      offsetUpdateShutdownTimeout:             2000
       default:
         batchingEnabled:           false
         batchSize:                 200
@@ -156,6 +167,7 @@ xd:
         requiredAcks:              1
         compressionCodec:          default
         autoCommitEnabled:         true
+        queueSize:                 1000
   security:
     authorization:
       rules:

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
@@ -132,8 +132,8 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 			Message<?> inbound = moduleInputChannel.receive(2000);
 			assertNotNull(inbound);
 			assertArrayEquals(ratherBigPayload, (byte[]) inbound.getPayload());
-			messageBus.unbindProducers("fooCompression"+codec+".0");
-			messageBus.unbindConsumers("fooCompression"+codec+".0");
+			messageBus.unbindProducers("foo.0");
+			messageBus.unbindConsumers("foo.0");
 		}
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
@@ -55,6 +55,7 @@ public class KafkaTestMessageBus extends AbstractTestMessageBus<KafkaMessageBus>
 			KafkaMessageBus messageBus = new KafkaMessageBus(zookeeperConnect,
 					kafkaTestSupport.getBrokerAddress(),
 					kafkaTestSupport.getZkConnectString(), codec);
+			messageBus.setDefaultBatchingEnabled(false);
 			messageBus.afterPropertiesSet();
 			GenericApplicationContext context = new GenericApplicationContext();
 			context.refresh();

--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -59,6 +59,7 @@ import org.springframework.integration.kafka.support.ProducerConfiguration;
 import org.springframework.integration.kafka.support.ProducerFactoryBean;
 import org.springframework.integration.kafka.support.ProducerMetadata;
 import org.springframework.integration.kafka.support.ZookeeperConnect;
+import org.springframework.integration.x.kafka.WindowingOffsetManager;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
@@ -250,6 +251,8 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 	private int defaultRequiredAcks = DEFAULT_REQUIRED_ACKS;
 
+	private int defaultQueueSize = 1000;
+
 	private ConnectionFactory connectionFactory;
 
 	private String offsetStoreTopic = "SpringXdOffsets";
@@ -258,6 +261,27 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 	private boolean defaultAutoCommitEnabled = DEFAULT_AUTO_COMMIT_ENABLED;
 
+	private int socketBufferSize = 2097152;
+
+	private int offsetStoreSegmentSize = 250 * 1024 * 1024;
+
+	private int offsetStoreRetentionTime = 60000;
+
+	private int offsetStoreRequiredAcks = 1;
+
+	private int offsetStoreMaxFetchSize = 1048576;
+
+	private boolean offsetStoreBatchEnabled = false;
+
+	private int offsetStoreBatchSize = 200;
+
+	private int offsetStoreBatchTime = 1000;
+
+	private int offsetUpdateTimeWindow = 10000;
+
+	private int offsetUpdateCount = 0;
+
+	private int offsetUpdateShutdownTimeout = 2000;
 
 	public KafkaMessageBus(ZookeeperConnect zookeeperConnect, String brokers, String zkAddress,
 			MultiTypeCodec<Object> codec, String... headersToMap) {
@@ -283,6 +307,51 @@ public class KafkaMessageBus extends MessageBusSupport {
 		this.offsetStoreTopic = offsetStoreTopic;
 	}
 
+	public void setOffsetStoreSegmentSize(int offsetStoreSegmentSize) {
+		this.offsetStoreSegmentSize = offsetStoreSegmentSize;
+	}
+
+	public void setOffsetStoreRetentionTime(int offsetStoreRetentionTime) {
+		this.offsetStoreRetentionTime = offsetStoreRetentionTime;
+	}
+
+	public void setSocketBufferSize(int socketBufferSize) {
+		this.socketBufferSize = socketBufferSize;
+	}
+
+	public void setOffsetStoreRequiredAcks(int offsetStoreRequiredAcks) {
+		this.offsetStoreRequiredAcks = offsetStoreRequiredAcks;
+	}
+
+	public void setOffsetStoreMaxFetchSize(int offsetStoreMaxFetchSize) {
+		this.offsetStoreMaxFetchSize = offsetStoreMaxFetchSize;
+	}
+
+
+	public void setOffsetUpdateTimeWindow(int offsetUpdateTimeWindow) {
+		this.offsetUpdateTimeWindow = offsetUpdateTimeWindow;
+	}
+
+	public void setOffsetUpdateCount(int offsetUpdateCount) {
+		this.offsetUpdateCount = offsetUpdateCount;
+	}
+
+	public void setOffsetUpdateShutdownTimeout(int offsetUpdateShutdownTimeout) {
+		this.offsetUpdateShutdownTimeout = offsetUpdateShutdownTimeout;
+	}
+
+	public void setOffsetStoreBatchEnabled(boolean offsetStoreBatchEnabled) {
+		this.offsetStoreBatchEnabled = offsetStoreBatchEnabled;
+	}
+
+	public void setOffsetStoreBatchSize(int offsetStoreBatchSize) {
+		this.offsetStoreBatchSize = offsetStoreBatchSize;
+	}
+
+	public void setOffsetStoreBatchTime(int offsetStoreBatchTime) {
+		this.offsetStoreBatchTime = offsetStoreBatchTime;
+	}
+
 	/**
 	 * Retry configuration for operations such as validating topic creation
 	 *
@@ -295,8 +364,10 @@ public class KafkaMessageBus extends MessageBusSupport {
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		// we instantiate the connection factory here due to https://jira.spring.io/browse/XD-2647
+		ZookeeperConfiguration configuration = new ZookeeperConfiguration(this.zookeeperConnect);
+		configuration.setBufferSize(socketBufferSize);
 		DefaultConnectionFactory defaultConnectionFactory =
-				new DefaultConnectionFactory(new ZookeeperConfiguration(this.zookeeperConnect));
+				new DefaultConnectionFactory(configuration);
 		defaultConnectionFactory.afterPropertiesSet();
 		this.connectionFactory = defaultConnectionFactory;
 		if (retryOperations == null) {
@@ -362,6 +433,9 @@ public class KafkaMessageBus extends MessageBusSupport {
 		this.defaultAutoCommitEnabled = defaultAutoCommitEnabled;
 	}
 
+	public void setDefaultQueueSize(int defaultQueueSize) {
+		this.defaultQueueSize = defaultQueueSize;
+	}
 
 	@Override
 	public void bindConsumer(String name, final MessageChannel moduleInputChannel, Properties properties) {
@@ -643,18 +717,39 @@ public class KafkaMessageBus extends MessageBusSupport {
 		}
 		// if we have less target partitions than target concurrency, adjust accordingly
 		messageListenerContainer.setConcurrency(Math.min(numThreads, listenedPartitions.size()));
-		KafkaTopicOffsetManager offsetManager = new KafkaTopicOffsetManager(zookeeperConnect, offsetStoreTopic,
-					Collections.<Partition, Long>emptyMap());
-		offsetManager.setConsumerId(group);
-		offsetManager.setReferenceTimestamp(referencePoint);
+		OffsetManager offsetManager = createOffsetManager(group, referencePoint);
+		messageListenerContainer.setOffsetManager(offsetManager);
+		messageListenerContainer.setQueueSize(defaultQueueSize);
+		return messageListenerContainer;
+	}
+
+	private OffsetManager createOffsetManager(String group, long referencePoint) {
 		try {
-			offsetManager.afterPropertiesSet();
+			KafkaTopicOffsetManager kafkaOffsetManager =
+					new KafkaTopicOffsetManager(zookeeperConnect, offsetStoreTopic, Collections.<Partition, Long>emptyMap());
+			kafkaOffsetManager.setConsumerId(group);
+			kafkaOffsetManager.setReferenceTimestamp(referencePoint);
+			kafkaOffsetManager.setSegmentSize(offsetStoreSegmentSize);
+			kafkaOffsetManager.setRetentionTime(offsetStoreRetentionTime);
+			kafkaOffsetManager.setRequiredAcks(offsetStoreRequiredAcks);
+			kafkaOffsetManager.setMaxSize(offsetStoreMaxFetchSize);
+			kafkaOffsetManager.setBatchWrites(offsetStoreBatchEnabled);
+			kafkaOffsetManager.setMaxBatchSize(offsetStoreBatchSize);
+			kafkaOffsetManager.setMaxQueueBufferingTime(offsetStoreBatchTime);
+
+			kafkaOffsetManager.afterPropertiesSet();
+
+			WindowingOffsetManager windowingOffsetManager = new WindowingOffsetManager(kafkaOffsetManager);
+			windowingOffsetManager.setTimespan(offsetUpdateTimeWindow);
+			windowingOffsetManager.setCount(offsetUpdateCount);
+			windowingOffsetManager.setShutdownTimeout(offsetUpdateShutdownTimeout);
+
+			windowingOffsetManager.afterPropertiesSet();
+			return windowingOffsetManager;
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
-		messageListenerContainer.setOffsetManager(offsetManager);
-		return messageListenerContainer;
 	}
 
 	@Override
@@ -750,6 +845,11 @@ public class KafkaMessageBus extends MessageBusSupport {
 			return true;
 		}
 
+		@Override
+		protected boolean shouldCopyRequestHeaders() {
+			// prevent the message from being copied again in superclass
+			return false;
+		}
 	}
 
 	private class SendingHandler extends AbstractMessageHandler {

--- a/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
+++ b/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
@@ -24,9 +24,20 @@
 		<property name="defaultReplicationFactor" value="${xd.messagebus.kafka.default.replicationFactor}"/>
 		<property name="defaultConcurrency" value="${xd.messagebus.kafka.default.concurrency}"/>
 		<property name="defaultRequiredAcks" value="${xd.messagebus.kafka.default.requiredAcks}"/>
+		<property name="defaultQueueSize" value="${xd.messagebus.kafka.default.queueSize}"/>
 		<property name="defaultCompressionCodec" value="${xd.messagebus.kafka.default.compressionCodec}"/>
 		<property name="defaultAutoCommitEnabled" value="${xd.messagebus.kafka.default.autoCommitEnabled}"/>
 		<property name="offsetStoreTopic" value="${xd.messagebus.kafka.offsetStoreTopic}"/>
+		<property name="offsetStoreSegmentSize" value="${xd.messagebus.kafka.offsetStoreSegmentSize}"/>
+		<property name="offsetStoreRetentionTime" value="${xd.messagebus.kafka.offsetStoreRetentionTime}"/>
+		<property name="offsetStoreRequiredAcks" value="${xd.messagebus.kafka.offsetStoreRequiredAcks}"/>
+		<property name="offsetStoreMaxFetchSize" value="${xd.messagebus.kafka.offsetStoreMaxFetchSize}"/>
+		<property name="offsetStoreBatchEnabled" value="${xd.messagebus.kafka.offsetStoreBatchEnabled}"/>
+		<property name="offsetStoreBatchSize" value="${xd.messagebus.kafka.offsetStoreBatchSize}"/>
+		<property name="offsetStoreBatchTime" value="${xd.messagebus.kafka.offsetStoreBatchTime}"/>
+		<property name="offsetUpdateTimeWindow" value="${xd.messagebus.kafka.offsetUpdateTimeWindow}"/>
+		<property name="offsetUpdateCount" value="${xd.messagebus.kafka.offsetUpdateCount}"/>
+		<property name="offsetUpdateShutdownTimeout" value="${xd.messagebus.kafka.offsetUpdateShutdownTimeout}"/>
 	</bean>
 
 </beans>

--- a/spring-xd-messagebus-local/src/main/java/org/springframework/xd/dirt/integration/bus/local/LocalMessageBus.java
+++ b/spring-xd-messagebus-local/src/main/java/org/springframework/xd/dirt/integration/bus/local/LocalMessageBus.java
@@ -331,6 +331,11 @@ public class LocalMessageBus extends MessageBusSupport {
 		BridgeHandler handler = new BridgeHandler() {
 
 			@Override
+			protected boolean shouldCopyRequestHeaders() {
+				return false;
+			}
+
+			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return requestMessage;
 			}

--- a/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -467,6 +467,11 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 			return deserializePayloadIfNecessary(theRequestMessage);
 		}
 
+		@Override
+		protected boolean shouldCopyRequestHeaders() {
+			// prevent returned message from being copied in superclass
+			return false;
+		}
 	}
 
 	private static class RedisPropertiesAccessor extends AbstractBusPropertiesAccessor {

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/KafkaSourceSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/KafkaSourceSinkTests.java
@@ -86,7 +86,7 @@ public class KafkaSourceSinkTests extends AbstractStreamIntegrationTest {
 				httpSource, topicToUse, kafkaTestSupport.getBrokerAddress());
 		// create stream with kafka source
 		final CounterSink counter = metrics().newCounterSink();
-		stream().create(generateStreamName(), "kafka --topic='%s' --zkconnect=%s | " +
+		stream().create(generateStreamName(), "kafka --topic='%s' --zkconnect=%s --outputType=text/plain | " +
 				"filter --expression=payload.toString().contains('%s') | %s",
 				topicToUse, kafkaTestSupport.getZkConnectString(), stringToPost, counter );
 		httpSource.ensureReady().postData(stringToPost);


### PR DESCRIPTION
- change defaults for consumers in the Kafka source and message bus
- expose configuration options for tuning consumers in the Kafka source and message bus
- add option to tune the frequency of offset manager updates
- disable redundant header copying in the Message Bus
- Kafka source emits the byte[] payload of the message, without automatically trying to convert it to String
