### PR TITLE
[Sprint: 46] XD-2829: Support XML Payloads in xd/lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -416,6 +416,7 @@ project('spring-xd-dirt') {
 			exclude group: 'org.springframework', module: 'spring-core'
 		}
 		compile "org.springframework.integration:spring-integration-event"
+		compile "org.springframework.integration:spring-integration-xml"
 		//compile "org.springframework.integration:spring-integration-http"
 		// TODO: Investigate why spring-integration-http's optional dependency xerces becomes transitive dependency
 		configurations.compile.exclude(group: "xerces")


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2829

Add spring-integration-xml (and hence spring-xml) to xd/lib
to support `xpath` expressions in standard modules that support
expressions (transform, filter etc).