### PR TITLE
XD-2923 [Sprint: 47] [master + backport] Spark streaming module to bind pubsub consumer

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -377,7 +377,7 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 		}
 	}
 
-	private boolean isChannelPubSub(String channelName) {
+	public static boolean isChannelPubSub(String channelName) {
 		Assert.isTrue(StringUtils.hasText(channelName), "Channel name should not be empty/null.");
 		// Check if the channelName starts with tap: or topic:
 		return (channelName.startsWith(TAP_CHANNEL_PREFIX) || channelName.startsWith(TOPIC_CHANNEL_PREFIX));

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
@@ -36,6 +36,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.MimeType;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
+import org.springframework.xd.dirt.plugins.AbstractMessageBusBinderPlugin;
 
 import scala.collection.mutable.ArrayBuffer;
 
@@ -108,7 +109,12 @@ class MessageBusReceiver extends Receiver {
 			applicationContext = MessageBusConfiguration.createApplicationContext(messageBusProperties);
 			messageBus = applicationContext.getBean(MessageBus.class);
 		}
-		messageBus.bindConsumer(channelName, messageStoringChannel, moduleConsumerProperties);
+		if (AbstractMessageBusBinderPlugin.isChannelPubSub(channelName)) {
+			messageBus.bindPubSubConsumer(channelName, messageStoringChannel, moduleConsumerProperties);
+		}
+		else {
+			messageBus.bindConsumer(channelName, messageStoringChannel, moduleConsumerProperties);
+		}
 	}
 
 	@Override

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
@@ -116,6 +116,30 @@ public abstract class AbstractSparkStreamingTests {
 	}
 
 	@Test
+	public void testSparkTapStream() throws Exception {
+		HttpSource source = new HttpSource(shell);
+		String streamName =  testName.getMethodName() + new Random().nextInt();
+		String tapStreamName =  testName.getMethodName() + new Random().nextInt();
+		FileSink sink = new FileSink().binary(true);
+		try {
+			String stream = String.format("%s | counter", source);
+			createStream(streamName, stream);
+			String tapStream = String.format("tap:stream:"+ streamName + " > spark-word-count | %s --inputType=text/plain", sink);
+			createStream(tapStreamName, tapStream);
+			source.ensureReady().postData(TEST_LONG_MESSAGE);
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(foo,6)"))));
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(bar,5)"))));
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test1,2)"))));
+			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test2,1)"))));
+		}
+		finally {
+			streamOps.destroyStream(streamName);
+			streamOps.destroyStream(tapStreamName);
+			sink.cleanup();
+		}
+	}
+
+	@Test
 	public void testSparkProcessorWithInputType() throws Exception {
 		HttpSource source = new HttpSource(shell);
 		String streamName =  testName.getMethodName()  + new Random().nextInt();


### PR DESCRIPTION
  - Fix the spark streaming `MessageBusReceiver` to bind
to the pubsub consumer if the underlying input channel is of pub/sub.