### PR TITLE
[master + backport] XD-2854 Check for ZK data with with no module defs

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamDefinitionRepository.java
@@ -21,10 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundPathAndBytesable;
 import org.apache.zookeeper.KeeperException.NoNodeException;
@@ -47,6 +43,11 @@ import org.springframework.xd.dirt.zookeeper.Paths;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperUtils;
 import org.springframework.xd.module.ModuleDefinition;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 
 /**
  * @author Mark Fisher
@@ -154,8 +155,10 @@ public class ZooKeeperStreamDefinitionRepository implements StreamDefinitionRepo
 			}
 			Map<String, String> map = ZooKeeperUtils.bytesToMap(bytes);
 			StreamDefinition streamDefinition = new StreamDefinition(id, map.get(DEFINITION_KEY));
-			List<ModuleDefinition> moduleDefinitions = objectReader.readValue(map.get(MODULE_DEFINITIONS_KEY));
-			streamDefinition.setModuleDefinitions(moduleDefinitions);
+			if (map.get(MODULE_DEFINITIONS_KEY) != null) {
+				List<ModuleDefinition> moduleDefinitions = objectReader.readValue(map.get(MODULE_DEFINITIONS_KEY));
+				streamDefinition.setModuleDefinitions(moduleDefinitions);
+			}
 			return streamDefinition;
 		}
 		catch (Exception e) {

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
@@ -576,7 +576,12 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
 
 		public ModuleDefinition getModuleDefinition() {
 			if (moduleDefinition == null) {
-				moduleDefinition = ModuleDefinitions.dummy(moduleName, type);
+				moduleDefinition = new ModuleDefinition(moduleName, type) {
+					@Override
+					public boolean isComposed() {
+						return false;
+					}
+				};
 			}
 			return moduleDefinition;
 		}

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
@@ -575,6 +575,9 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
 		}
 
 		public ModuleDefinition getModuleDefinition() {
+			if (moduleDefinition == null) {
+				moduleDefinition = ModuleDefinitions.dummy(moduleName, type);
+			}
 			return moduleDefinition;
 		}
 	}


### PR DESCRIPTION
 - Add null check if the module definitions weren't set for the given stream
 - Use `dummy` resources if the module definition is null