### PR TITLE
Allow "--path=..." configuration in HTTP channel adapter

### DIFF
--- a/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
+++ b/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
@@ -171,7 +171,9 @@ public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 	private void putToChannelAdapter() {
 		Map<String, Object> pathToProducer = getModuleState();
 		if (pathToProducer.containsKey(path)) {
-			logger.warn("Channel for path '" + path + "' already exists, overwriting.");
+			String msg = "Channel for HTTP port " + port + ", path '" + path + "' already exists.";
+			logger.warn(msg);
+			throw new RuntimeException(msg);
 		}
 		pathToProducer.put(path, this);
 	}
@@ -255,6 +257,8 @@ public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 		if (bootstrap != null) {
 			bootstrap.shutdown();
 		}
+		Map<String, Object> pathToProducer = getModuleState();
+		pathToProducer.remove(path);
 	}
 
 	private SSLContext initializeSSLContext() throws Exception {

--- a/modules/source/http/config/http.xml
+++ b/modules/source/http/config/http.xml
@@ -9,6 +9,7 @@
 
 	<beans:bean class="org.springframework.integration.x.http.NettyHttpInboundChannelAdapter">
 		<beans:constructor-arg value="${port}"/>
+		<beans:constructor-arg value="${path}"/>
 		<beans:constructor-arg value="${https}"/>
 		<beans:property name="autoStartup" value="false"/>
 		<beans:property name="outputChannel" ref="output"/>

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
@@ -27,6 +27,8 @@ public class HttpSourceOptionsMetadata {
 
 	private int port = 9000;
 
+	private String path = "/";
+
 	private boolean https;
 
 	private String sslPropertiesLocation = "classpath:httpSSL.properties";
@@ -42,6 +44,15 @@ public class HttpSourceOptionsMetadata {
 	@ModuleOption("the port to listen to")
 	public void setPort(int port) {
 		this.port = port;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	@ModuleOption("the path of this source")
+	public void setPath(String path) {
+		this.path = path;
 	}
 
 	public boolean isHttps() {

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ModuleOption.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ModuleOption.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Used to annotate the setter methods of a POJO Module Options class to provide the framework with additional option
  * information.
- * 
+ *
  * @author Eric Bottard
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -68,6 +68,7 @@ The **$$http$$** $$source$$ has the following options:
 $$https$$:: $$true for https://$$ *($$boolean$$, default: `false`)*
 $$maxContentLength$$:: $$the maximum allowed content length$$ *($$int$$, default: `1048576`)*
 $$messageConverterClass$$:: $$the name of a custom MessageConverter class, to convert HttpRequest to Message; must have a constructor with a 'MessageBuilderFactory' parameter$$ *($$String$$, default: `org.springframework.integration.x.http.NettyInboundMessageConverter`)*
+$$path$$:: $$the path of this source$$ *($$String$$, default: `/`)*
 $$port$$:: $$the port to listen to$$ *($$int$$, default: `9000`)*
 $$sslPropertiesLocation$$:: $$location (resource) of properties containing the location of the pkcs12 keyStore and pass phrase$$ *($$String$$, default: `classpath:httpSSL.properties`)*
 //$source.http


### PR DESCRIPTION
Currently, each HTTP stream channel uses its own port, which is a limitation if we want to use large numbers of HTTP streams with fine granularity. It would be nice to (additionally) use URI paths to identify HTTP channels, allowing to re-use a single HTTP port for multiple channels in XD. 

Example usage:
```
stream create --name s1 --definition "http --port=9495 --path=/foo  | log" --deploy
```

This pull request contains a working proof-of-concept implementation, including a set of simple integration tests. 

Any comments/suggestions welcome! Thanks