### PR TITLE
[Sprint: 47] XD-2987 Updated [Master+Backport] JMX Module name format

### DIFF
--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractIntegrationTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractIntegrationTest.java
@@ -65,7 +65,7 @@ import org.springframework.xd.test.fixtures.SimpleFileSink;
 @SpringApplicationConfiguration(classes = IntegrationTestConfig.class)
 public abstract class AbstractIntegrationTest {
 
-	private final static String STREAM_NAME = "ec2Test3";
+	protected final static String STREAM_NAME = "ec2Test3";
 
 	protected final static String XD_DELIMITER = " | ";
 
@@ -525,7 +525,7 @@ public abstract class AbstractIntegrationTest {
 	}
 
 	/**
-	 * Asserts that all channels of the processor channel combination, processed the correct number of messages
+	 * Asserts that the sink channel, processed the correct number of messages
 	 * The location of the sink is resolved at runtime.
 	 *
 	 * @param moduleName the name of the module jmx element to interrogate.
@@ -537,7 +537,7 @@ public abstract class AbstractIntegrationTest {
 	}
 
 	/**
-	 * Asserts that all channels of the processor channel combination, processed the correct number of messages
+	 * Asserts that source channel, processed the correct number of messages
 	 * The location of the source  is resolved at runtime.
 	 *
 	 * @param moduleName the name of the module jmx element to interrogate.
@@ -545,8 +545,7 @@ public abstract class AbstractIntegrationTest {
 	 * @param msgCountExpected The number of messages this module and channel should have sent.
 	 */
 	public void assertReceivedBySource(String moduleName, String channelName, int msgCountExpected) {
-		//TODO
-		assertReceived(getContainerResolver().getContainerUrlForSink(), moduleName, channelName, msgCountExpected);
+		assertReceived(getContainerResolver().getContainerUrlForSource(), moduleName, channelName, msgCountExpected);
 	}
 
 	/**

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/ProcessorTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/ProcessorTest.java
@@ -28,9 +28,9 @@ import java.util.UUID;
 public class ProcessorTest extends AbstractIntegrationTest {
 
 
-	private final static String HTTP_MODULE_NAME = "http.0";
+	private final static String HTTP_MODULE_NAME = STREAM_NAME+".source.http.1";
 
-	private final static String FILTER_MODULE_NAME = "filter.1";
+	private final static String FILTER_MODULE_NAME = STREAM_NAME+".processor.filter.1";
 
 	private final static String OUTPUT_CHANNEL_NAME = "output";
 
@@ -56,7 +56,7 @@ public class ProcessorTest extends AbstractIntegrationTest {
 		assertReceivedByProcessor(FILTER_MODULE_NAME, OUTPUT_CHANNEL_NAME, 0);
 		assertReceivedByProcessor(FILTER_MODULE_NAME, TO_SPEL_CHANNEL_NAME, 1);
 		assertReceivedByProcessor(FILTER_MODULE_NAME, TO_SCRIPT_CHANNEL_NAME, 0);
-		assertReceivedBySink(HTTP_MODULE_NAME, OUTPUT_CHANNEL_NAME, 1);
+		assertReceivedBySource(HTTP_MODULE_NAME, OUTPUT_CHANNEL_NAME, 1);
 
 	}
 


### PR DESCRIPTION
With the update of JMX Module Name format from XD-2941 the Acceptance tests had to be updated.
Also cleaned up some copy past errors from the past.