### PR TITLE
XD-2815: Refactored jdbchdfs job to not use Tuple data structure

### DIFF
--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReaderFactory.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReaderFactory.java
@@ -59,6 +59,8 @@ public class NamedColumnJdbcItemReaderFactory implements FactoryBean<NamedColumn
 
 	private NamedColumnJdbcItemReader reader;
 
+	private String delimiter;
+
 	@Override
 	public NamedColumnJdbcItemReader getObject() throws Exception {
 
@@ -118,6 +120,7 @@ public class NamedColumnJdbcItemReaderFactory implements FactoryBean<NamedColumn
 		reader.setFetchSize(fetchSize);
 		reader.setDataSource(dataSource);
 		reader.setVerifyCursorPosition(verifyCursorPosition);
+		reader.setDelimiter(delimiter);
 		reader.afterPropertiesSet();
 
 		initialized = true;
@@ -151,4 +154,7 @@ public class NamedColumnJdbcItemReaderFactory implements FactoryBean<NamedColumn
 		this.verifyCursorPosition = verify;
 	}
 
+	public void setDelimiter(String delimiter) {
+		this.delimiter = delimiter;
+	}
 }

--- a/modules/job/jdbchdfs/config/jdbchdfs.xml
+++ b/modules/job/jdbchdfs/config/jdbchdfs.xml
@@ -62,17 +62,13 @@
 		<property name="partitionClause" value="#{stepExecutionContext['partClause']}" />
 		<property name="sql" value="${sql}"/>
 		<property name="fetchSize" value="${commitInterval}"/>
+		<property name="delimiter" value="${delimiter}"/>
 	</bean>
 
 	<bean id="itemWriter" class="org.springframework.xd.batch.item.hadoop.HdfsTextItemWriter" scope="step">
 		<constructor-arg ref="hadoopFs"/>
 		<property name="lineAggregator">
-			<bean class="org.springframework.batch.item.file.transform.DelimitedLineAggregator">
-				<property name="fieldExtractor">
-					<bean class="org.springframework.xd.tuple.batch.TupleFieldExtractor"/>
-				</property>
-				<property name="delimiter" value="${delimiter}"/>
-			</bean>
+			<bean class="org.springframework.batch.item.file.transform.PassThroughLineAggregator"/>
 		</property>
 		<property name="baseFilename" value="${fileName}#{stepExecutionContext['partSuffix']}"/>
 		<property name="rolloverThresholdInBytes" value="${rollover}"/>
@@ -87,6 +83,7 @@
 	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
 		fs.defaultFS=${fsUri}
 	</hdp:configuration>
+
 	<hdp:resource-loader id="hadoopResourceLoader"/>
 
 </beans>


### PR DESCRIPTION
Removing the use of a `Tuple` in the processing of this job and just formatting the output in the `RowMapper` used in the reader provides significant performance benefits.