### PR TITLE
[Sprint: 46] XD-2389: Document Mandatory Module Labels

### DIFF
--- a/src/docs/asciidoc/DSL-Reference.asciidoc
+++ b/src/docs/asciidoc/DSL-Reference.asciidoc
@@ -17,7 +17,7 @@ A stream that involves some processing:
 
   http | filter | transform | file
 
-The modules in a stream definition are connected together using the pipe symbol `|`.  
+The modules in a stream definition are connected together using the pipe symbol `|`.
 
 === Module parameters
 
@@ -38,16 +38,16 @@ If the parameter value needs to embed a single quote, use two single quotes:
 === Named channels
 
 Instead of a source or sink it is possible to use a named channel. Normally the modules in a stream are connected
-by anonymous internal channels (represented by the pipes), but by using explicitly named channels it becomes 
+by anonymous internal channels (represented by the pipes), but by using explicitly named channels it becomes
 possible to construct more sophisticated flows. In keeping with the unix theme, sourcing/sinking data from/to a particular channel uses the `>` character. A named channel is specified by using a channel type, followed by a `:` followed by a name. The channel types available are:
 
   queue - this type of channel has point-to-point (p2p) semantics
 
   topic - this type of channel has pub/sub semantics
 
-Here is an example that shows how you can use a named channel to share a data pipeline driven by different input sources.  
+Here is an example that shows how you can use a named channel to share a data pipeline driven by different input sources.
 
-  queue:foo > file 
+  queue:foo > file
 
   http > queue:foo
 
@@ -58,23 +58,24 @@ Now if you post data to the http source, you will see that data intermingled wit
 
 The opposite case, the fanout of a message to multiple streams, is planned for a future release. However, xref:Taps#taps[taps] are a specialization of named channels that do allow publishing data to multiple sinks. For example:
 
-  tap:stream:mystream > file 
+  tap:stream:mystream > file
 
   tap:stream:mystream > log
 
-Once data is received on `mystream`, it will be written to both file and log. 
+Once data is received on `mystream`, it will be written to both file and log.
 
 Support for routing messages to different streams based on message content is also planned for a future release.
 
+[[labels]]
 === Labels
 
 Labels provide a means to alias or group modules.  Labels are simply a name followed by a `:`
-When used as an alias a label can provide a more descriptive name for a 
+When used as an alias a label can provide a more descriptive name for a
 particular configuration of a module and possibly something easier to refer to in other streams.
 
   mystream = http | obfuscator: transform --expression=payload.replaceAll('password','*') | file
 
-Labels are especially useful for disambiguating when multiple modules of the same name are used:
+Labels are especially useful (and required) for disambiguating when multiple modules of the same name are used:
 
   mystream = http | uppercaser: transform --expression=payload.toUpperCase() | exclaimer: transform --expression=payload+'!' | file
 
@@ -185,4 +186,3 @@ stream create foo --definition "http | transform --expression=\"'hello world'\" 
 
 <1> This uses single quotes around the string (at the XD parser level), but they need to be doubled because we're inside a string literal (very first single quote after the equals sign)
 <2> use single and double quotes respectively to encompass the whole string at the XD parser level. Hence, the other kind of quote can be used inside the string. The whole thing is inside the `--definition` argument to the shell though, which uses double quotes. So double quotes are escaped (at the shell level)
-

--- a/src/docs/asciidoc/Streams.asciidoc
+++ b/src/docs/asciidoc/Streams.asciidoc
@@ -14,7 +14,7 @@ A high level DSL is used to create stream definitions. The DSL to define a strea
 
      http | file
 
-The DSL mimics a UNIX pipes and filters syntax. Default values for ports and filenames are used in this example but can be overriden using `--` options, such as 
+The DSL mimics a UNIX pipes and filters syntax. Default values for ports and filenames are used in this example but can be overriden using `--` options, such as
 
      http --port=8091 | file --dir=/tmp/httpdata/
 
@@ -22,12 +22,12 @@ To create these stream definitions you make an HTTP POST request to the XD Admin
 
 === Creating a Simple Stream
 
-The XD Admin server footnote:[The server is implemented by the `AdminMain` class in the `spring-xd-dirt` subproject] exposes a full RESTful API for managing the lifecycle of stream definitions, but the easiest way to use the XD shell. Start the shell as described in the xref:Getting-Started#getting-started[Getting Started] section 
+The XD Admin server footnote:[The server is implemented by the `AdminMain` class in the `spring-xd-dirt` subproject] exposes a full RESTful API for managing the lifecycle of stream definitions, but the easiest way to use the XD shell. Start the shell as described in the xref:Getting-Started#getting-started[Getting Started] section
 
 New streams are created by posting stream definitions.  The definitions are built from a simple DSL. For example, let's walk through what happens if we execute the following shell command:
 
     xd:> stream create --definition "time | log" --name ticktock
-  
+
 
 This defines a stream named `ticktock` based off the DSL expression `time | log`.  The DSL uses the "pipe" symbol `|`, to connect a source to a sink.
 
@@ -49,10 +49,12 @@ You can also include a http://docs.spring.io/spring/docs/4.0.x/spring-framework-
 
     xd:> stream deploy --name ticktock --properties "module.time.count=3,module.log.criteria=groups.contains('x')"
 
+IMPORTANT: See <<module-labels>>.
+
 === Deleting a Stream
 
 You can delete a stream by issuing the `stream destroy` command from the shell:
-  
+
     xd:> stream destroy --name ticktock
 
 === Deploying and Undeploying Streams
@@ -110,7 +112,7 @@ See the xref:Processors#processors[Processors] section for more information.
 
 === DSL Syntax
 
-In the examples above, we connected a source to a sink using the pipe symbol `|`. You can also pass parameters to the source and sink configurations. The parameter names will depend on the individual module implementations, but as an example, the `http` source module exposes a `port` setting which allows you to change the data ingestion port from the default value. To create the stream using port 8000, we would use 
+In the examples above, we connected a source to a sink using the pipe symbol `|`. You can also pass parameters to the source and sink configurations. The parameter names will depend on the individual module implementations, but as an example, the `http` source module exposes a `port` setting which allows you to change the data ingestion port from the default value. To create the stream using port 8000, we would use
 
     xd:> stream create --definition "http --port=8000 | log" --name myhttpstream
 
@@ -121,3 +123,8 @@ If you know a bit about Spring configuration files, you can inspect the module d
 In the examples above, simple module definitions are used to construct each stream. However, modules may be grouped together in order to avoid duplication and/or reduce the amount of chattiness over the messaging middleware. To learn more about that feature, refer to the xref:Modules#composing-modules[Composing Modules] section.
 
 If directed graphs are needed instead of the simple linear streams described above, two features are relevant. First, named channels may be used as a way to combine multiple flows upstream and/or downstream from the channel. The behavior of that channel may either be queue-based or topic-based depending on what prefix is used ("queue:myqueue" or "topic:mytopic", respectively). To learn more, refer to the xref:DSL-Reference#named-channels[Named Channels] section. Second, you may need to determine the output channel of a stream based on some information that is only known at runtime. To learn about such content-based routing, refer to the xref:Sinks#dynamic-router[Dynamic Router] section.
+
+[[module-labels]]
+=== Module Labels
+
+When a stream is comprised of multiple modules with the same name, they must be qualified with labels. See <<labels>>.


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-2389

Indicate in the stream documentation that labels are mandatory when multiple modules have the same name.