### PR TITLE
[Sprint 49] XD-2992 Support multiple topics for kafka source

### DIFF
--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/InitialOffsetsFactoryBean.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/InitialOffsetsFactoryBean.java
@@ -16,8 +16,10 @@
 
 package org.springframework.integration.x.kafka;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -31,26 +33,28 @@ import org.springframework.util.StringUtils;
  * Parses the list of initial offsets and creates a map to initialize the {@link OffsetManager}
  *
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
 public class InitialOffsetsFactoryBean implements FactoryBean<Map<Partition, Long>> {
 
 	// Matches expressions like 0@20,1@50 etc.
 	public static final Pattern VALIDATION_PATTERN = Pattern.compile("(\\d+@\\d+)[,(\\d+@\\d+)]*");
 
-	private String topic;
+	private final List<String> topics;
 
 	private String initialOffsetList;
 
-	public InitialOffsetsFactoryBean(String topic, String initialOffsetList) {
-		Assert.hasText(topic, "Topic name must be provided");
-		this.topic = topic;
+	public InitialOffsetsFactoryBean(String topics, String initialOffsetList) {
+		this.topics = Arrays.asList(topics.split("\\s*,\\s*"));
+		Assert.isTrue(!topics.isEmpty(), "Topic names must be provided");
 		this.initialOffsetList = initialOffsetList;
 	}
 
 	@Override
 	public Map<Partition, Long> getObject() throws Exception {
-		return StringUtils.hasText(initialOffsetList) ?
-				parseOffsetList(topic, initialOffsetList) : Collections.<Partition, Long>emptyMap();
+		//TODO: support initial offsets for multiple topics' partitions
+		return (StringUtils.hasText(initialOffsetList) && topics.size() == 1) ?
+				parseOffsetList(topics.get(0), initialOffsetList) : Collections.<Partition, Long>emptyMap();
 	}
 
 	@Override

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaPartitionAllocator.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaPartitionAllocator.java
@@ -17,38 +17,24 @@
 
 package org.springframework.integration.x.kafka;
 
-import static org.apache.curator.framework.imps.CuratorFrameworkState.STARTED;
-
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.imps.CuratorFrameworkState;
-import org.apache.curator.framework.recipes.locks.InterProcessMutex;
-import org.apache.curator.utils.EnsurePath;
-import org.apache.zookeeper.KeeperException;
 
-import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.FactoryBean;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ContextClosedEvent;
-import org.springframework.integration.kafka.core.BrokerAddress;
 import org.springframework.integration.kafka.core.ConnectionFactory;
 import org.springframework.integration.kafka.core.Partition;
-import org.springframework.integration.kafka.listener.OffsetManager;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -56,31 +42,21 @@ import org.springframework.util.StringUtils;
  * Is responsible for managing the partition allocation between multiple instances of a Kafka source module
  * deployed in a stream.
  * As a {@link FactoryBean} it will return the partitions that the current module instance should listen to.
- * The list of partitions is stored in ZooKeeper, and is created when the module is started for the first time.
- * If multiple module instances are started at the same time, they synchronize via ZooKeeper, and only the first
- * will end up creating the module list, while the other instances will read it.
- * Restarted modules will read the list of partitions that corresponds to their own sequence. Zero-count Kafka source
- * modules are not supported.
- * As an {@link ApplicationListener}, it checks whether the current Stream state cleans up the partition table in
- * ZooKeeper when the stream is undeploying by validating that against the stream data path in ZooKeeper.
+ * The partitions for the given topic would be extracted from Kafka unless an explicit partition list
+ * is provided.
+ * Partitions are allocated evenly based on the number of module instances.
+ * Zero-count Kafka source modules are not supported.
  *
  * @author Marius Bogoevici
+ * @author Ilayaperumal Gopinathan
  */
-public class KafkaPartitionAllocator implements InitializingBean, FactoryBean<Partition[]>,
-		ApplicationListener<ContextClosedEvent> {
+public class KafkaPartitionAllocator implements FactoryBean<Partition[]> {
 
 	private static final Log log = LogFactory.getLog(KafkaPartitionAllocator.class);
 
-	private static final Pattern PARTITION_LIST_VALIDATION_REGEX =
-			Pattern.compile("\\d+([,-]\\d+)*");
+	private static final Pattern PARTITION_LIST_VALIDATION_REGEX = Pattern.compile("\\d+([,-]\\d+)*");
 
-	public static final String STREAM_STATUS_UNDEPLOYED = "undeployed";
-
-	public static final String STREAM_STATUS_UNDEPLOYING = "undeploying";
-
-	public static final String STREAM_PATH_PATTERN = "deployments/streams/%s/status";
-
-	private final String topic;
+	private final List<String> topics;
 
 	private final String partitionList;
 
@@ -90,54 +66,26 @@ public class KafkaPartitionAllocator implements InitializingBean, FactoryBean<Pa
 
 	private final int sequence;
 
-	private final CuratorFramework client;
-
-	private final OffsetManager offsetManager;
-
 	private final String moduleName;
 
 	private final String streamName;
 
-	private final ObjectMapper objectMapper = new ObjectMapper();
-
-	private final String partitionDataPath;
-
-	private volatile Partition[] partitions;
-
-	private InterProcessMutex partitionDataMutex;
-
-	public KafkaPartitionAllocator(CuratorFramework client, ConnectionFactory connectionFactory, String moduleName,
-			String streamName, String topic, String partitionList, int sequence, int count,
-			OffsetManager offsetManager) {
+	public KafkaPartitionAllocator(ConnectionFactory connectionFactory, String moduleName,
+			String streamName, String topics, String partitionList, int sequence, int count) {
 		Assert.notNull(connectionFactory, "cannot be null");
 		Assert.hasText(moduleName, "cannot be empty");
 		Assert.hasText(streamName, "cannot be empty");
-		Assert.hasText(topic, "cannot be empty");
+		Assert.hasText(topics, "cannot be empty");
 		Assert.isTrue(sequence > 0, " must be a positive number. 0-count kafka sources are not currently supported");
 		Assert.isTrue(count > 0, " must be a positive number. 0-count kafka sources are not currently supported");
 		Assert.notNull(count > 0, " must be a positive number. 0-count kafka sources are not currently supported");
-		this.client = client;
 		this.connectionFactory = connectionFactory;
 		this.moduleName = moduleName;
 		this.streamName = streamName;
-		this.topic = topic;
+		this.topics = Arrays.asList(topics.split("\\s*,\\s*"));
 		this.partitionList = partitionList;
 		this.sequence = sequence;
 		this.count = count;
-		this.offsetManager = offsetManager;
-		this.partitionDataPath = String.format("/sources/%s/%s", this.streamName, this.moduleName);
-	}
-
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		if (STARTED.equals(this.client.getState())) {
-			EnsurePath ensurePath = new EnsurePath(partitionDataPath);
-			ensurePath.ensure(client.getZookeeperClient());
-			this.partitionDataMutex = new InterProcessMutex(client, partitionDataPath);//NOSONAR
-		}
-		else {
-			throw new BeanInitializationException("Cannot connect to ZooKeeper, client state is " + client.getState());
-		}
 	}
 
 	@Override
@@ -147,180 +95,52 @@ public class KafkaPartitionAllocator implements InitializingBean, FactoryBean<Pa
 			log.debug("Stream name is " + streamName);
 			log.debug("Cardinality is " + count);
 			log.debug("Sequence is " + sequence);
-			log.debug("Client is " + client);
 		}
-		if (partitions == null) {
-			if (STARTED.equals(client.getState())) {
-				try {
-					partitionDataMutex.acquire();
-					byte[] partitionData = client.getData().forPath(partitionDataPath);
-					if (partitionData == null || partitionData.length == 0) {
-						Collection<Partition> existingPartitions = connectionFactory.getPartitions(topic);
-						Collection<Partition> listenedPartitions = !StringUtils.hasText(partitionList) ?
-								existingPartitions : Arrays.asList(toPartitions(parseNumberList(partitionList)));
-						if (existingPartitions != listenedPartitions && !existingPartitions.containsAll(listenedPartitions)) {
-							Collection<Partition> partitionsNotFound = new ArrayList<Partition>(listenedPartitions);
-							partitionsNotFound.removeAll(existingPartitions);
-							throw new BeanInitializationException("Configuration contains partitions that do not exist on the topic" +
-									" or have unavailable leaders: " + StringUtils.collectionToCommaDelimitedString(partitionsNotFound));
-						}
-						final Map<Partition, BrokerAddress> leaders = connectionFactory.getLeaders(listenedPartitions);
-						ArrayList<Partition> sortedPartitions = new ArrayList<Partition>(listenedPartitions);
-						Collections.sort(sortedPartitions, new Comparator<Partition>() {
-							@Override
-							public int compare(Partition o1, Partition o2) {
-								int i = leaders.get(o1).toString().compareTo(leaders.get(o2).toString());
-								if (i != 0) {
-									return i;
-								}
-								else return o1.getId() - o2.getId();
-							}
-						});
-						if (log.isDebugEnabled()) {
-							log.debug("Partitions: " + StringUtils.collectionToCommaDelimitedString(sortedPartitions));
-						}
-						// calculate the minimum size of a partition group.
-						int minimumSize = sortedPartitions.size() / count;
-						int remainder = sortedPartitions.size() % count;
-						List<List<Integer>> partitionGroups = new ArrayList<List<Integer>>();
-						int cursor = 0;
-						for (int i = 0; i < count; i++) {
-							// first partitions will get an extra element
-							int partitionGroupSize = i < remainder ? minimumSize + 1 : minimumSize;
-							ArrayList<Integer> partitionGroup = new ArrayList<Integer>();
-							for (int j = 0; j < partitionGroupSize; j++) {
-								partitionGroup.add(sortedPartitions.get(cursor++).getId());
-							}
-							if (log.isDebugEnabled()) {
-								log.debug("Partitions for " + (i + 1) + " : " + StringUtils.collectionToCommaDelimitedString(partitionGroup));
-							}
-							partitionGroups.add(partitionGroup);
-						}
-						byte[] dataAsBytes = objectMapper.writer().writeValueAsBytes(partitionGroups);
-						if (log.isDebugEnabled()) {
-							log.debug(new String(dataAsBytes));
-						}
-						client.setData().forPath(partitionDataPath, dataAsBytes);
-						// the partition mapping is stored 0-based but sequence/count are 1-based
-						if (log.isDebugEnabled()) {
-							log.debug("Listening to: " + StringUtils.collectionToCommaDelimitedString(partitionGroups.get(sequence - 1)));
-						}
-						partitions = toPartitions(partitionGroups.get(sequence - 1));
-					}
-					else {
-						if (log.isDebugEnabled()) {
-							log.debug(new String(partitionData));
-						}
-						@SuppressWarnings("unchecked")
-						List<List<Integer>> partitionGroups = objectMapper.reader(List.class).readValue(partitionData);
-						// the partition mapping is stored 0-based but sequence/count are 1-based
-						if (log.isDebugEnabled()) {
-							log.debug("Listening to: " + StringUtils.collectionToCommaDelimitedString(partitionGroups.get(sequence - 1)));
-						}
-						partitions = toPartitions(partitionGroups.get(sequence - 1));
-					}
-					return partitions;
+		Map<String, Collection<Partition>> partitionsMapByTopic = new HashMap<String, Collection<Partition>>();
+		int maxPartitionCount = 0;
+		for (String topic : topics) {
+			List<Partition> partitions = new ArrayList<Partition>(connectionFactory.getPartitions(topic));
+			Collections.sort(partitions, new Comparator<Partition>() {
+				@Override
+				public int compare(Partition partition1, Partition partition2) {
+					return partition1.getId() - partition2.getId();
 				}
-				finally {
-					if (partitionDataMutex.isAcquiredInThisProcess()) {
-						partitionDataMutex.release();
-					}
-				}
-			}
-			else {
-				throw new BeanInitializationException("Cannot connect to ZooKeeper, client state is " + client.getState());
+			});
+			partitionsMapByTopic.put(topic, partitions);
+			maxPartitionCount = (partitions.size() > maxPartitionCount) ? partitions.size() : maxPartitionCount;
+		}
+		Assert.isTrue(maxPartitionCount >= count, "Total module count should not be less than the maximum of " +
+				"partitions from the given topics");
+		if (topics.size() > 1) {
+			Assert.isTrue(!StringUtils.hasText(partitionList), "Explicit partitions list isn't supported for " +
+					"multi-topics");
+		}
+		Map<String, Collection<Partition>> partitionsToListen = StringUtils.hasText(partitionList) ?
+				toPartitionsMap(topics.get(0), parseNumberList(partitionList)) : partitionsMapByTopic;
+		Collection<Partition> partitionsToReturn = new ArrayList<Partition>();
+		// To evenly distribute the partitions, assign the group of deterministic partitions to the given moduleInstance
+		for (Collection<Partition> partitions : partitionsToListen.values()) {
+			Partition[] partitionsArray = partitions.toArray(new Partition[partitions.size()]);
+			for (int i = (sequence - 1); i < partitions.size(); i = i + count) {
+				partitionsToReturn.add(partitionsArray[i]);
 			}
 		}
-		else {
-			return partitions;
-		}
+		return partitionsToReturn.toArray(new Partition[partitionsToReturn.size()]);
 	}
 
-	private String getDataPath() {
-		return String.format("/sources/%s/%s", streamName, moduleName);
-	}
-
-	private Partition[] toPartitions(Iterable<Integer> partitionIds) {
+	/**
+	 * @param topic the topic name which is the key for the map
+	 * @param partitionIds the partition Ids to map
+	 * @return the map of {@ref Partition} collections for the given topic.
+	 */
+	private Map<String, Collection<Partition>> toPartitionsMap(String topic, Iterable<Integer> partitionIds) {
 		List<Partition> partitions = new ArrayList<Partition>();
 		for (Integer partitionId : partitionIds) {
 			partitions.add(new Partition(topic, partitionId));
 		}
-		return partitions.toArray(new Partition[partitions.size()]);
-	}
-
-	@Override
-	public Class<?> getObjectType() {
-		return Partition[].class;
-	}
-
-	@Override
-	public boolean isSingleton() {
-		return true;
-	}
-
-	@Override
-	public void onApplicationEvent(ContextClosedEvent event) {
-		CuratorFrameworkState state = client.getState();
-		if (state.equals(STARTED)) {
-			try {
-				byte[] streamStatusData;
-				try {
-					streamStatusData = client.getData().forPath(String.format(STREAM_PATH_PATTERN, streamName));
-				}
-				catch (KeeperException.NoNodeException e) {
-					// we ignore this error - the stream path does not exist, so it may have been removed already
-					// we'll behave as if we have received no data
-					streamStatusData = null;
-				}
-				// use the stored values in Zookeeper directoy, so as to we do not have a dependency on spring-xd-dirt
-				String deploymentStatus;
-				if (streamStatusData == null || streamStatusData.length == 0) {
-					deploymentStatus = STREAM_STATUS_UNDEPLOYED;
-				}
-				else {
-					Map<String, String> statusDataAsMap = objectMapper.reader(Map.class).readValue(streamStatusData);
-					deploymentStatus = statusDataAsMap.get("state");
-				}
-				if (STREAM_STATUS_UNDEPLOYED.equals(deploymentStatus)
-						|| STREAM_STATUS_UNDEPLOYING.equals(deploymentStatus)) {
-					// remove partitioning data from Kafka
-					if (client.checkExists().forPath(getDataPath()) != null) {
-						try {
-							client.delete().deletingChildrenIfNeeded().forPath(getDataPath());
-						}
-						catch (KeeperException.NoNodeException e) {
-							if (KeeperException.Code.NONODE.equals(e.code())) {
-								// ignore, most likely someone else has deleted the path already
-							}
-							else {
-								// this actually was an exception : we cannot recover, but cannot stop either
-								log.error("Irrecoverable error while trying to clean partitions table:", e);
-							}
-						}
-					}
-					// also, remove offsets
-					for (Partition partition : partitions) {
-						if (log.isDebugEnabled()) {
-							log.debug("Deleting offsets for " + partition.toString());
-						}
-						offsetManager.deleteOffset(partition);
-						try {
-							offsetManager.flush();
-						}
-						catch (IOException e) {
-							log.error("Error while trying to flush offsets: " + e);
-						}
-					}
-
-				}
-			}
-			catch (Exception e) {
-				log.error(e);
-			}
-		}
-		else {
-			log.warn("Could not check the stream state and perform cleanup, client state was " + state);
-		}
+		Map<String, Collection<Partition>> partitionsMap = new HashMap<String, Collection<Partition>>();
+		partitionsMap.put(topic, partitions);
+		return partitionsMap;
 	}
 
 	/**
@@ -356,5 +176,15 @@ public class KafkaPartitionAllocator implements InitializingBean, FactoryBean<Pa
 			}
 		}
 		return Collections.unmodifiableSet(numbers);
+	}
+
+	@Override
+	public Class<?> getObjectType() {
+		return Partition[].class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return true;
 	}
 }

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
@@ -36,7 +36,9 @@ import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 @Mixin({KafkaZKOptionMixin.class, KafkaConsumerOptionsMixin.class, KafkaOffsetTopicOptionsMixin.class})
 public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
-	private String topics = ModulePlaceholders.XD_STREAM_NAME;
+	private String topic = "";
+
+	private String topics = "";
 
 	private String partitions = "";
 
@@ -58,9 +60,18 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
 	private int queueSize = 1000;
 
+	@ModuleOption("single topic name")
+	public void setTopic(String topic) {
+		this.topic = topic;
+	}
+
+	public String getTopic() {
+		return this.topic;
+	}
+
 	@ModuleOption("comma separated kafka topic names")
-	public void setTopics(String topic) {
-		this.topics = topic;
+	public void setTopics(String topics) {
+		this.topics = topics;
 	}
 
 	public String getTopics() {
@@ -165,6 +176,21 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 		inmemory,
 		redis,
 		kafka
+	}
+
+	@AssertTrue(message = "the options topic and topics are mutually exclusive")
+	public boolean isTopicOptionValid() {
+		boolean isTopicValid = StringUtils.hasText(topic);
+		boolean isTopicsValid = StringUtils.hasText(topics);
+		boolean isOptionValid =   isTopicValid  ? !isTopicsValid : true;
+		if (isOptionValid && (!isTopicsValid && !isTopicValid)) {
+			this.topic = ModulePlaceholders.XD_STREAM_NAME;
+			this.topics = this.topic;
+		}
+		else if (isOptionValid && isTopicValid) {
+				this.topics = this.topic;
+		}
+		return isOptionValid;
 	}
 
 	@AssertTrue(message = "explicit partitions can only be set when using single topic source")

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
@@ -16,6 +16,11 @@
 
 package org.springframework.integration.x.kafka;
 
+import java.util.Arrays;
+
+import javax.validation.constraints.AssertTrue;
+
+import org.springframework.util.StringUtils;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
 import org.springframework.xd.module.options.spi.ModulePlaceholders;
@@ -31,7 +36,7 @@ import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 @Mixin({KafkaZKOptionMixin.class, KafkaConsumerOptionsMixin.class, KafkaOffsetTopicOptionsMixin.class})
 public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
-	private String topic = ModulePlaceholders.XD_STREAM_NAME;
+	private String topics = ModulePlaceholders.XD_STREAM_NAME;
 
 	private String partitions = "";
 
@@ -53,13 +58,13 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
 	private int queueSize = 1000;
 
-	@ModuleOption("kafka topic name")
-	public void setTopic(String topic) {
-		this.topic = topic;
+	@ModuleOption("comma separated kafka topic names")
+	public void setTopics(String topic) {
+		this.topics = topic;
 	}
 
-	public String getTopic() {
-		return this.topic;
+	public String getTopics() {
+		return this.topics;
 	}
 
 	public String getPartitions() {
@@ -160,6 +165,16 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 		inmemory,
 		redis,
 		kafka
+	}
+
+	@AssertTrue(message = "explicit partitions can only be set when using single topic source")
+	public boolean isPartitionsOptionValid() {
+		return (Arrays.asList(topics.split("\\s*,\\s*")).size() > 1) ? !StringUtils.hasText(partitions) : true;
+	}
+
+	@AssertTrue(message = "initial offsets can only be set when using single topic source")
+	public boolean isInitialOffsetsValid() {
+		return (Arrays.asList(topics.split("\\s*,\\s*")).size() > 1) ? !StringUtils.hasText(initialOffsets) : true;
 	}
 
 	@Override

--- a/modules/source/kafka/config/kafka.properties
+++ b/modules/source/kafka/config/kafka.properties
@@ -1,2 +1,2 @@
-info.shortDescription = Receives data from Kafka topic.
+info.shortDescription = Receives data from  a single or multiple Kafka topics.
 options_class = org.springframework.integration.x.kafka.KafkaSourceModuleOptionsMetadata

--- a/modules/source/kafka/config/kafka.xml
+++ b/modules/source/kafka/config/kafka.xml
@@ -28,19 +28,17 @@
 
 
 	<bean id="partitions" class="org.springframework.integration.x.kafka.KafkaPartitionAllocator">
-		<constructor-arg index="0" ref="xd.zookeeper.client"/>
-		<constructor-arg index="1" ref="connectionFactory"/>
-		<constructor-arg index="2" value="${xd.module.name}"/>
-		<constructor-arg index="3" value="${xd.stream.name}"/>
-		<constructor-arg index="4" value="${topic}"/>
-		<constructor-arg index="5" value="${partitions}"/>
-		<constructor-arg index="6" value="${xd.module.sequence}"/>
-		<constructor-arg index="7" value="${xd.module.count}"/>
-		<constructor-arg index="8" ref="offsetManager"/>
+		<constructor-arg index="0" ref="connectionFactory"/>
+		<constructor-arg index="1" value="${xd.module.name}"/>
+		<constructor-arg index="2" value="${xd.stream.name}"/>
+		<constructor-arg index="3" value="${topics}"/>
+		<constructor-arg index="4" value="${partitions}"/>
+		<constructor-arg index="5" value="${xd.module.sequence}"/>
+		<constructor-arg index="6" value="${xd.module.count}"/>
 	</bean>
 
 	<bean id="initialOffsetsMap" class="org.springframework.integration.x.kafka.InitialOffsetsFactoryBean">
-		<constructor-arg index="0" value="${topic}"/>
+		<constructor-arg index="0" value="${topics}"/>
 		<constructor-arg index="1" value="${initialOffsets}"/>
 	</bean>
 

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/KafkaSourceSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/KafkaSourceSinkTests.java
@@ -18,12 +18,11 @@ package org.springframework.xd.shell.command;
 import static org.junit.Assert.assertThat;
 import static org.springframework.xd.shell.command.fixtures.XDMatchers.eventually;
 import static org.springframework.xd.shell.command.fixtures.XDMatchers.exists;
+import static org.springframework.xd.shell.command.fixtures.XDMatchers.hasValue;
 
 import java.util.Collections;
 import java.util.Properties;
 
-import kafka.admin.AdminUtils;
-import kafka.api.TopicMetadata;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,6 +38,9 @@ import org.springframework.xd.shell.command.fixtures.HttpSource;
 import org.springframework.xd.test.fixtures.CounterSink;
 import org.springframework.xd.test.kafka.KafkaTestSupport;
 
+import kafka.admin.AdminUtils;
+import kafka.api.TopicMetadata;
+
 /**
  * Integration tests for Kafka source and sinks.
  *
@@ -48,16 +50,26 @@ import org.springframework.xd.test.kafka.KafkaTestSupport;
  */
 public class KafkaSourceSinkTests extends AbstractStreamIntegrationTest {
 
-	private String topicToUse;
+	private String topic1ToUse;
+
+	private String topic2ToUse;
+
 
 	@Rule
 	public KafkaTestSupport kafkaTestSupport = new KafkaTestSupport();
 
 	@Before
 	public void createTopic() throws Exception {
-		topicToUse = "kafka-test-topic-" + random.nextInt();
+		topic1ToUse = "kafka-test-topic-" + random.nextInt();
+		topic2ToUse = "kafka-test-topic-" + random.nextInt();
 		// create Kafka topic
-		AdminUtils.createTopic(kafkaTestSupport.getZkClient(), topicToUse, 1, 1, new Properties());
+		AdminUtils.createTopic(kafkaTestSupport.getZkClient(), topic1ToUse, 1, 1, new Properties());
+		AdminUtils.createTopic(kafkaTestSupport.getZkClient(), topic2ToUse, 1, 1, new Properties());
+		setupRetryTemplate(topic1ToUse);
+		setupRetryTemplate(topic2ToUse);
+	}
+
+	private void setupRetryTemplate(final String topic) throws Exception {
 		RetryTemplate retryTemplate = new RetryTemplate();
 		retryTemplate.setRetryPolicy(new SimpleRetryPolicy(5,
 				Collections.<Class<? extends Throwable>,Boolean>singletonMap(TopicNotFoundException.class, true)));
@@ -65,7 +77,7 @@ public class KafkaSourceSinkTests extends AbstractStreamIntegrationTest {
 		retryTemplate.execute(new RetryCallback<TopicMetadata, Exception>() {
 			@Override
 			public TopicMetadata doWithRetry(RetryContext context) throws Exception {
-				return AdminUtils.fetchTopicMetadataFromZk(topicToUse, kafkaTestSupport.getZkClient());
+				return AdminUtils.fetchTopicMetadataFromZk(topic, kafkaTestSupport.getZkClient());
 			}
 		});
 	}
@@ -73,7 +85,8 @@ public class KafkaSourceSinkTests extends AbstractStreamIntegrationTest {
 	@After
 	public void deleteTopic() {
 		// delete topic
-		AdminUtils.deleteTopic(kafkaTestSupport.getZkClient(), topicToUse);
+		AdminUtils.deleteTopic(kafkaTestSupport.getZkClient(), topic1ToUse);
+		AdminUtils.deleteTopic(kafkaTestSupport.getZkClient(), topic2ToUse);
 	}
 
 
@@ -81,16 +94,21 @@ public class KafkaSourceSinkTests extends AbstractStreamIntegrationTest {
 	public void testKafkaSourceAndSink() throws Exception {
 		final String stringToPost = "Hi there!";
 		// create stream with kafka sink
-		final HttpSource httpSource = newHttpSource();
+		final HttpSource httpSource1 = newHttpSource();
+		final HttpSource httpSource2 = newHttpSource();
 		stream().create(generateStreamName(), "%s | kafka --topic='%s' --brokerList='%s'",
-				httpSource, topicToUse, kafkaTestSupport.getBrokerAddress());
+				httpSource1, topic1ToUse, kafkaTestSupport.getBrokerAddress());
+		stream().create(generateStreamName(), "%s | kafka --topic='%s' --brokerList='%s'",
+				httpSource2, topic2ToUse, kafkaTestSupport.getBrokerAddress());
 		// create stream with kafka source
 		final CounterSink counter = metrics().newCounterSink();
-		stream().create(generateStreamName(), "kafka --topic='%s' --zkconnect=%s --outputType=text/plain | " +
+		stream().create(generateStreamName(), "kafka --topics='%s,%s' --zkconnect=%s --outputType=text/plain | " +
 				"filter --expression=payload.toString().contains('%s') | %s",
-				topicToUse, kafkaTestSupport.getZkConnectString(), stringToPost, counter );
-		httpSource.ensureReady().postData(stringToPost);
+				topic1ToUse, topic2ToUse, kafkaTestSupport.getZkConnectString(), stringToPost, counter );
+		httpSource1.ensureReady().postData(stringToPost);
+		httpSource1.ensureReady().postData(stringToPost);
 		assertThat(counter, eventually(exists()));
+		assertThat(counter, eventually(hasValue("2")));
 	}
 
 

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -1076,7 +1076,7 @@ $$queueSize$$:: $$the maximum number of messages held internally and waiting for
 $$socketBufferBytes$$:: $$socket receive buffer for network requests$$ *($$int$$, default: `2097152`)*
 $$socketTimeout$$:: $$sock timeout for network requests in milliseconds$$ *($$int$$, default: `30000`)*
 $$streams$$:: $$number of streams in the topic$$ *($$int$$, default: `1`)*
-$$topic$$:: $$kafka topic name$$ *($$String$$, default: `<stream name>`)*
+$$topics$$:: $$comma separated kafka topic names$$ *($$String$$, default: `<stream name>`)*
 $$zkconnect$$:: $$zookeeper connect string$$ *($$String$$, default: `localhost:2181/kafka`)*
 $$zkconnectionTimeout$$:: $$the max time the client waits to connect to ZK in milliseconds$$ *($$int$$, default: `6000`)*
 $$zksessionTimeout$$:: $$zookeeper session timeout in milliseconds$$ *($$int$$, default: `6000`)*

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -1076,7 +1076,8 @@ $$queueSize$$:: $$the maximum number of messages held internally and waiting for
 $$socketBufferBytes$$:: $$socket receive buffer for network requests$$ *($$int$$, default: `2097152`)*
 $$socketTimeout$$:: $$sock timeout for network requests in milliseconds$$ *($$int$$, default: `30000`)*
 $$streams$$:: $$number of streams in the topic$$ *($$int$$, default: `1`)*
-$$topics$$:: $$comma separated kafka topic names$$ *($$String$$, default: `<stream name>`)*
+$$topic$$:: $$single topic name$$ *($$String$$, default: ``)*
+$$topics$$:: $$comma separated kafka topic names$$ *($$String$$, default: ``)*
 $$zkconnect$$:: $$zookeeper connect string$$ *($$String$$, default: `localhost:2181/kafka`)*
 $$zkconnectionTimeout$$:: $$the max time the client waits to connect to ZK in milliseconds$$ *($$int$$, default: `6000`)*
 $$zksessionTimeout$$:: $$zookeeper session timeout in milliseconds$$ *($$int$$, default: `6000`)*


### PR DESCRIPTION
 - Allow comma separated list of topics as module option to kafka source module
 - Restrict initialOffset and explicit partition list only for single topic
   - Add validation that checks these options are valid only if single topic is configured
 - Modify `KafkaPartitionAllocator`
   - Remove ZooKeeper dependency to persist the partitions for the kafka source
   - Evenly distribute the kafka partitions (all or specific) to the requested module instances
 - Update test