### PR TITLE
XD-2911 - Improved performance of Tuple Creation

### DIFF
--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleFieldSetMapper.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleFieldSetMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ import java.util.Map;
 
 import org.springframework.batch.item.file.mapping.FieldSetMapper;
 import org.springframework.batch.item.file.transform.FieldSet;
+import org.springframework.format.support.FormattingConversionService;
 import org.springframework.util.CollectionUtils;
 import org.springframework.validation.BindException;
+import org.springframework.xd.tuple.DefaultTupleConversionService;
 import org.springframework.xd.tuple.Tuple;
 import org.springframework.xd.tuple.TupleBuilder;
 
@@ -43,6 +45,8 @@ public class TupleFieldSetMapper implements FieldSetMapper<Tuple> {
 	// TODO: Currently this is bound by the convenience methods on the Tuple object. Is custom conversion necessary?
 	private Map<String, FieldSetType> types;
 
+	private FormattingConversionService defaultConversionService = new DefaultTupleConversionService();
+
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -55,7 +59,7 @@ public class TupleFieldSetMapper implements FieldSetMapper<Tuple> {
 		TupleBuilder builder = TupleBuilder.tuple();
 
 		if (dateFormat != null) {
-			builder.setDateFormat(dateFormat);
+			builder.setFormats(null, dateFormat).setConfigurableConversionService(defaultConversionService);
 		}
 
 		for (int i = 0; i < fieldSet.getFieldCount(); i++) {

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/DefaultTupleTestForBatch.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/DefaultTupleTestForBatch.java
@@ -148,16 +148,20 @@ public class DefaultTupleTestForBatch {
 
 	@Test
 	public void testReadBigDecimalWithFormat() throws Exception {
-		Tuple numberFormatTuple = TupleBuilder.tuple().setNumberFormatFromLocale(Locale.US).ofNamesAndValues(
-				tuple.getFieldNames(), tuple.getValues());
+		Tuple numberFormatTuple = TupleBuilder.tuple()
+				.setFormats(Locale.US, null)
+				.setConfigurableConversionService(new DefaultTupleConversionService())
+				.ofNamesAndValues(tuple.getFieldNames(), tuple.getValues());
 		BigDecimal bd = new BigDecimal("424.3");
 		assertEquals(bd, numberFormatTuple.getBigDecimal(8));
 	}
 
 	@Test
 	public void testReadBigDecimalWithEuroFormat() throws Exception {
-		Tuple numberFormatTuple = TupleBuilder.tuple().setNumberFormatFromLocale(Locale.GERMANY).ofNamesAndValues(
-				tuple.getFieldNames(), tuple.getValues());
+		Tuple numberFormatTuple = TupleBuilder.tuple()
+				.setFormats(Locale.GERMANY, null)
+				.setConfigurableConversionService(new DefaultTupleConversionService())
+				.ofNamesAndValues(tuple.getFieldNames(), tuple.getValues());
 		BigDecimal bd = new BigDecimal("1.3245");
 		assertEquals(bd, numberFormatTuple.getBigDecimal(9));
 	}
@@ -236,7 +240,10 @@ public class DefaultTupleTestForBatch {
 
 	@Test
 	public void testReadIntWithSeparatorAndFormat() throws Exception {
-		Tuple t = TupleBuilder.tuple().setNumberFormatFromLocale(Locale.GERMAN).of("foo", "354.224");
+		Tuple t = TupleBuilder.tuple()
+				.setFormats(Locale.GERMAN, null)
+				.setConfigurableConversionService(new DefaultTupleConversionService())
+				.of("foo", "354.224");
 		assertThat(354224, equalTo(t.getInt(0)));
 	}
 
@@ -348,7 +355,10 @@ public class DefaultTupleTestForBatch {
 	@Test
 	public void testReadDateWithFormat() throws Exception {
 		SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
-		Tuple t = TupleBuilder.tuple().setDateFormat(dateFormat).of("foo", "13/01/1999");
+		Tuple t = TupleBuilder.tuple()
+				.setFormats(null, dateFormat)
+				.setConfigurableConversionService(new DefaultTupleConversionService())
+				.of("foo", "13/01/1999");
 		assertEquals(dateFormat.parse("13/01/1999"), t.getDate(0));
 	}
 

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/TupleCreationPerformanceTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/TupleCreationPerformanceTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.tuple;
+
+import java.util.Date;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.support.FormattingConversionService;
+import org.springframework.test.annotation.Repeat;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.StopWatch;
+
+/**
+ * Illustrates the impact of creating a {@link DefaultTupleConversionService} for each
+ * instance of Tuple.  The recommended approach is to either use the default instance or
+ * configure a customized version that is created as a singleton within the context of
+ * the module it's used.
+ * 
+ * @author Michael Minella
+ * @author Gunnar Hillert
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {TupleCreationPerformanceTests.ConversionServiceConfiguration.class})
+public class TupleCreationPerformanceTests {
+
+	@Configuration
+	static class ConversionServiceConfiguration {
+
+		@Bean
+		public FormattingConversionService conversionService() {
+			return new DefaultTupleConversionService();
+		}
+	}
+
+	@Autowired
+	private FormattingConversionService conversionService;
+
+	@Test
+	@Repeat(4)
+	public void testCreationOfTuples() {
+		StopWatch watch = new StopWatch();
+		watch.start();
+		for(int i = 0; i < 100000; i++) {
+			TupleBuilder.tuple()
+				.put("field1", Math.random())
+				.put("field2", UUID.randomUUID())
+				.put("field3", "AAAAA")
+				.put("field4", new Date().getTime()).build();
+		}
+		watch.stop();
+		System.out.println(watch.prettyPrint());
+	}
+
+	@Test
+	@Repeat(4)
+	public void testCreationOfTuplesCustomConversionService() {
+		StopWatch watch = new StopWatch();
+		watch.start();
+		for(int i = 0; i < 100000; i++) {
+			TupleBuilder.tuple()
+				.setConfigurableConversionService(new DefaultTupleConversionService())
+				.put("field1", Math.random())
+				.put("field2", UUID.randomUUID())
+				.put("field3", "AAAAA")
+				.put("field4", new Date().getTime()).build();
+		}
+		watch.stop();
+		System.out.println(watch.prettyPrint());
+	}
+
+	@Test
+	@Repeat(4)
+	public void testCreationOfTuplesCustomConversionServiceAutowired() {
+		StopWatch watch = new StopWatch();
+		watch.start();
+		for(int i = 0; i < 100000; i++) {
+			TupleBuilder.tuple()
+				.setConfigurableConversionService(conversionService)
+				.put("field1", Math.random())
+				.put("field2", UUID.randomUUID())
+				.put("field3", "AAAAA")
+				.put("field4", new Date().getTime()).build();
+		}
+		watch.stop();
+		System.out.println(watch.prettyPrint());
+	}
+}


### PR DESCRIPTION
**NOTE -** This is a breaking change.

This commit refactors how the conversion service used within a Tuple is
created to a more performant option.  Prior to this commit, for each
instance of TupleBuilder created (and under typical usage, each Tuple)
an instance of DefaultTupleConversionService was created.  This updated
version changes the default to be a static instance and changes the
recommended approach for customization to be a
ConfigurableConversionService be configured as a singleton within your
module's context and then used across all Tuple instances.  This
provides better performance in the creation of Tuples.