### PR TITLE
XD-2995 Fix group name assignment

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/MBeanExportingPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/MBeanExportingPlugin.java
@@ -13,6 +13,10 @@
 
 package org.springframework.xd.dirt.plugins;
 
+import static org.springframework.xd.module.options.spi.ModulePlaceholders.XD_GROUP_NAME_KEY;
+
+import java.util.Properties;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.xd.dirt.util.ConfigLocations;
@@ -23,6 +27,7 @@ import org.springframework.xd.module.core.Module;
  *
  * @author David Turanski
  * @author Gary Russell
+ * @author Ilayaperumal Gopinathan
  */
 public class MBeanExportingPlugin extends AbstractPlugin {
 
@@ -33,6 +38,9 @@ public class MBeanExportingPlugin extends AbstractPlugin {
 
 	@Override
 	public void preProcessModule(Module module) {
+		Properties properties = new Properties();
+		properties.setProperty(XD_GROUP_NAME_KEY, module.getDescriptor().getGroup());
+		module.addProperties(properties);
 		module.addSource(new ClassPathResource(CONTEXT_CONFIG_ROOT + "mbean-exporters.xml"));
 	}
 

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/jmx/mbean-exporters.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/jmx/mbean-exporters.xml
@@ -14,7 +14,7 @@
 
 	<!-- TODO: Add BatchMbeanExporter -->
 	<util:properties id="objectNameProperties">
-		<prop key="group">${xd.stream.name}</prop>
+		<prop key="group">${xd.group.name}</prop>
 		<prop key="label">${xd.module.label}</prop>
 		<prop key="type">${xd.module.type}</prop>
 		<prop key="sequence">${xd.module.sequence}</prop>

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ModulePlaceholders.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ModulePlaceholders.java
@@ -29,6 +29,8 @@ public final class ModulePlaceholders {
 
 	public static final String XD_JOB_NAME_KEY = "xd.job.name";
 
+	public static final String XD_GROUP_NAME_KEY = "xd.group.name";
+
 	public static final String XD_MODULE_NAME_KEY = "xd.module.name";
 
 	public static final String XD_MODULE_TYPE_KEY = "xd.module.type";


### PR DESCRIPTION
 - For JMX MBean naming strategy, the mbean-exporter was using `xd.stream.name`
to uniquely identify each module. This broke the job module naming.
   - This fix uses a key `xd.group.name` to assign both the job/stream name
for the module being exported. That way we would avoid having Stream/Job specific
key to identify the module.