### PR TITLE
[Sprint: 46] XD-2853 Deployment message consumer ordering

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
@@ -456,9 +456,6 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 				jobDeployments = instantiatePathChildrenCache(client, Paths.JOB_DEPLOYMENTS);
 				jobDeployments.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
 
-				deploymentQueueForConsumer = new DeploymentQueue(client, deploymentMessageConsumer, Paths.DEPLOYMENT_QUEUE,
-						executorService);
-				deploymentQueueForConsumer.start();
 				SupervisorElectedEvent supervisorElectedEvent = new SupervisorElectedEvent(moduleDeploymentRequests,
 						streamDeployments, jobDeployments);
 
@@ -484,6 +481,10 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 				containers = instantiatePathChildrenCache(client, Paths.CONTAINERS);
 				containers.getListenable().addListener(containerListener);
 				containers.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
+
+				deploymentQueueForConsumer = new DeploymentQueue(client, deploymentMessageConsumer, Paths.DEPLOYMENT_QUEUE,
+						executorService);
+				deploymentQueueForConsumer.start();
 
 				Thread.sleep(Long.MAX_VALUE);
 			}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
@@ -433,9 +433,6 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 		public void takeLeadership(CuratorFramework client) throws Exception {
 			logger.info("Leader Admin {} is watching for stream/job deployment requests.", getId());
 			cleanupDeployments(client);
-			deploymentQueueForConsumer = new DeploymentQueue(client, deploymentMessageConsumer, Paths.DEPLOYMENT_QUEUE,
-					executorService);
-			deploymentQueueForConsumer.start();
 			PathChildrenCache containers = null;
 			PathChildrenCache streamDeployments = null;
 			PathChildrenCache jobDeployments = null;
@@ -459,6 +456,9 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 				jobDeployments = instantiatePathChildrenCache(client, Paths.JOB_DEPLOYMENTS);
 				jobDeployments.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
 
+				deploymentQueueForConsumer = new DeploymentQueue(client, deploymentMessageConsumer, Paths.DEPLOYMENT_QUEUE,
+						executorService);
+				deploymentQueueForConsumer.start();
 				SupervisorElectedEvent supervisorElectedEvent = new SupervisorElectedEvent(moduleDeploymentRequests,
 						streamDeployments, jobDeployments);
 


### PR DESCRIPTION
 - Make sure the ZK distributed queue consumer for
processing deployment messages is initialized after
the path cache is setup for module, stream and job
deployment requests paths.