### PR TITLE
[Sprint: 49] [master + backport] XD-2924 Tap spark processor output

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -382,10 +382,9 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 	/**
 	 * Event handler for tap additions.
 	 *
-	 * @param client curator client
 	 * @param data module data
 	 */
-	private void onTapAdded(CuratorFramework client, ChildData data) {
+	private void onTapAdded(ChildData data) {
 		String tapChannelName = buildTapChannelNameFromPath(data.getPath());
 		MessageChannel outputChannel = tappableChannels.get(tapChannelName);
 		if (outputChannel != null) {
@@ -396,10 +395,9 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 	/**
 	 * Event handler for tap removals.
 	 *
-	 * @param client curator client
 	 * @param data module data
 	 */
-	private void onTapRemoved(CuratorFramework client, ChildData data) {
+	private void onTapRemoved(ChildData data) {
 		unbindTapChannel(buildTapChannelNameFromPath(data.getPath()));
 	}
 
@@ -449,10 +447,10 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 				case INITIALIZED:
 					break;
 				case CHILD_ADDED:
-					onTapAdded(client, event.getData());
+					onTapAdded(event.getData());
 					break;
 				case CHILD_REMOVED:
-					onTapRemoved(client, event.getData());
+					onTapRemoved(event.getData());
 					break;
 				default:
 					break;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
@@ -110,7 +110,7 @@ public class SparkStreamingPlugin extends AbstractStreamPlugin {
 			if (module.getType().equals(ModuleType.processor)) {
 				MessageBusSender sender = new MessageBusSender(messageBusHolder, getOutputChannelName(module),
 						buildTapChannelName(module), messageBusProperties, outboundModuleProperties,
-						ModuleTypeConversionSupport.getOutputMimeType(module));
+						ModuleTypeConversionSupport.getOutputMimeType(module), module.getProperties());
 				ConfigurableBeanFactory beanFactory = module.getApplicationContext().getBeanFactory();
 				beanFactory.registerSingleton("messageBusSender", sender);
 			}
@@ -122,7 +122,7 @@ public class SparkStreamingPlugin extends AbstractStreamPlugin {
 				ConfigurableBeanFactory beanFactory = module.getApplicationContext().getBeanFactory();
 				MessageBusSender sender = new MessageBusSender(getOutputChannelName(module), buildTapChannelName(module),
 						messageBusProperties, outboundModuleProperties,
-						ModuleTypeConversionSupport.getOutputMimeType(module));
+						ModuleTypeConversionSupport.getOutputMimeType(module), module.getProperties());
 				beanFactory.registerSingleton("messageBusSender", sender);
 			}
 		}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
@@ -109,7 +109,7 @@ public class SparkStreamingPlugin extends AbstractStreamPlugin {
 					inboundModuleProperties, ModuleTypeConversionSupport.getInputMimeType(module));
 			if (module.getType().equals(ModuleType.processor)) {
 				MessageBusSender sender = new MessageBusSender(messageBusHolder, getOutputChannelName(module),
-						messageBusProperties, outboundModuleProperties,
+						buildTapChannelName(module), messageBusProperties, outboundModuleProperties,
 						ModuleTypeConversionSupport.getOutputMimeType(module));
 				ConfigurableBeanFactory beanFactory = module.getApplicationContext().getBeanFactory();
 				beanFactory.registerSingleton("messageBusSender", sender);
@@ -120,7 +120,7 @@ public class SparkStreamingPlugin extends AbstractStreamPlugin {
 					ModuleTypeConversionSupport.getInputMimeType(module));
 			if (module.getType().equals(ModuleType.processor)) {
 				ConfigurableBeanFactory beanFactory = module.getApplicationContext().getBeanFactory();
-				MessageBusSender sender = new MessageBusSender(getOutputChannelName(module),
+				MessageBusSender sender = new MessageBusSender(getOutputChannelName(module), buildTapChannelName(module),
 						messageBusProperties, outboundModuleProperties,
 						ModuleTypeConversionSupport.getOutputMimeType(module));
 				beanFactory.registerSingleton("messageBusSender", sender);

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
@@ -26,6 +26,7 @@ import static org.springframework.xd.shell.command.fixtures.XDMatchers.hasConten
 import java.io.File;
 import java.util.Random;
 
+import org.hamcrest.core.StringContains;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,6 +40,7 @@ import org.springframework.xd.dirt.server.SingleNodeApplication;
 import org.springframework.xd.dirt.test.SingleNodeIntegrationTestSupport;
 import org.springframework.xd.shell.command.StreamCommandTemplate;
 import org.springframework.xd.shell.command.fixtures.HttpSource;
+import org.springframework.xd.shell.command.fixtures.XDMatchers;
 import org.springframework.xd.test.RandomConfigurationSupport;
 import org.springframework.xd.test.fixtures.FileSink;
 
@@ -147,7 +149,7 @@ public abstract class AbstractSparkStreamingTests {
 		String tapStreamName =  testName.getMethodName() + new Random().nextInt();
 		FileSink sink = new FileSink().binary(true);
 		try {
-			String stream = String.format("%s | spark-word-count | counter", source);
+			String stream = String.format("%s | spark-word-count --enableTap=true | counter", source);
 			createStream(streamName, stream);
 			String tapStream = String.format("tap:stream:%s.spark-word-count > %s --inputType=text/plain", streamName, sink);
 			createStream(tapStreamName, tapStream);

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/DefaultSparkStreamingModuleOptionsMetadata.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/DefaultSparkStreamingModuleOptionsMetadata.java
@@ -36,6 +36,8 @@ public class DefaultSparkStreamingModuleOptionsMetadata {
 
 	private String storageLevel = "";
 
+	private boolean enableTap = false;
+
 	@ModuleOption("the time interval in millis for batching the stream events")
 	public void setBatchInterval(final String batchInterval) {
 		this.batchInterval = batchInterval;
@@ -68,6 +70,15 @@ public class DefaultSparkStreamingModuleOptionsMetadata {
 				return false;
 			}
 		}
+	}
+
+	@ModuleOption("enable tap at the output of the spark processor module")
+	public void setEnableTap(boolean enableTap) {
+		this.enableTap = enableTap;
+	}
+
+	public boolean isEnableTap() {
+		return this.enableTap;
 	}
 
 	@ModuleOption(value = "the underlying execution framework", hidden = true)


### PR DESCRIPTION
 - Add support to tap spark streaming processor module's output
   - Add wiretap channel to processor module output channel
   - Bind wiretap channel to messagebus pub/sub producer
   - Unbind/close wiretap channel upon module stop