### PR TITLE
[Sprint: 47] XD-2815 (DO NOT MERGE)

### DIFF
--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReaderFactory.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReaderFactory.java
@@ -59,6 +59,8 @@ public class NamedColumnJdbcItemReaderFactory implements FactoryBean<NamedColumn
 
 	private NamedColumnJdbcItemReader reader;
 
+	private String delimiter;
+
 	@Override
 	public NamedColumnJdbcItemReader getObject() throws Exception {
 
@@ -118,6 +120,7 @@ public class NamedColumnJdbcItemReaderFactory implements FactoryBean<NamedColumn
 		reader.setFetchSize(fetchSize);
 		reader.setDataSource(dataSource);
 		reader.setVerifyCursorPosition(verifyCursorPosition);
+		reader.setDelimiter(delimiter);
 		reader.afterPropertiesSet();
 
 		initialized = true;
@@ -151,4 +154,7 @@ public class NamedColumnJdbcItemReaderFactory implements FactoryBean<NamedColumn
 		this.verifyCursorPosition = verify;
 	}
 
+	public void setDelimiter(String delimiter) {
+		this.delimiter = delimiter;
+	}
 }

--- a/modules/job/jdbchdfs/config/jdbchdfs.xml
+++ b/modules/job/jdbchdfs/config/jdbchdfs.xml
@@ -62,17 +62,13 @@
 		<property name="partitionClause" value="#{stepExecutionContext['partClause']}" />
 		<property name="sql" value="${sql}"/>
 		<property name="fetchSize" value="${commitInterval}"/>
+		<property name="delimiter" value="${delimiter}"/>
 	</bean>
 
 	<bean id="itemWriter" class="org.springframework.xd.batch.item.hadoop.HdfsTextItemWriter" scope="step">
 		<constructor-arg ref="hadoopFs"/>
 		<property name="lineAggregator">
-			<bean class="org.springframework.batch.item.file.transform.DelimitedLineAggregator">
-				<property name="fieldExtractor">
-					<bean class="org.springframework.xd.tuple.batch.TupleFieldExtractor"/>
-				</property>
-				<property name="delimiter" value="${delimiter}"/>
-			</bean>
+			<bean class="org.springframework.batch.item.file.transform.PassThroughLineAggregator"/>
 		</property>
 		<property name="baseFilename" value="${fileName}#{stepExecutionContext['partSuffix']}"/>
 		<property name="rolloverThresholdInBytes" value="${rollover}"/>
@@ -87,6 +83,7 @@
 	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
 		fs.defaultFS=${fsUri}
 	</hdp:configuration>
+
 	<hdp:resource-loader id="hadoopResourceLoader"/>
 
 </beans>


### PR DESCRIPTION
This PR removes the use of the Tuple in the jdbchdfs job and replaces it by creating the output String in the RowMapper.  On my laptop, this change took the processing from 2:20 to 17 seconds processing 1.7 million records.