### PR TITLE
xd-2972: ensure eclipse metadata files are correct java level

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,10 @@ configure(javaProjects) { subproject ->
 		}
 
 		eclipse {
+			jdt {
+				sourceCompatibility=1.7
+				targetCompatibility=1.7
+			}
 			project { natures += 'org.springframework.ide.eclipse.core.springnature' }
 		}
 


### PR DESCRIPTION
Ensures the source/target are set to 1.7 for created metadata. Without this the eclipse gradle plugin will set them to the level of the JDK you are running the gradle command on...