### PR TITLE
[Sprint: 47] [master][backport]XD-2879 Customizable Kafka message bus partition setting

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -91,6 +91,7 @@
 #        autoCommitEnabled:         true
 #        queueSize:                 1000
 #        fetchSize:                 1048576
+#        minPartitionCount:         1
 
 #Disable batch database initialization
 #spring:

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -169,6 +169,7 @@ xd:
         autoCommitEnabled:         true
         queueSize:                 1000
         fetchSize:                 1048576
+        minPartitionCount:         1
   security:
     authorization:
       rules:

--- a/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
+++ b/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
@@ -28,6 +28,7 @@
 		<property name="defaultCompressionCodec" value="${xd.messagebus.kafka.default.compressionCodec}"/>
 		<property name="defaultAutoCommitEnabled" value="${xd.messagebus.kafka.default.autoCommitEnabled}"/>
 		<property name="defaultFetchSize" value="${xd.messagebus.kafka.default.fetchSize}"/>
+		<property name="defaultMinPartitionCount" value="${xd.messagebus.kafka.default.minPartitionCount}"/>
 		<property name="offsetStoreTopic" value="${xd.messagebus.kafka.offsetStoreTopic}"/>
 		<property name="offsetStoreSegmentSize" value="${xd.messagebus.kafka.offsetStoreSegmentSize}"/>
 		<property name="offsetStoreRetentionTime" value="${xd.messagebus.kafka.offsetStoreRetentionTime}"/>


### PR DESCRIPTION
Add `minKafkaPartitions` property that can be used on a Kafka Bus producer for (optionally) overpartitioning the bus. In case the module/partition count and concurrency are higher than this value, it will be overriden.