### PR TITLE
[XD-2920] Dynamic router should allow to discard messages

### DIFF
--- a/modules/sink/router/config/router.xml
+++ b/modules/sink/router/config/router.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+ <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
@@ -15,12 +15,13 @@
 
 
 	<beans:beans profile="use-expression">
-		<router input-channel="input" expression="${expression}"/>
+		<router input-channel="input" expression="${expression}" resolution-required="false"
+						default-output-channel="nullChannel"/>
 	</beans:beans>
 
 	<beans:beans profile="use-script">
 		<beans:import resource="../../../common/script-variable-generator.xml"/>
-		<router input-channel="input">
+		<router input-channel="input" resolution-required="false" default-output-channel="nullChannel">
 			<int-groovy:script location="${script}" script-variable-generator="variableGenerator" refresh-check-delay="60"/>
 		</router>
 	</beans:beans>

--- a/modules/sink/router/config/router.xml
+++ b/modules/sink/router/config/router.xml
@@ -1,4 +1,4 @@
- <?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"

--- a/spring-xd-shell/src/test/resources/org/springframework/xd/shell/command/router-discard.groovy
+++ b/spring-xd-shell/src/test/resources/org/springframework/xd/shell/command/router-discard.groovy
@@ -1,0 +1,5 @@
+if (payload.contains('a')) {
+    return 'queue:my-queue'
+} else {
+    return null
+}


### PR DESCRIPTION
Router now allows to return null to discard the message.

Current tests would pass on both old and new `router` module implementation which is bad. The only difference can be observed in the logs as the `MessageDeliveryException` is not thrown. 

Is there a way to register a `MessageHandler` on router step `errorChannel` to intercept the `MessageDeliveryException` from `AbstractMessageRouter` so I can add some more test assertions? Is there a global Spring XD `errorChannel` if all steps within a stream are running in separate contexts?

Calling `getErrorChannel().subscribe(MessageHandler)` in my test is not working. Most likely because test is running synchronously using local transport and the `errorChannel` property is not set on `http` source which is the stream entry point.