### PR TITLE
[Sprint: 49] XD-3024: Extra metric endpoints for getting all metric resources for counters, gauges and rich-gauges.

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AbstractMetricsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AbstractMetricsController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.data.web.PagedResourcesAssemblerArgumentResolver;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.ResourceAssembler;
+import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,7 +39,7 @@ import org.springframework.xd.rest.domain.metrics.MetricResource;
 /**
  * Base class for controllers that expose metrics related resources. Subclasses are meant to provide the root
  * {@link RequestMapping} uri.
- * 
+ *
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
  */
@@ -66,8 +67,28 @@ abstract class AbstractMetricsController<R extends MetricRepository<M>, M extend
 	}
 
 	/**
+	 * Lists metric resources.
+	 *
+	 * @param pageable
+	 * @param pagedAssembler
+	 * @param resourceAssembler
+	 * @return
+	 */
+	protected PagedResources<? extends MetricResource> list(Pageable pageable,
+			PagedResourcesAssembler<M> pagedAssembler,
+			ResourceAssemblerSupport<M, ? extends MetricResource> resourceAssembler) {
+		/* Page */Iterable<M> metrics = repository.findAll(/* pageable */);
+
+		// Ok for now until we use PagingAndSortingRepo as we know we have lists
+		Page<M> page = new PageImpl<M>((List<M>) metrics);
+		return pagedAssembler.toResource(page,
+				resourceAssembler == null ? shallowResourceAssembler : resourceAssembler);
+	}
+
+
+	/**
 	 * Deletes the metric from the repository
-	 * 
+	 *
 	 * @param name the name of the metric to delete
 	 */
 	@RequestMapping(value = "/{name}", method = RequestMethod.DELETE)

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AbstractMetricsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AbstractMetricsController.java
@@ -22,10 +22,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
-import org.springframework.data.web.PagedResourcesAssemblerArgumentResolver;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.ResourceAssembler;
-import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -51,20 +49,8 @@ abstract class AbstractMetricsController<R extends MetricRepository<M>, M extend
 		this.repository = repository;
 	}
 
