### PR TITLE
[master] XD-2865: Ensure that consumers are shut down before unbinding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ ext {
 	splunkVersion = '1.3.0'
 	springBatchAdminMgrVersion = '1.3.0.RELEASE'
 	springIntegrationSplunkVersion = '1.1.0.RELEASE'
-	springIntegrationKafkaVersion = '1.1.0.RELEASE'
+	springIntegrationKafkaVersion = '1.1.1.RELEASE'
 	kafkaVersion = '0.8.1.1'
 	springShellVersion = '1.1.0.RELEASE'
 	zookeeperVersion = '3.4.6'


### PR DESCRIPTION
- Upgrade to 1.1.1 for reliable KafkaMessageListenerChannelAdapter stopping;
- Ensure that the component is stopped before unbinding.