### PR TITLE
[Sprint: 49] XD-3041 Exclude MongoDB autoconfiguration

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
@@ -24,6 +24,8 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -41,8 +43,8 @@ import org.springframework.xd.dirt.util.ConfigLocations;
  * @author Gunnar Hillert
  */
 @EnableAutoConfiguration(exclude = {ServerPropertiesAutoConfiguration.class, BatchAutoConfiguration.class,
-		ThymeleafAutoConfiguration.class, JmxAutoConfiguration.class,
-		HealthIndicatorAutoConfiguration.class, AuditAutoConfiguration.class})
+		ThymeleafAutoConfiguration.class, JmxAutoConfiguration.class, HealthIndicatorAutoConfiguration.class,
+		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class })
 @ImportResource("classpath:" + ConfigLocations.XD_CONFIG_ROOT + "global/parent-context.xml")
 @EnableBatchProcessing
 public class ParentConfiguration {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminServerApplication.java
@@ -32,6 +32,8 @@ import org.springframework.boot.autoconfigure.batch.BatchDatabaseInitializer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerException;
 import org.springframework.context.ApplicationContext;
@@ -62,7 +64,8 @@ import org.springframework.xd.dirt.web.WebConfiguration;
 
 @Configuration
 @EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, JmxAutoConfiguration.class,
-		AuditAutoConfiguration.class, GroovyTemplateAutoConfiguration.class})
+		AuditAutoConfiguration.class, GroovyTemplateAutoConfiguration.class, MongoAutoConfiguration.class,
+		MongoDataAutoConfiguration.class })
 @ImportResource("classpath:" + ConfigLocations.XD_INTERNAL_CONFIG_ROOT + "admin-server.xml")
 @ComponentScan("org.springframework.xd.dirt.server.security")
 @Import({RestConfiguration.class, WebConfiguration.class, DeploymentConfiguration.class})

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentConfiguration.java
@@ -20,6 +20,8 @@ import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.xd.dirt.cluster.AdminAttributes;
@@ -49,7 +51,7 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
  */
 @Configuration
 @EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, JmxAutoConfiguration.class,
-		AuditAutoConfiguration.class})
+		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class })
 public class DeploymentConfiguration {
 
 	@Autowired

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerConfiguration.java
@@ -21,6 +21,8 @@ import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
@@ -49,7 +51,7 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
  */
 @Configuration
 @EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, JmxAutoConfiguration.class,
-		AuditAutoConfiguration.class})
+		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class })
 public class ContainerConfiguration {
 
 	/*

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerServerApplication.java
@@ -26,6 +26,8 @@ import org.springframework.boot.actuate.autoconfigure.AuditAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -61,7 +63,7 @@ import org.springframework.xd.dirt.util.XdProfiles;
  */
 @Configuration
 @EnableAutoConfiguration(exclude = { BatchAutoConfiguration.class, JmxAutoConfiguration.class,
-	AuditAutoConfiguration.class })
+	AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class })
 public class ContainerServerApplication implements EnvironmentAware {
 
 	private static final Log logger = LogFactory.getLog(ContainerServerApplication.class);

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/WebConfiguration.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/WebConfiguration.java
@@ -16,6 +16,8 @@ package org.springframework.xd.dirt.web;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,7 +26,8 @@ import org.springframework.context.annotation.Configuration;
  *
  * @author Gunnar Hillert
  */
-@EnableAutoConfiguration(exclude = GroovyTemplateAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {GroovyTemplateAutoConfiguration.class,
+		MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
 @Configuration
 @ComponentScan
 public class WebConfiguration {


### PR DESCRIPTION
 - exclude `MongoAutoConfiguration` and `MongoDataAutoConfiguration` from
XD admin, container and singlenode applications.