### PR TITLE
[Sprint 47] XD-2984 Move hadoopDistro option to CommonOptions

### DIFF
--- a/scripts/xd/xd-admin
+++ b/scripts/xd/xd-admin
@@ -65,44 +65,29 @@ cd "`dirname \"$PRG\"`/.." >&-
 APP_HOME="`pwd -P`"
 cd "$SAVED" >&-
 
-APP_HOME_LIB=$APP_HOME/lib
-CLASSPATH=$APP_HOME/modules/processor/scripts:$APP_HOME/config
+# If you change the default hadoop distro, make sure to update ContainerOptions.DEFAULT_HADOOP_OPTION
 HADOOP_DISTRO="${HADOOP_DISTRO:-hadoop26}"
 x=0
 args=("$@")
 for arg in "${args[@]}" ; do
     if [ "$arg" = "--hadoopDistro" ] ; then
-        if [ "${args[x+1]}" = "hadoop25" ] || [ "${args[x+1]}" = "hadoop26" ] || [ "${args[x+1]}" = "cdh5" ] || [ "${args[x+1]}" = "hdp22" ] || [ "${args[x+1]}" = "phd21" ] ; then
-          HADOOP_DISTRO="${args[x+1]}"
-          unset args[x+1]
-          unset args[x]
-        else
-          echo "ERROR: '${args[x+1]}' is not a valid Hadoop distro - valid distros are hadoop25, hadoop26, cdh5, hdp22 and phd21"
-          exit
-        fi
+        HADOOP_DISTRO="${args[x+1]}"
     fi
     x=$((x+1))
 done