-	private final ResourceAssembler<M, MetricResource> shallowResourceAssembler = new ShallowMetricResourceAssembler<M>(
+	protected final ResourceAssembler<M, MetricResource> shallowResourceAssembler = new ShallowMetricResourceAssembler<M>(
 			this.getClass());
-
-	/**
-	 * Handles listing of shallow metric representations. Method still has to be overridden (and annotated) in
-	 * subclasses because of the way {@link PagedResourcesAssemblerArgumentResolver} works.
-	 */
-	protected PagedResources<MetricResource> list(Pageable pageable, PagedResourcesAssembler<M> pagedAssembler) {
-		/* Page */Iterable<M> metrics = repository.findAll(/* pageable */);
-
-		// Ok for now until we use PagingAndSortingRepo as we know we have lists
-		Page<M> page = new PageImpl<M>((List<M>) metrics);
-		return pagedAssembler.toResource(page, shallowResourceAssembler);
-	}
 
 	/**
 	 * Lists metric resources.
@@ -76,7 +62,7 @@ abstract class AbstractMetricsController<R extends MetricRepository<M>, M extend
 	 */
 	protected PagedResources<? extends MetricResource> list(Pageable pageable,
 			PagedResourcesAssembler<M> pagedAssembler,
-			ResourceAssemblerSupport<M, ? extends MetricResource> resourceAssembler) {
+			ResourceAssembler<M, ? extends MetricResource> resourceAssembler) {
 		/* Page */Iterable<M> metrics = repository.findAll(/* pageable */);
 
 		// Ok for now until we use PagingAndSortingRepo as we know we have lists

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ import org.springframework.xd.rest.domain.metrics.MetricResource;
 
 /**
  * Exposes representations of {@link AggregateCount}s.
- * 
+ *
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
  */
@@ -61,16 +61,16 @@ public class AggregateCountersController extends AbstractMetricsController<Aggre
 	/**
 	 * List {@link AggregateCount}s that match the given criteria.
 	 */
-	@Override
 	@ResponseBody
 	@RequestMapping(value = "", method = RequestMethod.GET)
-	public PagedResources<MetricResource> list(Pageable pageable, PagedResourcesAssembler<Counter> pagedAssembler) {
-		return super.list(pageable, pagedAssembler);
+	public PagedResources<? extends MetricResource> list(Pageable pageable,
+			PagedResourcesAssembler<Counter> pagedAssembler) {
+		return list(pageable, pagedAssembler, shallowResourceAssembler);
 	}
 
 	/**
 	 * Retrieve counts for a given time interval, using some precision.
-	 * 
+	 *
 	 * @param name the name of the aggregate counter we want to retrieve data from
 	 * @param from the start-time for the interval, default depends on the resolution (e.g. go back 1 day for hourly
 	 *        buckets)
@@ -79,8 +79,8 @@ public class AggregateCountersController extends AbstractMetricsController<Aggre
 	 */
 	@ResponseBody
 	@RequestMapping(value = "/{name}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public AggregateCountsResource display(@PathVariable("name") String name,//
-			@RequestParam(value = "from", required = false) @DateTimeFormat(iso = ISO.DATE_TIME) DateTime from,//
+	public AggregateCountsResource display(@PathVariable("name") String name, //
+			@RequestParam(value = "from", required = false) @DateTimeFormat(iso = ISO.DATE_TIME) DateTime from, //
 			@RequestParam(value = "to", required = false) @DateTimeFormat(iso = ISO.DATE_TIME) DateTime to, //
 			@RequestParam(value = "resolution", defaultValue = "hour") AggregateCountResolution resolution) {
 
@@ -97,7 +97,7 @@ public class AggregateCountersController extends AbstractMetricsController<Aggre
 	}
 
 	private DateTime fromValue(DateTime to, AggregateCountResolution resolution) {
-		switch(resolution) {
+		switch (resolution) {
 			case minute:
 				return to.minusMinutes(59);
 			case hour:

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/CountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/CountersController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.xd.dirt.rest.metrics;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -35,7 +36,7 @@ import org.springframework.xd.rest.domain.metrics.MetricResource;
 
 /**
  * Exposes representations of {@link Counter}s.
- * 
+ *
  * @author Eric Bottard
  */
 @Controller
@@ -71,5 +72,16 @@ public class CountersController extends AbstractMetricsController<CounterReposit
 			throw new NoSuchMetricException(name, "There is no counter named '%s'");
 		}
 		return counterResourceAssembler.toResource(c);
+	}
+
+	/**
+	 * Retrieve information about a page of specific counters.
+	 */
+	@ResponseBody
+	@RequestMapping(value = "/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	public PagedResources<CounterResource> displayAll(Pageable pageable,
+			PagedResourcesAssembler<Counter> pagedAssembler) {
+		Page<Counter> page = repository.findAll(pageable);
+		return pagedAssembler.toResource(page, counterResourceAssembler);
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/CountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/CountersController.java
@@ -59,8 +59,7 @@ public class CountersController extends AbstractMetricsController<CounterReposit
 	public PagedResources<? extends MetricResource> list(Pageable pageable,
 			PagedResourcesAssembler<Counter> pagedAssembler,
 			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {
-		return detailed ? list(pageable, pagedAssembler, counterResourceAssembler)
-				: list(pageable, pagedAssembler);
+		return list(pageable, pagedAssembler, detailed ? counterResourceAssembler : shallowResourceAssembler);
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/CountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/CountersController.java
@@ -17,7 +17,6 @@
 package org.springframework.xd.dirt.rest.metrics;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -27,6 +26,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.xd.analytics.metrics.core.Counter;
 import org.springframework.xd.analytics.metrics.core.CounterRepository;
@@ -54,11 +54,13 @@ public class CountersController extends AbstractMetricsController<CounterReposit
 	/**
 	 * List Counters that match the given criteria.
 	 */
-	@Override
 	@ResponseBody
 	@RequestMapping(value = "", method = RequestMethod.GET)
-	public PagedResources<MetricResource> list(Pageable pageable, PagedResourcesAssembler<Counter> pagedAssembler) {
-		return super.list(pageable, pagedAssembler);
+	public PagedResources<? extends MetricResource> list(Pageable pageable,
+			PagedResourcesAssembler<Counter> pagedAssembler,
+			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {
+		return detailed ? list(pageable, pagedAssembler, counterResourceAssembler)
+				: list(pageable, pagedAssembler);
 	}
 
 	/**
@@ -74,14 +76,4 @@ public class CountersController extends AbstractMetricsController<CounterReposit
 		return counterResourceAssembler.toResource(c);
 	}
 
-	/**
-	 * Retrieve information about a page of specific counters.
-	 */
-	@ResponseBody
-	@RequestMapping(value = "/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public PagedResources<CounterResource> displayAll(Pageable pageable,
-			PagedResourcesAssembler<Counter> pagedAssembler) {
-		Page<Counter> page = repository.findAll(pageable);
-		return pagedAssembler.toResource(page, counterResourceAssembler);
-	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/FieldValueCountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/FieldValueCountersController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2013 the original author or authors.
+ * Copyright 2002-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.springframework.xd.rest.domain.metrics.MetricResource;
 
 /**
  * Controller that exposes {@link FieldValueCounter} related representations.
- * 
+ *
  * @author Eric Bottard
  */
 @Controller
@@ -57,12 +57,11 @@ public class FieldValueCountersController extends
 	/**
 	 * List {@link FieldValueCounter}s that match the given criteria.
 	 */
-	@Override
 	@ResponseBody
 	@RequestMapping(value = "", method = RequestMethod.GET)
-	public PagedResources<MetricResource> list(Pageable pageable,
+	public PagedResources<? extends MetricResource> list(Pageable pageable,
 			PagedResourcesAssembler<FieldValueCounter> pagedAssembler) {
-		return super.list(pageable, pagedAssembler);
+		return super.list(pageable, pagedAssembler, shallowResourceAssembler);
 	}
 
 	@ResponseBody

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/FieldValueCountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/FieldValueCountersController.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.xd.analytics.metrics.core.FieldValueCounter;
 import org.springframework.xd.analytics.metrics.core.FieldValueCounterRepository;
@@ -60,8 +61,9 @@ public class FieldValueCountersController extends
 	@ResponseBody
 	@RequestMapping(value = "", method = RequestMethod.GET)
 	public PagedResources<? extends MetricResource> list(Pageable pageable,
-			PagedResourcesAssembler<FieldValueCounter> pagedAssembler) {
-		return super.list(pageable, pagedAssembler, shallowResourceAssembler);
+			PagedResourcesAssembler<FieldValueCounter> pagedAssembler,
+			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {
+		return list(pageable, pagedAssembler, detailed ? fvcResourceAssembler : shallowResourceAssembler);
 	}
 
 	@ResponseBody

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/GaugesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/GaugesController.java
@@ -55,8 +55,7 @@ public class GaugesController extends AbstractMetricsController<GaugeRepository,
 	public PagedResources<? extends MetricResource> list(Pageable pageable,
 			PagedResourcesAssembler<Gauge> pagedAssembler,
 			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {
-		return detailed ? list(pageable, pagedAssembler, gaugeResourceAssembler)
-				: list(pageable, pagedAssembler);
+		return list(pageable, pagedAssembler, detailed ? gaugeResourceAssembler : shallowResourceAssembler);
 	}
 
 	@ResponseBody

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/GaugesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/GaugesController.java
@@ -16,20 +16,16 @@
 
 package org.springframework.xd.dirt.rest.metrics;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.xd.analytics.metrics.core.Gauge;
 import org.springframework.xd.analytics.metrics.core.GaugeRepository;
@@ -54,12 +50,13 @@ public class GaugesController extends AbstractMetricsController<GaugeRepository,
 		super(repository);
 	}
 
-	@Override
 	@ResponseBody
 	@RequestMapping(value = "", method = RequestMethod.GET)
-	public PagedResources<MetricResource> list(Pageable pageable,
-			PagedResourcesAssembler<Gauge> pagedAssembler) {
-		return super.list(pageable, pagedAssembler);
+	public PagedResources<? extends MetricResource> list(Pageable pageable,
+			PagedResourcesAssembler<Gauge> pagedAssembler,
+			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {
+		return detailed ? list(pageable, pagedAssembler, gaugeResourceAssembler)
+				: list(pageable, pagedAssembler);
 	}
 
 	@ResponseBody
@@ -72,11 +69,4 @@ public class GaugesController extends AbstractMetricsController<GaugeRepository,
 		return gaugeResourceAssembler.toResource(g);
 	}
 
-	@ResponseBody
-	@RequestMapping(value = "/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public PagedResources<GaugeResource> displayAll(Pageable pageable,
-			PagedResourcesAssembler<Gauge> pagedAssembler) {
-		Page<Gauge> page = new PageImpl<Gauge>((List<Gauge>) repository.findAll());
-		return pagedAssembler.toResource(page, gaugeResourceAssembler);
-	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/GaugesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/GaugesController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@
 
 package org.springframework.xd.dirt.rest.metrics;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,7 +39,7 @@ import org.springframework.xd.rest.domain.metrics.MetricResource;
 
 /**
  * Exposes representations of {@link Gauge}s.
- * 
+ *
  * @author Luke Taylor
  */
 @Controller
@@ -65,5 +70,13 @@ public class GaugesController extends AbstractMetricsController<GaugeRepository,
 			throw new NoSuchMetricException(name, "There is no gauge named '%s'");
 		}
 		return gaugeResourceAssembler.toResource(g);
+	}
+
+	@ResponseBody
+	@RequestMapping(value = "/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	public PagedResources<GaugeResource> displayAll(Pageable pageable,
+			PagedResourcesAssembler<Gauge> pagedAssembler) {
+		Page<Gauge> page = new PageImpl<Gauge>((List<Gauge>) repository.findAll());
+		return pagedAssembler.toResource(page, gaugeResourceAssembler);
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/RichGaugesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/RichGaugesController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package org.springframework.xd.dirt.rest.metrics;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -35,7 +39,7 @@ import org.springframework.xd.rest.domain.metrics.RichGaugeResource;
 
 /**
  * Exposes representations of {@link org.springframework.xd.analytics.metrics.core.Gauge}s.
- * 
+ *
  * @author Luke Taylor
  */
 @Controller
@@ -66,5 +70,13 @@ public class RichGaugesController extends AbstractMetricsController<RichGaugeRep
 			throw new NoSuchMetricException(name, "There is no rich gauge named '%s'");
 		}
 		return gaugeResourceAssembler.toResource(g);
+	}
+
+	@ResponseBody
+	@RequestMapping(value = "/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+	public PagedResources<RichGaugeResource> displayAll(Pageable pageable,
+			PagedResourcesAssembler<RichGauge> pagedAssembler) {
+		Page<RichGauge> page = new PageImpl<RichGauge>((List<RichGauge>) repository.findAll());
+		return pagedAssembler.toResource(page, gaugeResourceAssembler);
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/RichGaugesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/RichGaugesController.java
@@ -56,8 +56,7 @@ public class RichGaugesController extends AbstractMetricsController<RichGaugeRep
 	public PagedResources<? extends MetricResource> list(Pageable pageable,
 			PagedResourcesAssembler<RichGauge> pagedAssembler,
 			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {
-		return detailed ? list(pageable, pagedAssembler, gaugeResourceAssembler)
-				: list(pageable, pagedAssembler);
+		return list(pageable, pagedAssembler, detailed ? gaugeResourceAssembler : shallowResourceAssembler);
 	}
 
 	@ResponseBody

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/RichGaugesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/RichGaugesController.java
@@ -16,11 +16,7 @@
 
 package org.springframework.xd.dirt.rest.metrics;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
@@ -30,6 +26,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.xd.analytics.metrics.core.RichGauge;
 import org.springframework.xd.analytics.metrics.core.RichGaugeRepository;
@@ -54,12 +51,13 @@ public class RichGaugesController extends AbstractMetricsController<RichGaugeRep
 		super(repository);
 	}
 
-	@Override
 	@ResponseBody
 	@RequestMapping(value = "", method = RequestMethod.GET)
-	public PagedResources<MetricResource> list(Pageable pageable,
-			PagedResourcesAssembler<RichGauge> pagedAssembler) {
-		return super.list(pageable, pagedAssembler);
+	public PagedResources<? extends MetricResource> list(Pageable pageable,
+			PagedResourcesAssembler<RichGauge> pagedAssembler,
+			@RequestParam(value = "detailed", defaultValue = "false") boolean detailed) {
+		return detailed ? list(pageable, pagedAssembler, gaugeResourceAssembler)
+				: list(pageable, pagedAssembler);
 	}
 
 	@ResponseBody
@@ -72,11 +70,4 @@ public class RichGaugesController extends AbstractMetricsController<RichGaugeRep
 		return gaugeResourceAssembler.toResource(g);
 	}
 
-	@ResponseBody
-	@RequestMapping(value = "/all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public PagedResources<RichGaugeResource> displayAll(Pageable pageable,
-			PagedResourcesAssembler<RichGauge> pagedAssembler) {
-		Page<RichGauge> page = new PageImpl<RichGauge>((List<RichGauge>) repository.findAll());
-		return pagedAssembler.toResource(page, gaugeResourceAssembler);
-	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/AbstractControllerIntegrationTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/AbstractControllerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.xd.analytics.metrics.core.AggregateCounterRepository;
 import org.springframework.xd.analytics.metrics.core.CounterRepository;
 import org.springframework.xd.analytics.metrics.core.FieldValueCounterRepository;
 import org.springframework.xd.analytics.metrics.core.GaugeRepository;
@@ -51,7 +52,7 @@ import org.springframework.xd.dirt.zookeeper.ZooKeeperAccessException;
 /**
  * Base class for Controller layer tests. Takes care of resetting the mocked (be them mockito mocks or <i>e.g.</i> in
  * memory) dependencies before each test.
- * 
+ *
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
  */
@@ -117,6 +118,9 @@ public class AbstractControllerIntegrationTest {
 
 	@Autowired
 	protected RichGaugeRepository richGaugeRepository;
+
+	@Autowired
+	protected AggregateCounterRepository aggregateCounterRepository;
 
 	@Autowired
 	private JobService jobService;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersControllerIntegrationTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.springframework.xd.dirt.rest.metrics;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+
+import org.hamcrest.Matchers;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.xd.analytics.metrics.core.AggregateCount;
+import org.springframework.xd.analytics.metrics.core.AggregateCountResolution;
+import org.springframework.xd.analytics.metrics.core.Counter;
+import org.springframework.xd.dirt.rest.AbstractControllerIntegrationTest;
+import org.springframework.xd.dirt.rest.Dependencies;
+import org.springframework.xd.dirt.rest.RestConfiguration;
+
+/**
+ * @author Alex Boyko
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(classes = { RestConfiguration.class, Dependencies.class })
+public class AggregateCountersControllerIntegrationTests extends AbstractControllerIntegrationTest {
+
+	private void setupAggCounts(int number) {
+		Counter[] counters = new Counter[10];
+		AggregateCount[] aggCounters = new AggregateCount[10];
+		DateTime to = new DateTime();
+		DateTime from = to.minusMinutes(59);
+		Interval interval = new Interval(from, to);
+		AggregateCountResolution resolution = AggregateCountResolution.minute;
+		long[] counts = new long[60];
+		for (int i = 0; i < 60; i++) {
+			counts[i] = i;
+		}
+		for (int i = 0; i < counters.length; i++) {
+			counters[i] = new Counter("c" + i, i);
+			aggCounters[i] = new AggregateCount("c" + i, interval, counts, resolution);
+			when(aggregateCounterRepository.getCounts(org.mockito.Matchers.eq(aggCounters[i].getName()),
+					org.mockito.Matchers.any(Interval.class), org.mockito.Matchers.eq(resolution))).thenReturn(
+							aggCounters[i]);
+		}
+		when(aggregateCounterRepository.findAll()).thenReturn(Arrays.asList(counters));
+	}
+
+	@Test
+	public void testAggregateCountersListing() throws Exception {
+		setupAggCounts(10);
+
+		ResultActions resActions = mockMvc.perform(get("/metrics/aggregate-counters")).andExpect(status().isOk())//
+		.andExpect(jsonPath("$.content", Matchers.hasSize(10)));
+
+		for (int i = 0; i < 10; i++) {
+			resActions.andExpect(jsonPath("$.content[" + i + "].name").value("c" + i));
+			resActions.andExpect(jsonPath("$.content[" + i + "].counts").doesNotExist());
+		}
+	}
+
+	@Test
+	public void testDetailedAggregateCountersListing() throws Exception {
+		setupAggCounts(10);
+
+		ResultActions resActions = mockMvc.perform(get("/metrics/aggregate-counters?detailed=true")).andExpect(
+				status().isOk())//
+				.andExpect(jsonPath("$.content", Matchers.hasSize(10)));
+
+		for (int i = 0; i < 10; i++) {
+			resActions.andExpect(jsonPath("$.content[" + i + "].name").value("c" + i));
+			resActions.andExpect(jsonPath("$.content[" + i + "].counts").exists());
+		}
+	}
+
+}

--- a/src/docs/asciidoc/REST-API.asciidoc
+++ b/src/docs/asciidoc/REST-API.asciidoc
@@ -343,6 +343,10 @@ For both the GET endpoints **only** 'application/json' accept header is supporte
 |GET
 |list all the known counters
 
+|/metrics/counters?detailed=true
+|GET
+|list metric values for all known counters
+
 |/metrics/counters/\{name\}
 |GET
 |get the current metric value
@@ -363,6 +367,10 @@ For both the GET endpoints **only** 'application/json' accept header is supporte
 |/metrics/field-value-counters/
 |GET
 |list all the known field value counters
+
+|/metrics/field-value-counters?detailed=true
+|GET
+|list metric values for all known field value counters
 
 |/metrics/field-value-counters/\{name\}
 |GET
@@ -385,6 +393,10 @@ For both the GET endpoints **only** 'application/json' accept header is supporte
 |GET
 |list all the known aggregate counters
 
+|/metrics/aggregate-counters?detailed=true
+|GET
+|list current metric values for all known aggregate counters
+
 |/metrics/aggregate-counters/\{name\}
 |GET
 |get the current metric values
@@ -406,6 +418,10 @@ For both the GET endpoints **only** 'application/json' accept header is supporte
 |GET
 |list all the known gauges
 
+|/metrics/gauges?detailed=true
+|GET
+|list current metric values for all known gauges
+
 |/metrics/gauges/\{name\}
 |GET
 |get the current metric values
@@ -426,6 +442,10 @@ For both the GET endpoints **only** 'application/json' accept header is supporte
 |/metrics/rich-gauges/
 |GET
 |list all the known rich gauges
+
+|/metrics/rich-gauges?detailed=true
+|GET
+|list metric values for all known rich gauges
 
 |/metrics/rich-gauges/\{name\}
 |GET


### PR DESCRIPTION
Counters supports paging. Gauges and rich-gauges I couldn't get paging support implementation thus it's just gets all resources. (Couldn't figure out the right implementation for Redis based repository class)

See https://jira.spring.io/browse/XD-3024