### PR TITLE
XD-2885: Fix modules packaging to only include relevant files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -589,7 +589,12 @@ project('spring-xd-dirt') {
 
 	applicationDistribution.from(scriptFiles) { into "bin" }
 
-	applicationDistribution.from(moduleFiles) { into "modules" }
+	applicationDistribution.from(moduleFiles) {
+		into "modules"
+		include "*/*/lib/*"
+		include "*/*/config/*"
+		include "common"
+	}
 
 	// Following execution is used by jsTests task to start SingleNodeApplication as background process
 	task backgroundAdminServer << { task ->

--- a/build.gradle
+++ b/build.gradle
@@ -593,7 +593,7 @@ project('spring-xd-dirt') {
 		into "modules"
 		include "*/*/lib/*"
 		include "*/*/config/*"
-		include "common"
+		include "common/*"
 	}
 
 	// Following execution is used by jsTests task to start SingleNodeApplication as background process


### PR DESCRIPTION
You'll also want to make sure that you don't have `${checkout_dir}/modules/lib`, as this was a previous bogus dir (fixed in a different PR), but not cleaned. This can safely be `rm -fR`ed, and it should not re-appear (and not be packaged)