### PR TITLE
[Sprint: 46] XD-2861 Exclude management context for leader election

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
@@ -216,10 +216,8 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 					logger.info("Set container quiet period to {} ms", delay);
 				}
 				if (this.zkConnection.isConnected()) {
-					if (this.applicationContext.equals(((ContextRefreshedEvent) event).getApplicationContext())) {
-						// initial registration, we don't yet have a port info
-						registerWithZooKeeper(zkConnection.getClient());
-					}
+					// initial registration, we don't yet have a port info
+					registerWithZooKeeper(zkConnection.getClient());
 					requestLeadership(this.zkConnection.getClient());
 				}
 				this.zkConnection.addListener(connectionListener);
@@ -467,7 +465,6 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 						applicationContext.getBeansOfType(SupervisorElectionListener.class);
 				System.out.println("listenersMap ***** "+ listenersMap);
 				for (Map.Entry<String, SupervisorElectionListener> entry : listenersMap.entrySet()) {
-					System.out.println("firing supervisorElectedEvent ***** "+ entry.getValue());
 					entry.getValue().onSupervisorElected(supervisorElectedEvent);
 				}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
@@ -463,7 +463,6 @@ public class DeploymentSupervisor implements ApplicationListener<ApplicationEven
 
 				Map<String, SupervisorElectionListener> listenersMap =
 						applicationContext.getBeansOfType(SupervisorElectionListener.class);
-				System.out.println("listenersMap ***** "+ listenersMap);
 				for (Map.Entry<String, SupervisorElectionListener> entry : listenersMap.entrySet()) {
 					entry.getValue().onSupervisorElected(supervisorElectedEvent);
 				}


### PR DESCRIPTION
 - When the admin server uses different port for management context,
then the management context requests the leadership. This leads to
issues accessing the beans from the original admin server context
inside leader election.
 - Check for `management` namespace for the context when the
context refresh event is fired and exclude this context for
leadership election.