### PR TITLE
[Sprint: 46] XD-2854 Migrate Stream definitions that don't have MDs

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -123,7 +123,7 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 	 * @param moduleDescriptors The list of ModuleDescriptors resulting from parsing the definition.
 	 * @return a list of ModuleDefinitions
 	 */
-	private List<ModuleDefinition> createModuleDefinitions(List<ModuleDescriptor> moduleDescriptors) {
+	protected List<ModuleDefinition> createModuleDefinitions(List<ModuleDescriptor> moduleDescriptors) {
 		List<ModuleDefinition> moduleDefinitions = new ArrayList<ModuleDefinition>(moduleDescriptors.size());
 		for (ModuleDescriptor moduleDescriptor : moduleDescriptors) {
 			moduleDefinitions.add(moduleDescriptor.getModuleDefinition());

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDeployer.java
@@ -21,6 +21,26 @@ import static org.springframework.xd.dirt.stream.ParsingContext.stream;
 import org.springframework.xd.dirt.server.admin.deployment.DeploymentHandler;
 import org.springframework.xd.dirt.zookeeper.Paths;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.BackgroundPathAndBytesable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.xd.dirt.zookeeper.Paths;
+import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
+import org.springframework.xd.dirt.zookeeper.ZooKeeperUtils;
+import org.springframework.xd.module.ModuleDefinition;
+import org.springframework.xd.module.ModuleDescriptor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 
 /**
  * Default implementation of {@link StreamDeployer} that uses provided
@@ -33,8 +53,21 @@ import org.springframework.xd.dirt.zookeeper.ZooKeeperConnection;
  * @author Eric Bottard
  * @author Gunnar Hillert
  * @author Patrick Peralta
+ * @author Ilayaperumal Gopinathan
  */
 public class StreamDeployer extends AbstractInstancePersistingDeployer<StreamDefinition, Stream> {
+
+	private static final Logger logger = LoggerFactory.getLogger(StreamDeployer.class);
+
+	private final static TypeReference<List<ModuleDefinition>> MODULE_DEFINITIONS_LIST = new TypeReference<List<ModuleDefinition>>() {};
+
+	private final ObjectWriter objectWriter = new ObjectMapper().writerWithType(MODULE_DEFINITIONS_LIST);
+
+	private static final String DEFINITION_KEY = "definition";
+
+	private static final String MODULE_DEFINITIONS_KEY = "moduleDefinitions";
+
+	private final ZooKeeperConnection zkConnection;
 
 	/**
 	 * Stream definition parser.
@@ -52,6 +85,7 @@ public class StreamDeployer extends AbstractInstancePersistingDeployer<StreamDef
 	public StreamDeployer(ZooKeeperConnection zkConnection, StreamDefinitionRepository repository,
 			StreamRepository streamRepository, XDParser parser, DeploymentHandler deploymentHandler) {
 		super(zkConnection, repository, streamRepository, parser, deploymentHandler, stream);
+		this.zkConnection = zkConnection;
 		this.parser = parser;
 
 	}
@@ -78,6 +112,72 @@ public class StreamDeployer extends AbstractInstancePersistingDeployer<StreamDef
 	@Override
 	protected String getDeploymentPath(StreamDefinition definition) {
 		return Paths.build(Paths.STREAM_DEPLOYMENTS, definition.getName());
+	}
+
+	/**
+	 * The migration code to run against existing stream definitions that don't have module definitions set already.
+	 * The following method will update the module definitions for those stream definitions.
+	 * See https://jira.spring.io/browse/XD-2854
+	 */
+	@PostConstruct
+	private void updateModuleDefinitions() {
+		if (this.zkConnection.getClient() != null) {
+			try {
+				CuratorFramework client = this.zkConnection.getClient();
+				if (client.checkExists().forPath(Paths.STREAMS) != null) {
+					Iterable<StreamDefinition> streamDefinitions = findAll();
+					for (StreamDefinition definition : streamDefinitions) {
+						setModuleDefinitions(client, definition);
+					}
+				}
+			}
+			catch (Exception e) {
+				logger.error("Exception migrating stream definitions. This migration is done when the existing " +
+						"stream definitions that don't have module definitions set. " + e);
+			}
+		}
+	}
+
+	/**
+	 * Set the module definitions for the given stream definition.
+	 * Module definitions are obtained by parsing the stream definition.
+	 *
+	 * @param client the curator framework client
+	 * @param definition the stream definition
+	 */
+	private void setModuleDefinitions(CuratorFramework client, StreamDefinition definition) {
+		String streamName = definition.getName();
+		String path = Paths.build(Paths.STREAMS, streamName);
+		try {
+			byte[] bytes = client.getData().forPath(path);
+			if (bytes != null) {
+				Map<String, String> map = ZooKeeperUtils.bytesToMap(bytes);
+				if (map.get(MODULE_DEFINITIONS_KEY) == null) {
+					List<ModuleDescriptor> moduleDescriptors = this.parser.parse(streamName,
+							definition.getDefinition(), definitionKind);
+					List<ModuleDefinition> moduleDefinitions = createModuleDefinitions(moduleDescriptors);
+					if (!moduleDefinitions.isEmpty()) {
+						map.put(DEFINITION_KEY, definition.getDefinition());
+						try {
+							map.put(MODULE_DEFINITIONS_KEY,
+									objectWriter.writeValueAsString(moduleDefinitions));
+							byte[] binary = ZooKeeperUtils.mapToBytes(map);
+							BackgroundPathAndBytesable<?> op = client.checkExists().forPath(path) == null
+									? client.create() : client.setData();
+							op.forPath(path, binary);
+						}
+						catch (JsonProcessingException jpe) {
+							logger.error("Exception writing module definitions " + moduleDefinitions +
+									" for the stream " + streamName + " : " + jpe);
+						}
+					}
+				}
+			}
+		}
+		catch (Exception e) {
+			logger.error("Exception when updating module definitions for the stream "
+					+ streamName + " : " + e);
+		}
 	}
 
 }

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
@@ -112,10 +112,10 @@ public class ModuleDescriptor implements Comparable<ModuleDescriptor> {
 		this.index = index;
 		this.moduleDefinition = moduleDefinition;
 		this.parameters = parameters == null
-				? Collections.<String, String> emptyMap()
+				? Collections.<String, String>emptyMap()
 				: Collections.unmodifiableMap(new HashMap<String, String>(parameters));
 		this.children = children == null
-				? Collections.<ModuleDescriptor> emptyList()
+				? Collections.<ModuleDescriptor>emptyList()
 				: Collections.unmodifiableList(new ArrayList<ModuleDescriptor>(children));
 	}
 


### PR DESCRIPTION
 - This code checks for existing stream definitions and update
the module definitions if they don't exist.
 - Add better exception handling
 - Use PostConstruct to run migration