-
-addJarsToClassPath( ) {
-    if [ -d $1 ]; then
-        for jar in "$1"/*.jar; do
-            CLASSPATH="$CLASSPATH":"$jar"
+APP_HOME_LIB=$APP_HOME/lib
+CLASSPATH=$APP_HOME/modules/processor/scripts:$APP_HOME/config
+if [ -d "$APP_HOME_LIB" ]; then
+    for i in "$APP_HOME_LIB"/*.jar; do
+        CLASSPATH="$CLASSPATH":"$i"
+    done
+    HADOOP_LIB=$APP_HOME/lib/$HADOOP_DISTRO
+    if [ -d "$HADOOP_LIB" ]; then
+        for j in "$HADOOP_LIB"/*.jar; do
+            CLASSPATH="$CLASSPATH":"$j"
         done
     fi
-}
-
-CLASSPATH="$APP_HOME/config"
-APP_HOME_LIB=$APP_HOME/lib
-XD_LIB=$APP_HOME/../xd/lib
-addJarsToClassPath $APP_HOME_LIB
-if [ -d $XD_LIB ]; then
-    addJarsToClassPath $XD_LIB
-    HADOOP_LIB=$XD_LIB/$HADOOP_DISTRO
-else
-    HADOOP_LIB=$APP_HOME_LIB/$HADOOP_DISTRO
 fi
-addJarsToClassPath $HADOOP_LIB
 
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then

--- a/scripts/xd/xd-admin.bat
+++ b/scripts/xd/xd-admin.bat
@@ -70,28 +70,28 @@ set CMD_LINE_ARGS=%$
 @rem Setup the command line
 
 @echo off
+set APP_HOME_LIB=%APP_HOME%\lib
+@rem If you change the default hadoop distro, make sure to update ContainerOptions.DEFAULT_HADOOP_OPTION
 set HADOOP_DISTRO=hadoop26
-set found=0
-set NEW_CMD_LINE_ARGS=
-for %%a in (%CMD_LINE_ARGS%) do (
+if exist "%APP_HOME_LIB%" (
     setLocal EnableDelayedExpansion
-    if "%%a"=="--hadoopDistro" (
-        set found=1
-    ) else (
-        if !found!==1 (
-            if not "%%a"=="hadoop25" if not "%%a"=="hadoop26" if not "%%a"=="cdh5" if not "%%a"=="hdp22" if not "%%a"=="phd21" (
-                echo ERROR: %%a is not a valid Hadoop distro - valid distros are hadoop25, hadoop26, cdh5, hdp22 and phd21
-                goto fail
-            )
-            set HADOOP_DISTRO=%%a
-            set found=0
+    set found=0
+    for %%a in (%CMD_LINE_ARGS%) do (
+        if !found!==1 set HADOOP_DISTRO=%%a
+        if "%%a"=="--hadoopDistro" (
+            set found=1
         ) else (
-            set NEW_CMD_LINE_ARGS=!NEW_CMD_LINE_ARGS! %%a
+            set found=0
         )
+    )
+    set CLASSPATH=%APP_HOME%\modules\processor\scripts;%APP_HOME%\config
+    set CLASSPATH=!CLASSPATH!;%APP_HOME_LIB%\*
+    set HADOOP_LIB=%APP_HOME%\lib\!HADOOP_DISTRO!
+    if exist "!HADOOP_LIB!" (
+        set CLASSPATH=!CLASSPATH!;!HADOOP_LIB!\*
     )
 )
 set CMD_LINE_ARGS=!NEW_CMD_LINE_ARGS!
-set APP_HOME_LIB=%APP_HOME%\lib
 
 if exist "%APP_HOME_LIB%" (
     setLocal EnableDelayedExpansion

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
@@ -39,6 +39,12 @@ public class CommonOptions {
 	@Option(name = "--mgmtPort", usage = "The port for the management server", metaVar = "<mgmtPort>")
 	private Integer mgmtPort;
 
+	static final String DEFAULT_HADOOP_DISTRO = "hadoop26";
+
+	@Option(name = "--hadoopDistro", handler = ResourcePatternScanningOptionHandlers.HadoopDistroOptionHandler.class,
+			usage = "The Hadoop distribution to be used for HDFS access")
+	private String distro = ContainerOptions.DEFAULT_HADOOP_DISTRO;
+
 	// Using wrapped here so that "showHelp" is not returned as a property by BeanPropertiesPropertySource
 	public Boolean isShowHelp() {
 		return showHelp ? true : null;
@@ -54,6 +60,14 @@ public class CommonOptions {
 
 	public void setXD_MGMT_PORT(int mgmtPort) {
 		this.mgmtPort = mgmtPort;
+	}
+
+	public void setHADOOP_DISTRO(String distro) {
+		this.distro = distro;
+	}
+
+	public String getHADOOP_DISTRO() {
+		return this.distro;
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ContainerOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ContainerOptions.java
@@ -19,7 +19,6 @@ package org.springframework.xd.dirt.server.options;
 import org.kohsuke.args4j.Option;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.xd.dirt.server.options.ResourcePatternScanningOptionHandlers.HadoopDistroOptionHandler;
 
 /**
  * Holds configuration options that are valid for the Container node, when using distributed mode.
@@ -31,13 +30,6 @@ import org.springframework.xd.dirt.server.options.ResourcePatternScanningOptionH
 @ConfigurationProperties
 public class ContainerOptions extends CommonDistributedOptions {
 
-	/* This is also used in SingleNodeOptions. */
-	/*default*/static final String DEFAULT_HADOOP_DISTRO = "hadoop26";
-
-	@Option(name = "--hadoopDistro", handler = HadoopDistroOptionHandler.class,
-			usage = "The Hadoop distribution to be used for HDFS access")
-	private String distro = DEFAULT_HADOOP_DISTRO;
-
 	@Option(name = "--groups", usage = "The group memberships for this container as a comma delimited string")
 	private String groups;
 
@@ -46,10 +38,6 @@ public class ContainerOptions extends CommonDistributedOptions {
 
 	@Option(name = "--containerIp", usage = "The IP address of the container.")
 	private String ip;
-
-	public String getHADOOP_DISTRO() {
-		return this.distro;
-	}
 
 	public String getXD_CONTAINER_HOSTNAME() {
 		return hostname;
@@ -61,11 +49,6 @@ public class ContainerOptions extends CommonDistributedOptions {
 
 	public String getXD_CONTAINER_GROUPS() {
 		return this.groups;
-	}
-
-
-	public void setHADOOP_DISTRO(String distro) {
-		this.distro = distro;
 	}
 
 	public void setXD_CONTAINER_HOSTNAME(String hostname) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/SingleNodeOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/SingleNodeOptions.java
@@ -21,7 +21,6 @@ import javax.validation.constraints.NotNull;
 import org.kohsuke.args4j.Option;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.xd.dirt.server.options.ResourcePatternScanningOptionHandlers.HadoopDistroOptionHandler;
 import org.springframework.xd.dirt.server.options.ResourcePatternScanningOptionHandlers.SingleNodeAnalyticsOptionHandler;
 import org.springframework.xd.dirt.server.options.ResourcePatternScanningOptionHandlers.SingleNodeDataTransportOptionHandler;
 
@@ -45,10 +44,6 @@ public class SingleNodeOptions extends CommonOptions {
 
 	@Option(name = "--httpPort", usage = "HTTP port for the REST API server", metaVar = "<httpPort>")
 	private Integer httpPort;
-
-	@Option(name = "--hadoopDistro", handler = HadoopDistroOptionHandler.class,
-			usage = "The Hadoop distribution to be used for HDFS access")
-	private String distro = ContainerOptions.DEFAULT_HADOOP_DISTRO;
 
 	public Integer getPORT() {
 		return httpPort;
@@ -74,13 +69,5 @@ public class SingleNodeOptions extends CommonOptions {
 
 	public void setXD_TRANSPORT(String transport) {
 		this.transport = transport;
-	}
-
-	public void setHADOOP_DISTRO(String distro) {
-		this.distro = distro;
-	}
-
-	public String getHADOOP_DISTRO() {
-		return this.distro;
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdConfigLoggingInitializer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdConfigLoggingInitializer.java
@@ -95,10 +95,10 @@ public class XdConfigLoggingInitializer implements ApplicationListener<ContextRe
 	public void onApplicationEvent(ContextRefreshedEvent event) {
 		logger.info("XD Home: " + environment.resolvePlaceholders("${XD_HOME}"));
 		logger.info("Transport: " + environment.resolvePlaceholders("${XD_TRANSPORT}"));
+		logHadoopDistro();
 		logConfigLocations();
 		if (isContainer) {
 			logContainerInfo();
-			logHadoopDistro();
 		}
 		else {
 			logAdminUI();


### PR DESCRIPTION
 - Since both the `admin` and `container` use `--hadoopDistro` option
we can have this option moved to `CommonOptions`
 - Fix XD config logger to log `hadooDistro` option for all the runtime JVMs.