### PR TITLE
[Sprint 48][master][1.1.x][1.2.M1]XD-3009 Copy request headers into message

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
@@ -383,7 +383,7 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 				if (bytes == null) {
 					return null;
 				}
-				bytes = embeddedHeadersMessageConverter.extractHeaders(new GenericMessage<byte[]>(bytes)).getPayload();
+				bytes = embeddedHeadersMessageConverter.extractHeaders(new GenericMessage<byte[]>(bytes), false).getPayload();
 				return new String(bytes, "UTF-8");
 			}
 

--- a/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -452,7 +452,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		protected Object handleRequestMessage(Message<?> requestMessage) {
 			Message<?> theRequestMessage = requestMessage;
 			try {
-				theRequestMessage = embeddedHeadersMessageConverter.extractHeaders((Message<byte[]>) requestMessage);
+				theRequestMessage = embeddedHeadersMessageConverter.extractHeaders((Message<byte[]>) requestMessage, true);
 			}
 			catch (Exception e) {
 				logger.error(EmbeddedHeadersMessageConverter.decodeExceptionMessage(requestMessage), e);


### PR DESCRIPTION
 - At the message bus receiving handler, when the embedded headers are extreacted back to the message,
the request headers were left out.
  - Fix is made to copy the request headers also into the message if `copyRequestHeaders` is set to true