### PR TITLE
[Sprint: 47] [1.1.x] XD-2923 Spark streaming module pubsub consumer fix

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -367,7 +367,12 @@ public abstract class AbstractMessageBusBinderPlugin extends AbstractPlugin {
 		}
 	}
 
-	private boolean isChannelPubSub(String channelName) {
+	/**
+	 * Determine whether the provided channel name represents a pub/sub channel (i.e. topic or tap).
+	 * @param channelName name of the channel to check
+	 * @return true if pub/sub.
+	 */
+	public static boolean isChannelPubSub(String channelName) {
 		Assert.isTrue(StringUtils.hasText(channelName), "Channel name should not be empty/null.");
 		// Check if the channelName starts with tap: or topic:
 		return (channelName.startsWith(TAP_CHANNEL_PREFIX) || channelName.startsWith(TOPIC_CHANNEL_PREFIX));

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
@@ -36,6 +36,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.MimeType;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
+import org.springframework.xd.dirt.plugins.AbstractMessageBusBinderPlugin;
 
 import scala.collection.mutable.ArrayBuffer;
 
@@ -108,7 +109,12 @@ class MessageBusReceiver extends Receiver {
 			applicationContext = MessageBusConfiguration.createApplicationContext(messageBusProperties);
 			messageBus = applicationContext.getBean(MessageBus.class);
 		}
-		messageBus.bindConsumer(channelName, messageStoringChannel, moduleConsumerProperties);
+		if (AbstractMessageBusBinderPlugin.isChannelPubSub(channelName)) {
+			messageBus.bindPubSubConsumer(channelName, messageStoringChannel, moduleConsumerProperties);
+		}
+		else {
+			messageBus.bindConsumer(channelName, messageStoringChannel, moduleConsumerProperties);
+		}
 	}
 
 	@Override

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
@@ -17,14 +17,15 @@ package org.springframework.xd.spark.streaming;
 
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertThat;
 import static org.springframework.xd.shell.command.fixtures.XDMatchers.eventually;
 import static org.springframework.xd.shell.command.fixtures.XDMatchers.fileContent;
+import static org.springframework.xd.shell.command.fixtures.XDMatchers.hasContentsThat;
 
 import java.io.File;
 import java.util.Random;
 
-import org.hamcrest.core.StringContains;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,7 +39,6 @@ import org.springframework.xd.dirt.server.SingleNodeApplication;
 import org.springframework.xd.dirt.test.SingleNodeIntegrationTestSupport;
 import org.springframework.xd.shell.command.StreamCommandTemplate;
 import org.springframework.xd.shell.command.fixtures.HttpSource;
-import org.springframework.xd.shell.command.fixtures.XDMatchers;
 import org.springframework.xd.test.RandomConfigurationSupport;
 import org.springframework.xd.test.fixtures.FileSink;
 
@@ -104,13 +104,38 @@ public abstract class AbstractSparkStreamingTests {
 			String stream = String.format("%s | spark-word-count | %s --inputType=text/plain", source, sink);
 			createStream(streamName, stream);
 			source.ensureReady().postData(TEST_LONG_MESSAGE);
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(foo,6)"))));
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(bar,5)"))));
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test1,2)"))));
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test2,1)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(foo,6)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(bar,5)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(test1,2)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(test2,1)"))));
 		}
 		finally {
 			streamOps.destroyStream(streamName);
+			sink.cleanup();
+		}
+	}
+
+	@Test
+	public void testSparkTapStream() throws Exception {
+		HttpSource source = new HttpSource(shell);
+		String streamName =  testName.getMethodName() + new Random().nextInt();
+		String tapStreamName =  testName.getMethodName() + new Random().nextInt();
+		FileSink sink = new FileSink().binary(true);
+		try {
+			String stream = String.format("%s | counter", source);
+			createStream(streamName, stream);
+			String tapStream = String.format("tap:stream:%s > spark-word-count | %s --inputType=text/plain",
+					streamName, sink);
+			createStream(tapStreamName, tapStream);
+			source.ensureReady().postData(TEST_LONG_MESSAGE);
+			assertThat(sink, eventually(hasContentsThat(containsString("(foo,6)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(bar,5)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(test1,2)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(test2,1)"))));
+		}
+		finally {
+			streamOps.destroyStream(streamName);
+			streamOps.destroyStream(tapStreamName);
 			sink.cleanup();
 		}
 	}
@@ -125,7 +150,7 @@ public abstract class AbstractSparkStreamingTests {
 					"--inputType=text/plain", source, sink);
 			createStream(streamName, stream);
 			source.ensureReady().postData(TEST_MESSAGE);
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(equalTo("(foo,3)"))));
+			assertThat(sink, eventually(hasContentsThat(equalTo("(foo,3)"))));
 		}
 		finally {
 			streamOps.destroyStream(streamName);
@@ -142,7 +167,7 @@ public abstract class AbstractSparkStreamingTests {
 			String stream = String.format("%s | spark-word-count --outputType=application/json | %s", source, sink);
 			createStream(streamName, stream);
 			source.ensureReady().postData(TEST_MESSAGE);
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(equalTo("{\"_1\":\"foo\",\"_2\":3}"))));
+			assertThat(sink, eventually(hasContentsThat(equalTo("{\"_1\":\"foo\",\"_2\":3}"))));
 		}
 		finally {
 			streamOps.destroyStream(streamName);
@@ -159,10 +184,10 @@ public abstract class AbstractSparkStreamingTests {
 			String stream = String.format("%s | spark-scala-word-count | %s --inputType=text/plain", source, sink);
 			createStream(streamName, stream);
 			source.ensureReady().postData(TEST_LONG_MESSAGE);
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(foo,6)"))));
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(bar,5)"))));
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test1,2)"))));
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(StringContains.containsString("(test2,1)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(foo,6)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(bar,5)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(test1,2)"))));
+			assertThat(sink, eventually(hasContentsThat(containsString("(test2,1)"))));
 		}
 		finally {
 			streamOps.destroyStream(streamName);
@@ -180,7 +205,7 @@ public abstract class AbstractSparkStreamingTests {
 					"%s --inputType=text/plain", source, sink);
 			createStream(streamName, stream);
 			source.ensureReady().postData(TEST_MESSAGE);
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(equalTo("(foo,3)"))));
+			assertThat(sink, eventually(hasContentsThat(equalTo("(foo,3)"))));
 		}
 		finally {
 			streamOps.destroyStream(streamName);
@@ -197,7 +222,7 @@ public abstract class AbstractSparkStreamingTests {
 			String stream = String.format("%s | spark-scala-word-count --outputType=application/json | %s", source, sink);
 			createStream(streamName, stream);
 			source.ensureReady().postData(TEST_MESSAGE);
-			assertThat(sink, XDMatchers.eventually(XDMatchers.hasContentsThat(equalTo("{\"_1\":\"foo\",\"_2\":3}"))));
+			assertThat(sink, eventually(hasContentsThat(equalTo("{\"_1\":\"foo\",\"_2\":3}"))));
 		}
 		finally {
 			streamOps.destroyStream(streamName);


### PR DESCRIPTION
  - Fix the spark streaming `MessageBusReceiver` to bind
to the pubsub consumer if the underlying input channel is of pub/sub.

  - Minor fixes to SparkStreamingTests class