### PR TITLE
[Sprint 48] [master + backport] XD-2941 Fix message rate collection strategy

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/jmx/ModuleObjectNamingStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/jmx/ModuleObjectNamingStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,8 +27,10 @@ import org.springframework.util.Assert;
 
 
 /**
- * 
+ * Object naming strategy for XD module.
+ *
  * @author David Turanski
+ * @author Ilayaperumal Gopinathan
  */
 public class ModuleObjectNamingStrategy implements ObjectNamingStrategy {
 
@@ -48,8 +50,10 @@ public class ModuleObjectNamingStrategy implements ObjectNamingStrategy {
 		ObjectName originalName = ObjectNameManager.getInstance(beanKey);
 		StringBuilder sb = new StringBuilder();
 		sb.append(domain).append(":");
-		sb.append("module=").append(objectNameProperties.get("module")).append(".").append(
-				objectNameProperties.getProperty("index")).append(",");
+		sb.append("module=").append(objectNameProperties.get("group")).append(".").append(
+				objectNameProperties.getProperty("type")).append(".").append(
+				objectNameProperties.getProperty("label")).append(".").append(
+				objectNameProperties.getProperty("sequence")).append(",");
 		sb.append("component=").append(originalName.getKeyProperty("type")).append(",");
 		sb.append("name=").append(originalName.getKeyProperty("name"));
 		return ObjectNameManager.getInstance(sb.toString());

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ModuleInfoPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ModuleInfoPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.xd.dirt.plugins;
 
 import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_MODULE_INDEX_KEY;
+import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_MODULE_LABEL_KEY;
 import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_MODULE_NAME_KEY;
 import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_MODULE_TYPE_KEY;
 import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_MODULE_COUNT_KEY;
@@ -34,6 +35,7 @@ import org.springframework.xd.module.core.Module;
  * 
  * @author Eric Bottard
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 public class ModuleInfoPlugin extends AbstractPlugin {
 
@@ -46,6 +48,7 @@ public class ModuleInfoPlugin extends AbstractPlugin {
 	public void preProcessModule(Module module) {
 		Properties props = new Properties();
 		props.setProperty(XD_MODULE_NAME_KEY, module.getName());
+		props.setProperty(XD_MODULE_LABEL_KEY, module.getDescriptor().getModuleLabel());
 		props.setProperty(XD_MODULE_INDEX_KEY, String.valueOf(module.getDescriptor().getIndex()));
 		props.setProperty(XD_MODULE_TYPE_KEY, module.getType().name());
 		props.setProperty(XD_MODULE_COUNT_KEY, String.valueOf(module.getDeploymentProperties().getCount()));

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/jmx/mbean-exporters.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/jmx/mbean-exporters.xml
@@ -14,8 +14,10 @@
 
 	<!-- TODO: Add BatchMbeanExporter -->
 	<util:properties id="objectNameProperties">
-		<prop key="module">${xd.module.name}</prop>
-		<prop key="index">${xd.module.index}</prop>
+		<prop key="group">${xd.stream.name}</prop>
+		<prop key="label">${xd.module.label}</prop>
+		<prop key="type">${xd.module.type}</prop>
+		<prop key="sequence">${xd.module.sequence}</prop>
 	</util:properties>
 
 	<bean id="moduleObjectNamingStrategy"


### PR DESCRIPTION
 - Add `moduleLabel`, `moduleSequence` and `deploymentUnitName` to the module MBean name
   - This will enable the construction of unique qualified ID for the given module
 - To obtain message rates:
   - Iterate over each container
   - Get all the module's input/output `messagechannel` MBean
   - Collect the `MeanSendRate` metric for each channel