### PR TITLE
[Sprint 49]XD-2691 Upgraded to gradle 2.2 and ported to maven-publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,26 @@ ext {
 	linkScmUrl = 'https://github.com/spring-projects/spring-xd'
 	linkScmConnection = 'https://github.com/spring-projects/spring-xd.git'
 	linkScmDevConnection = 'git@github.com:spring-projects/spring-xd.git'
+	xdDevelopers = [
+		[ name:'Mark Fisher', id:'markfisher', email: 'mfisher@pivotal.io'],
+		[ name:'Mark Pollack', id:'markpollack', email: 'mpollack@pivotal.io'],
+		[ name:'Gary Russell', id:'garyrussell', email: 'grussell@pivotal.io'],
+		[ name:'Gunnar Hillert', id:'ghillert', email: 'ghillert@pivotal.io'],
+		[ name:'Patrick Peralta', id:'pperalta', email: 'pperalta@pivotal.io'],
+		[ name:'David Turanski', id:'dturanski', email: 'dturanski@pivotal.io'],
+		[ name:'Eric Bottard', id:'ebottard', 	email: 'ebottard@pivotal.io'],
+		[ name:'Glenn Renfro', id:'grenfro', email: 'grenfro@pivotal.io'],
+		[ name:'Ilayaperumal Gopinathan', id:'igopinathan', email: 'igopinathan@pivotal.io'],
+		[ name:'Thomas Risberg', id:'trisberg', email: 'trisberg@pivotal.io'],
+		[ name:'Marius Bogoevici', id:'mbogoevici', email: 'mbogoevici@pivotal.io'],
+		[ name:'Jennifer Hickey', id:'jhickey', email: ''],
+		[ name:'Michael Minella', id:'mminella', email: 'mminella@pivotal.io'],
+		[ name:'Andy Clement', id:'aclement', email: 'aclement@pivotal.io'],
+		[ name:'Luke Taylor', id:'ltaylor', email: ''],
+		[ name:'Dave Syer', id:'dsyer', email: 'dsyer@pivotal.io'],
+		[ name:'Janne Valkealahti', id:'jvalkealahti', email: 'jvalkealahti@pivotal.io'],
+		[ name: 'Thomas Darimont', id:'tdarimont', email: 'tdarimont@pivotal.io']
+	]
 
 	javadocLinks = [
 			"http://docs.spring.io/spring-xd/docs/1.0.x/api/"
@@ -153,7 +173,6 @@ configure(javaProjects) { subproject ->
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
 	apply plugin: 'propdeps'
-	apply plugin: 'propdeps-maven'
 	apply plugin: 'propdeps-idea'
 	apply plugin: 'propdeps-eclipse'
 
@@ -165,8 +184,7 @@ configure(javaProjects) { subproject ->
 		enabled = false
 	}
 
-	if (!subproject.projectDir.absolutePath.contains('spring-xd-starters')
-			&& !subproject.projectDir.absolutePath.contains('spring-xd-gradle-plugins')) {
+	if (!subproject.projectDir.absolutePath.contains('spring-xd-starters')) {
 		apply from: "${rootProject.projectDir}/publish-maven.gradle"
 		apply plugin: 'javadocHotfix'
 		apply plugin: 'license'
@@ -1337,7 +1355,9 @@ apply from: 'gradle/build-dist.gradle'
 
 task wrapper(type: Wrapper) {
 	description = "Generates build_xd[.bat] scripts"
-	gradleVersion = "1.12"
+	//see http://stackoverflow.com/questions/29113972/spring-boot-gradle-plugin-application-plugin-and-gradle-2-3-wrapper
+	//before upgrading to 2.3
+	gradleVersion = "2.2"
 	scriptFile = "gradle/build_xd"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,32 @@ configure(javaProjects) { subproject ->
 		enabled = false
 	}
 
+	compileJava {
+		sourceCompatibility = 1.7
+		targetCompatibility = 1.7
+		options.fork = true
+		options.forkOptions.with {
+			memoryMaximumSize = "512m"
+		}
+	}
+
+	compileTestJava {
+		sourceCompatibility = 1.7
+		targetCompatibility = 1.7
+		options.fork = true
+		options.forkOptions.with {
+			memoryMaximumSize = "512m"
+		}
+	}
+
+	eclipse {
+		jdt {
+			sourceCompatibility=1.7
+			targetCompatibility=1.7
+		}
+		project { natures += 'org.springframework.ide.eclipse.core.springnature' }
+	}
+
 	if (!subproject.projectDir.absolutePath.contains('spring-xd-starters')) {
 		apply from: "${rootProject.projectDir}/publish-maven.gradle"
 		apply plugin: 'javadocHotfix'
@@ -200,31 +226,6 @@ configure(javaProjects) { subproject ->
 			excludes(['**/package-info.java'])
 		}
 
-		compileJava {
-			sourceCompatibility = 1.7
-			targetCompatibility = 1.7
-			options.fork = true
-			options.forkOptions.with {
-				memoryMaximumSize = "512m"
-			}
-		}
-
-		compileTestJava {
-			sourceCompatibility = 1.7
-			targetCompatibility = 1.7
-			options.fork = true
-			options.forkOptions.with {
-				memoryMaximumSize = "512m"
-			}
-		}
-
-		eclipse {
-			jdt {
-				sourceCompatibility=1.7
-				targetCompatibility=1.7
-			}
-			project { natures += 'org.springframework.ide.eclipse.core.springnature' }
-		}
 
 		// Include project specific settings
 		task eclipseSettings(type: Copy) {

--- a/gradle/build-docs.gradle
+++ b/gradle/build-docs.gradle
@@ -28,6 +28,7 @@ project('documentation-toolchain') {
 	task shellReferenceDoc(type: JavaExec) {
 		classpath = sourceSets.test.runtimeClasspath
 		mainClassName = 'org.springframework.xd.documentation.ShellReferenceDoc'
+		main = mainClassName
 		workingDir = rootProject.file('.')
 		args = [
 				"$docsDir/ShellReference.asciidoc"
@@ -37,6 +38,7 @@ project('documentation-toolchain') {
 	task moduleOptionsReferenceDoc(type: JavaExec, dependsOn: ':spring-xd-dirt:build') {
 		classpath = sourceSets.main.runtimeClasspath
 		mainClassName = 'org.springframework.xd.documentation.ModuleOptionsReferenceDoc'
+		main = mainClassName
 		workingDir = rootProject.file('.')
 		args = [
 				"$docsDir/Sources.asciidoc",
@@ -49,6 +51,7 @@ project('documentation-toolchain') {
 	task checkDocsLinks(type: JavaExec, dependsOn: [compileJava, shellReferenceDoc, moduleOptionsReferenceDoc]) {
 		classpath = sourceSets.main.runtimeClasspath
 		mainClassName = 'org.springframework.xd.documentation.AsciidocLinkChecker'
+		main = mainClassName
 		args = [
 				"file:$docsDir/*.asciidoc"
 		]

--- a/gradle/build-docs.gradle
+++ b/gradle/build-docs.gradle
@@ -27,7 +27,7 @@ project('documentation-toolchain') {
 
 	task shellReferenceDoc(type: JavaExec) {
 		classpath = sourceSets.test.runtimeClasspath
-		main = 'org.springframework.xd.documentation.ShellReferenceDoc'
+		mainClassName = 'org.springframework.xd.documentation.ShellReferenceDoc'
 		workingDir = rootProject.file('.')
 		args = [
 				"$docsDir/ShellReference.asciidoc"
@@ -36,7 +36,7 @@ project('documentation-toolchain') {
 
 	task moduleOptionsReferenceDoc(type: JavaExec, dependsOn: ':spring-xd-dirt:build') {
 		classpath = sourceSets.main.runtimeClasspath
-		main = 'org.springframework.xd.documentation.ModuleOptionsReferenceDoc'
+		mainClassName = 'org.springframework.xd.documentation.ModuleOptionsReferenceDoc'
 		workingDir = rootProject.file('.')
 		args = [
 				"$docsDir/Sources.asciidoc",
@@ -48,7 +48,7 @@ project('documentation-toolchain') {
 	}
 	task checkDocsLinks(type: JavaExec, dependsOn: [compileJava, shellReferenceDoc, moduleOptionsReferenceDoc]) {
 		classpath = sourceSets.main.runtimeClasspath
-		main = 'org.springframework.xd.documentation.AsciidocLinkChecker'
+		mainClassName = 'org.springframework.xd.documentation.AsciidocLinkChecker'
 		args = [
 				"file:$docsDir/*.asciidoc"
 		]
@@ -56,11 +56,6 @@ project('documentation-toolchain') {
 
 
 }
-
-
-
-
-
 
 apply plugin: org.asciidoctor.gradle.AsciidoctorPlugin
 

--- a/gradle/build-gradle-plugins.gradle
+++ b/gradle/build-gradle-plugins.gradle
@@ -23,9 +23,6 @@ propertiesFile.withInputStream {
 	versions.load(it)
 }
 
-//apply from: 'publish-maven.gradle'
-//task install(dependsOn:'publishToMavenLocal'){}
-
 project('spring-xd-module-plugin') {
 	startScripts.setEnabled(false)
     description = 'Gradle plugin to build a Spring XD Module'
@@ -37,8 +34,8 @@ project('spring-xd-module-plugin') {
  		runtime "org.springframework.build.gradle:propdeps-plugin:${versions['org.springframework.build.gradle:propdeps-plugin']}"
  	}
  	compileGroovy {
-		sourceCompatibility = 1.6
-		targetCompatibility = 1.6
+		sourceCompatibility = project.compileJava.sourceCompatibility
+		targetCompatibility = project.compileJava.targetCompatibility
 	}
 }
 

--- a/gradle/build-gradle-plugins.gradle
+++ b/gradle/build-gradle-plugins.gradle
@@ -23,8 +23,11 @@ propertiesFile.withInputStream {
 	versions.load(it)
 }
 
+//apply from: 'publish-maven.gradle'
+//task install(dependsOn:'publishToMavenLocal'){}
+
 project('spring-xd-module-plugin') {
-	apply plugin: 'maven'
+	startScripts.setEnabled(false)
     description = 'Gradle plugin to build a Spring XD Module'
 	dependencies {
  		compile gradleApi()

--- a/gradle/build-starters.gradle
+++ b/gradle/build-starters.gradle
@@ -25,6 +25,8 @@ project('spring-xd-module-parent') {
 		compile project(':spring-xd-dirt')
 	}
 
+	startScripts.setEnabled(false)
+
 	bootRepackage {
  	   enabled = false
 	}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 18 13:16:47 EST 2014
+#Fri May 01 15:35:53 EDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-bin.zip

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven-publish'
 
 //alias install -> publishToMavenLocal
-task install(dependsOn:'publishToMavenLocal'){}
+task install(dependsOn: 'publishToMavenLocal') {}
 
 // exclude hadoop install sub projects
 def hadoopInstalls = ['cdh5', 'hadoop26', 'hdp22', 'phd21', 'phd30']
@@ -9,14 +9,7 @@ if (hadoopInstalls.contains(project.name)) {
 	project.tasks.findByPath("artifactoryPublish")?.enabled = false
 }
 
-
-
-// load versions
-def versions = new Properties()
-def propertiesFile = new File('dependencies.properties')
-propertiesFile.withInputStream {
-	versions.load(it)
-}
+def nonPublishedProjects = hadoopInstalls + 'documentation-toolchain'
 
 def customizePom = {
 	description project.description
@@ -40,7 +33,7 @@ def customizePom = {
 	}
 
 	developers {
-		xdDevelopers.each {dev ->
+		xdDevelopers.each { dev ->
 			developer {
 				id dev.id
 				name dev.name
@@ -64,7 +57,7 @@ task javadocMaven(type: Jar, dependsOn: javadoc) {
 	from javadoc.destinationDir
 }
 
-def providedDep = {dep->
+def providedDep = { dep ->
 	dependency {
 		artifactId dep.name
 		groupId dep.group
@@ -75,8 +68,34 @@ def providedDep = {dep->
 
 providedDep.resolveStrategy = Closure.DELEGATE_ONLY
 
+class ProjectDependenciesVersionResolver {
+	Map<String, ResolvedDependency>  resolvedDependencies = [:]
+
+	ProjectDependenciesVersionResolver(project) {
+		project.configurations.findAll {
+			['compile', 'runtime', 'default', 'optional', 'provided'].contains(it.name)
+		}.each { cfg ->
+			cfg.resolvedConfiguration.firstLevelModuleDependencies.each { dep ->
+				def existing = resolvedDependencies.putIfAbsent("${dep.moduleGroup}:${dep.moduleName}".toString(), dep)
+
+				//TODO: This may never happen, but added here just in case it does.
+				if (existing) {
+					assert existing.moduleVersion == dep.moduleVersion:
+							"Cannot resolve dependency version for ${project.name}. Different versions ${dep} ${existing}"
+				}
+			}
+		}
+	}
+
+	def getVersion(groupId, artifactId) {
+		def dep = resolvedDependencies["${groupId}:${artifactId}".toString()]
+		assert dep: "Unable to resolve dependency version for ${groupId}:${artifactId}"
+		return dep.moduleVersion
+	}
+}
+
 //Note setting enabled=false on publishing tasks doesn't work as expected
-if (!(hadoopInstalls + 'documentation-toolchain').contains(project.name)) {
+if (!nonPublishedProjects.contains(project.name)) {
 	publishing {
 		publications {
 			mavenCustom(MavenPublication) {
@@ -92,23 +111,29 @@ if (!(hadoopInstalls + 'documentation-toolchain').contains(project.name)) {
 				}
 
 				pom.withXml {
+
+					def projectDependenciesVersionResolver = new ProjectDependenciesVersionResolver(project)
+
 					asNode().version + customizePom
 
 					asNode().dependencies.'*'.each {
+
 						// Add version as the 3rd element
 						it.version ||
-							it.children().add(2,
-								new Node(null, 'version', versions["${it.groupId.text()}:${it.artifactId.text()}"]))
+								it.children().add(2,
+										new Node(null, 'version', 
+										projectDependenciesVersionResolver.getVersion(it.groupId.text(), it.artifactId.text())))
 					}
 
 					project.configurations.optional.allDependencies.each { dep ->
-						def mvnDep = asNode().dependencies.'*'.find { it.artifactId.text() == dep.name }
+						def mvnDep = asNode().dependencies.'*'.find {
+							it.artifactId.text() == dep.name && it.groupId.text() == dep.group
+						}
 						new Node(mvnDep, 'optional', 'true')
 					}
 					project.configurations.provided.allDependencies.each { dep ->
-						println "provided: ${dep.name}"
 						def mvnDep = asNode().dependencies.'*'.find {
-							it.artifactId.text() == dep.name && it.scope?.text() == 'runtime'
+							it.artifactId.text() == dep.name && it.groupId.text() == dep.group
 						}
 						if (mvnDep) {
 							mvnDep.scope*.replaceNode(new Node(null, 'scope', 'provided'))
@@ -116,9 +141,12 @@ if (!(hadoopInstalls + 'documentation-toolchain').contains(project.name)) {
 							asNode().dependencies + providedDep(dep)
 						}
 					}
+
 					project.configurations.compile.allDependencies.each { dep ->
+						// Since provided is a subset of compile or runtime, 'runtime' guard is required here to preserve
+						// dependencies already changed to 'provided' above
 						def mvnDep = asNode().dependencies.'*'.find {
-							it.artifactId.text() == dep.name && it.scope?.text() == 'runtime'
+							it.artifactId.text() == dep.name && it.groupId.text() == dep.group && it.scope?.text() == 'runtime'
 						}
 						mvnDep?.scope*.replaceNode(new Node(null, 'scope', 'compile'))
 					}
@@ -129,19 +157,18 @@ if (!(hadoopInstalls + 'documentation-toolchain').contains(project.name)) {
 					asNode().dependencies.'*'.each { mvnDep ->
 						def scope = mvnDep.scope ? mvnDep.scope.text() : 'compile'
 						def configuration = project.configurations."${scope}"
-						
-						configuration.excludeRules.each { ex->
+
+						configuration.excludeRules.each { ex ->
 							// TODO: Extra credit for getting the builder style to work here (see 'providedDep' above)
 							if (mvnDep.exclusions) {
 								def exclusion = new Node(mvnDep.exclusions[0], 'exclusion', null)
 								new Node(exclusion, 'groupId', ex.group)
 								new Node(exclusion, 'artifactId', ex.module ?: '*')
-							}
-							else {
+							} else {
 								def exclusions = new Node(mvnDep, 'exclusions', null)
 								def exclusion = new Node(exclusions, 'exclusion', null)
-								new Node(exclusion, 'groupId',ex.group)
-								new Node(exclusion, 'artifactId',ex.module ?: '*')
+								new Node(exclusion, 'groupId', ex.group)
+								new Node(exclusion, 'artifactId', ex.module ?: '*')
 							}
 						}
 					}

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -1,170 +1,150 @@
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
+
+//alias install -> publishToMavenLocal
+task install(dependsOn:'publishToMavenLocal'){}
 
 // exclude hadoop install sub projects
 def hadoopInstalls = ['cdh5', 'hadoop26', 'hdp22', 'phd21', 'phd30']
 if (hadoopInstalls.contains(project.name)) {
-	// Disable installing hadoop distro artifacts
-	install.enabled = false
-	// Disable publishing hadoop distro artifacts
 	project.tasks.findByPath("artifactoryPublish")?.enabled = false
 }
 
-install {
-	repositories.mavenInstaller {
-		customizePom(pom, project)
+
+
+// load versions
+def versions = new Properties()
+def propertiesFile = new File('dependencies.properties')
+propertiesFile.withInputStream {
+	versions.load(it)
+}
+
+def customizePom = {
+	description project.description
+	url linkHomepage
+	organization {
+		name 'Spring by Pivotal'
+		url 'https://spring.io'
+	}
+	licenses {
+		license {
+			name 'The Apache Software License, Version 2.0'
+			url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+			distribution 'repo'
+		}
+	}
+
+	scm {
+		url linkScmUrl
+		connection linkScmConnection
+		developerConnection linkScmDevConnection
+	}
+
+	developers {
+		xdDevelopers.each {dev ->
+			developer {
+				id dev.id
+				name dev.name
+				if (dev.email) {
+					email dev.email
+				}
+			}
+		}
 	}
 }
 
-def customizePom(pom, gradleProject) {
-	pom.whenConfigured { generatedPom ->
-		// respect 'optional' and 'provided' dependencies
-		gradleProject.configurations.optional.each { dep ->
-			generatedPom.dependencies.find { it.artifactId == dep.name }?.optional = 'true'
-		}
-		gradleProject.configurations.provided.each { dep ->
-			generatedPom.dependencies.find { it.artifactId == dep.name }?.scope = 'provided'
-		}
+// This is needed to generate elements that are also defined methods in MavenPublication
+customizePom.resolveStrategy = Closure.DELEGATE_FIRST
 
-		// eliminate test-scoped dependencies (no need in maven central poms)
-		generatedPom.dependencies.removeAll { dep ->
-			dep.scope == 'test'
-		}
+task sourceJar(type: Jar) {
+	from sourceSets.main.allJava
+}
 
-		def versions = new Properties()
-		def propertiesFile = new File('dependencies.properties')
-		propertiesFile.withInputStream {
-			versions.load(it)
-		}
 
-		// add all items necessary for maven central publication
-		generatedPom.project {
-			dependencyManagement {
-				dependencies {
-					versions.each { k,v ->
-						dependency {
-							def toks = k.split(':')
-							groupId = toks[0]
-							artifactId = toks[1]
-							version = v
+task javadocMaven(type: Jar, dependsOn: javadoc) {
+	from javadoc.destinationDir
+}
+
+def providedDep = {dep->
+	dependency {
+		artifactId dep.name
+		groupId dep.group
+		version dep.version
+		scope provided
+	}
+}
+
+providedDep.resolveStrategy = Closure.DELEGATE_ONLY
+
+//Note setting enabled=false on publishing tasks doesn't work as expected
+if (!(hadoopInstalls + 'documentation-toolchain').contains(project.name)) {
+	publishing {
+		publications {
+			mavenCustom(MavenPublication) {
+
+				from components.java
+
+				artifact sourceJar {
+					classifier 'sources'
+				}
+
+				artifact javadocMaven {
+					classifier 'javadoc'
+				}
+
+				pom.withXml {
+					asNode().version + customizePom
+
+					asNode().dependencies.'*'.each {
+						// Add version as the 3rd element
+						it.version ||
+							it.children().add(2,
+								new Node(null, 'version', versions["${it.groupId.text()}:${it.artifactId.text()}"]))
+					}
+
+					project.configurations.optional.allDependencies.each { dep ->
+						def mvnDep = asNode().dependencies.'*'.find { it.artifactId.text() == dep.name }
+						new Node(mvnDep, 'optional', 'true')
+					}
+					project.configurations.provided.allDependencies.each { dep ->
+						println "provided: ${dep.name}"
+						def mvnDep = asNode().dependencies.'*'.find {
+							it.artifactId.text() == dep.name && it.scope?.text() == 'runtime'
+						}
+						if (mvnDep) {
+							mvnDep.scope*.replaceNode(new Node(null, 'scope', 'provided'))
+						} else {
+							asNode().dependencies + providedDep(dep)
 						}
 					}
-				}
-			}
+					project.configurations.compile.allDependencies.each { dep ->
+						def mvnDep = asNode().dependencies.'*'.find {
+							it.artifactId.text() == dep.name && it.scope?.text() == 'runtime'
+						}
+						mvnDep?.scope*.replaceNode(new Node(null, 'scope', 'compile'))
+					}
 
-			name = gradleProject.description
-			description = gradleProject.description
-			url = linkHomepage
-			organization {
-				name = 'Spring by Pivotal'
-				url = 'https://spring.io'
-			}
-			licenses {
-				license {
-					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-					distribution 'repo'
-				}
-			}
-			scm {
-				url = linkScmUrl
-				connection = linkScmConnection
-				developerConnection = linkScmDevConnection
-			}
-
-			developers {
-				developer {
-					id = 'markfisher'
-					name = 'Mark Fisher'
-					email = 'mfisher@pivotal.io'
-				}
-				developer {
-					id = 'markpollack'
-					name = 'Mark Pollack'
-					email = 'mpollack@pivotal.io'
-				}
-				developer {
-					id = 'garyrussell'
-					name = 'Gary Russell'
-					email = 'grussell@pivotal.io'
-				}
-				developer {
-					id = 'ghillert'
-					name = 'Gunnar Hillert'
-					email = 'ghillert@pivotal.io'
-				}
-				developer {
-					id = 'pperalta'
-					name = 'Patrick Peralta'
-					email = 'pperalta@pivotal.io'
-				}
-				developer {
-					id = 'dturanski'
-					name = 'David Turanski'
-					email = 'dturanski@pivotal.io'
-				}
-				developer {
-					id = 'ebottard'
-					name = 'Eric Bottard'
-					email = 'ebottard@pivotal.io'
-				}
-				developer {
-					id = 'grenfro'
-					name = 'Glenn Renfro'
-					email = 'grenfro@pivotal.io'
-				}
-				developer {
-					id = 'igopinathan'
-					name = 'Ilayaperumal Gopinathan'
-					email = 'igopinathan@pivotal.io'
-				}
-				developer {
-					id = 'trisberg'
-					name = 'Thomas Risberg'
-					email = 'trisberg@pivotal.io'
-				}
-				developer {
-					id = 'mbogoevici'
-					name = 'Marius Bogoevici'
-					email = 'mbogoevici@pivotal.io'
-				}
-				developer {
-					id = 'jhickey'
-					name = 'Jennifer Hickey'
-				}
-				developer {
-					id = 'mminella'
-					name = 'Michael Minella'
-					email = 'mminella@pivotal.io'
-				}
-				developer {
-					id = 'ltaylor'
-					name = 'Luke Taylor'
-					email = 'ltaylor@pivotal.io'
-				}
-				developer {
-					id = 'aclement'
-					name = 'Andy Clement'
-					email = 'aclement@pivotal.io'
-				}
-				developer {
-					id = 'dsyer'
-					name = 'Dave Syer'
-					email = 'dsyer@pivotal.io'
-				}
-				developer {
-					id = 'jvalkealahti'
-					name = 'Janne Valkealahti'
-					email = 'jvalkealahti@pivotal.io'
-				}
-				developer {
-					id = 'jbrisbin'
-					name = 'Jon Brisbin'
-					email = 'jbrisbin@pivotal.io'
-				}
-				developer {
-					id = 'tdarimont'
-					name = 'Thomas Darimont'
-					email = 'tdarimont@pivotal.io'
+					// 
+					// This plugin does not support excludes applied to configurations.
+					//
+					asNode().dependencies.'*'.each { mvnDep ->
+						def scope = mvnDep.scope ? mvnDep.scope.text() : 'compile'
+						def configuration = project.configurations."${scope}"
+						
+						configuration.excludeRules.each { ex->
+							// TODO: Extra credit for getting the builder style to work here (see 'providedDep' above)
+							if (mvnDep.exclusions) {
+								def exclusion = new Node(mvnDep.exclusions[0], 'exclusion', null)
+								new Node(exclusion, 'groupId', ex.group)
+								new Node(exclusion, 'artifactId', ex.module ?: '*')
+							}
+							else {
+								def exclusions = new Node(mvnDep, 'exclusions', null)
+								def exclusion = new Node(exclusions, 'exclusion', null)
+								new Node(exclusion, 'groupId',ex.group)
+								new Node(exclusion, 'artifactId',ex.module ?: '*')
+							}
+						}
+					}
 				}
 			}
 		}

--- a/spring-xd-gradle-plugins/spring-xd-module-plugin/src/main/groovy/org/springframework/xd/gradle/plugin/ModulePlugin.groovy
+++ b/spring-xd-gradle-plugins/spring-xd-module-plugin/src/main/groovy/org/springframework/xd/gradle/plugin/ModulePlugin.groovy
@@ -47,7 +47,6 @@ class ModulePlugin implements Plugin<Project> {
 	void apply(Project project) {
 		project.apply plugin: 'spring-boot'
 		project.apply plugin: 'propdeps'
-		project.apply plugin: 'propdeps-maven'
 		project.apply plugin: 'propdeps-idea'
 		project.apply plugin: 'propdeps-eclipse'
 
@@ -81,10 +80,6 @@ class ModulePlugin implements Plugin<Project> {
 		project.springBoot {
 			layout = 'MODULE'
 			customConfiguration = "exported"
-		}
-
-		project.test {
-			systemProperty 'XD_HOME', project.rootDir
 		}
 
 		project.task('configureModule') << {

--- a/spring-xd-starters/spring-xd-module-parent/publish-maven.gradle
+++ b/spring-xd-starters/spring-xd-module-parent/publish-maven.gradle
@@ -1,5 +1,3 @@
-import org.gradle.api.artifacts.ProjectDependency
-
 apply plugin: 'maven-publish'
 //alias install -> publishToMavenLocal
 task install(dependsOn:'publishToMavenLocal'){}
@@ -38,8 +36,8 @@ def customizePom = {
 	description project.description
 	properties {
 		'project.build.sourceEncoding' 'UTF-8'
-		'java.source.version' '1.7'
-		'java.target.version' '1.7'
+		'java.source.version' project.compileJava.sourceCompatibility
+		'java.target.version' project.compileJava.targetCompatibility
 		'resource.delimiter' '@'
 		'project.reporting.outputEncoding' 'UTF-8'
 		'maven.compiler.source' '${java.source.version}'

--- a/spring-xd-starters/spring-xd-module-parent/publish-maven.gradle
+++ b/spring-xd-starters/spring-xd-module-parent/publish-maven.gradle
@@ -1,9 +1,8 @@
-apply plugin: 'maven'
 import org.gradle.api.artifacts.ProjectDependency
 
-install.repositories.mavenInstaller {
-	customizePom(pom, project)
-}
+apply plugin: 'maven-publish'
+//alias install -> publishToMavenLocal
+task install(dependsOn:'publishToMavenLocal'){}
 
 ext.dependencyList = []
 
@@ -25,153 +24,169 @@ def getAllDependentProjects(project) {
 	}
 }
 
-def customizePom(pom, gradleProject) {
-	pom.whenConfigured { generatedPom ->
-		// add all items necessary for maven central publication
-		
-		getAllDependentProjects(gradleProject)
+// load versions
+def versions = new Properties()
+def propertiesFile = new File('dependencies.properties')
+propertiesFile.withInputStream {
+	versions.load(it)
+}
 
-		generatedPom.dependencies.clear()
-		
-    	generatedPom.project {
-      		inceptionYear '2014'
-      		packaging 'pom'
-      		url linkHomepage
-      		licenses {
-        		license {
-          			name 'The Apache Software License, Version 2.0'
-          			url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-          			distribution 'repo'
-        		}
-      		}
-      		scm {
-				url = linkScmUrl
-				connection = linkScmConnection
-				developerConnection = linkScmDevConnection
-	  		}
-  
-			name = gradleProject.description
-			description = gradleProject.description
+def customizePom = {
 
-			properties {
-				'project.build.sourceEncoding' 'UTF-8'
-				'java.source.version' '1.7'
-				'java.target.version' '1.7'
-				'resource.delimiter' '@'
-				'project.reporting.outputEncoding' 'UTF-8'
-				'maven.compiler.source' '${java.source.version}'
-				'maven.compiler.target' '${java.target.version}'
-				'spring.xd.version'  version
-				'spring.boot.version' '1.2.1.RELEASE'
-			}
-			
-	 
-			/*
-			TODO: This breaks with Gradle 2.x see http://forums.gradle.org/gradle/topics/after_upgrade_gradle_to_2_0_version_the_maven_pom_not_support_build_property
-			*/
-			'build' {
-				'plugins' {
-					'plugin' {
-						'groupId' 'org.springframework.boot'
-						'artifactId' 'spring-boot-maven-plugin'
-						'version' '${spring.boot.version}'
-						'configuration' {
-							'layout' 'MODULE'
-							excludes {
-								dependencyList.each {
-									def toks = it.split(':')
-									exclude {
-										groupId toks[0]
-										artifactId toks[1]
-									}
-								}
-							}
-						}
-						'executions' {
-							'execution' {
-								'goals' {
-									'goal' 'repackage'
-								}
+	inceptionYear '2014'
+	packaging 'pom'
+	description project.description
+	properties {
+		'project.build.sourceEncoding' 'UTF-8'
+		'java.source.version' '1.7'
+		'java.target.version' '1.7'
+		'resource.delimiter' '@'
+		'project.reporting.outputEncoding' 'UTF-8'
+		'maven.compiler.source' '${java.source.version}'
+		'maven.compiler.target' '${java.target.version}'
+		'spring.xd.version' version
+		'spring.boot.version' versions['org.springframework.boot:spring-boot']
+	}
+	url linkHomepage
+	organization {
+		name 'Spring by Pivotal'
+		url 'https://spring.io'
+	}
+	licenses {
+		license {
+			name 'The Apache Software License, Version 2.0'
+			url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+			distribution 'repo'
+		}
+	}
+
+	scm {
+		url linkScmUrl
+		connection linkScmConnection
+		developerConnection linkScmDevConnection
+	}
+	build {
+		plugins {
+			plugin {
+				groupId 'org.springframework.boot'
+				artifactId 'spring-boot-maven-plugin'
+				version '${spring.boot.version}'
+				configuration {
+					layout 'MODULE'
+					getAllDependentProjects(project)
+					excludes {
+						dependencyList.each {
+							def toks = it.split(':')
+							exclude {
+								groupId toks[0]
+								artifactId toks[1]
 							}
 						}
 					}
-
-					plugin {
-						'groupId' 'org.apache.maven.plugins'
-						'artifactId' 'maven-surefire-plugin'
-					  	'version' '2.18'
-					  	configuration {
-					  		systemPropertyVariables {
-					  			'XD_HOME' '${project.basedir}'
-					  		}
-					  	}
-					}
 				}
-			}
-
-			dependencies {
-				dependency {
-					groupId 'org.springframework.xd'
-					artifactId 'spring-xd-dirt'
-					version '${spring.xd.version}'
-					scope 'provided'
-					exclusions {
-						exclusion {
-							groupId 'org.springframework.xd'
-							artifactId 'spring-xd-hadoop'
-						}
-						exclusion {
-							groupId 'org.springframework.xd'
-							artifactId 'spring-xd-spark-streaming'
-						}
-					}
-				}
-				dependency {
-					groupId 'org.springframework.xd'
-					artifactId 'spring-xd-test'
-					version '${spring.xd.version}'
-					scope 'test'
-					exclusions {
-						exclusion {
-							groupId 'org.springframework.xd'
-							artifactId 'spring-xd-hadoop'
-						}
-						exclusion {
-							groupId 'org.springframework.data'
-							artifactId 'spring-data-hadoop-test'
-						}
-						exclusion {
-							groupId 'org.springframework.data'
-							artifactId 'spring-data-hadoop'
+				executions {
+					execution {
+						goals {
+							goal 'repackage'
 						}
 					}
 				}
 			}
 
-			repositories {
-				repository {
-					id = 'jcenter'
-					name = 'JCenter Repository'
-					url = 'http://jcenter.bintray.com/'
-				}
-				repository {
-					id = 'repository.io.snapshot'
-					name = 'Spring Snapshot Repository'
-					url = 'http://repo.spring.io/snapshot'
-				}
-				repository {
-					id = 'repository.io.milestone'
-					name = 'Spring Milestone Repository'
-					url = 'http://repo.spring.io/milestone'
-				}
-			}
-			pluginRepositories {
-				pluginRepository {
-					id = 'repository.io.milestone'
-					name = 'Spring Milestone Repository'
-					url = 'http://repo.spring.io/milestone'
+			plugin {
+				groupId 'org.apache.maven.plugins'
+				artifactId 'maven-surefire-plugin'
+				version '2.18'
+				configuration {
 				}
 			}
 		}
 	}
+
+	repositories {
+		repository {
+			id 'jcenter'
+			name 'JCenter Repository'
+			url 'http://jcenter.bintray.com/'
+		}
+		repository {
+			id 'repository.io.snapshot'
+			name 'Spring Snapshot Repository'
+			url 'http://repo.spring.io/snapshot'
+		}
+		repository {
+			id 'repository.io.milestone'
+			name 'Spring Milestone Repository'
+			url 'http://repo.spring.io/milestone'
+		}
+	}
+	pluginRepositories {
+		pluginRepository {
+			id 'repository.io.milestone'
+			name 'Spring Milestone Repository'
+			url 'http://repo.spring.io/milestone'
+		}
+	}
 }
+
+// This is needed to generate elements that are also defined methods in MavenPublication
+customizePom.resolveStrategy = Closure.DELEGATE_FIRST
+
+publishing {
+	publications {
+		mavenCustom(MavenPublication) {
+			from components.java
+			
+			pom.withXml {
+				asNode().version + customizePom
+
+				asNode().remove(asNode().dependencies)
+				// Builder is not straightforward here.
+				def dependencyManagement = new Node(asNode(),'dependencyManagement', null)
+				def dependencies
+				dependencies = new Node(dependencyManagement, 'dependencies', null)
+				versions.each {k,version ->
+					def (groupId,artifactId) = k.split(':')
+					def dependency = new Node(dependencies, 'dependency', null)
+					new Node(dependency, 'groupId', groupId)
+					new Node(dependency, 'artifactId', artifactId)
+					new Node(dependency, 'version', version)
+				}
+				
+				dependencies = new Node(asNode(), 'dependencies', null)
+				def dependency
+				dependency = new Node(dependencies, 'dependency', null)
+				new Node(dependency, 'groupId', 'org.springframework.xd')
+				new Node(dependency, 'artifactId', 'spring-xd-dirt')
+				new Node(dependency, 'version', project.version)
+				new Node(dependency, 'scope', 'provided')
+				def exclusions
+				def exclusion
+				exclusions = new Node(dependency, 'exclusions', null)
+				exclusion = new Node(exclusions, 'exclusion', null)
+				new Node(exclusion, 'groupId', 'org.springframework.xd')
+				new Node(exclusion, 'artifactId', 'spring-xd-hadoop')
+				exclusion = new Node(exclusions, 'exclusion', null)
+				new Node(exclusion, 'groupId', 'org.springframework.xd')
+				new Node(exclusion, 'artifactId', 'spring-xd-spark-streaming')
+
+				dependency = new Node(dependencies, 'dependency', null)
+				new Node(dependency, 'groupId', 'org.springframework.xd')
+				new Node(dependency, 'artifactId', 'spring-xd-test')
+				new Node(dependency, 'version', project.version)
+				new Node(dependency, 'scope', 'test')
+				exclusions = new Node(dependency, 'exclusions', null)
+				exclusion = new Node(exclusions, 'exclusion', null)
+				new Node(exclusion, 'groupId', 'org.springframework.xd')
+				new Node(exclusion, 'artifactId', 'spring-xd-hadoop')
+				exclusion = new Node(exclusions, 'exclusion', null)
+				new Node(exclusion, 'groupId', 'org.springframework.xd.data')
+				new Node(exclusion, 'artifactId', 'spring-data-hadoop-test')
+				exclusion = new Node(exclusions, 'exclusion', null)
+				new Node(exclusion, 'groupId', 'org.springframework.xd.data')
+				new Node(exclusion, 'artifactId', 'spring-data-hadoop')
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
* Upgraded to gradle 2.2 (There is an issue with the boot gradle plugin and 2.3 - https://github.com/spring-projects/spring-boot/issues/2679)
* Ported maven pom publishing to use maven-publish plugin
* Aliased publishPomToLocalMavenRepo -> install for backward compatibility. This required removing 'propdeps-maven' plugin which doesn't appear to do anything useful for spring-xd anyway, and includes the replaced 'maven' plugin.
* Removed dependencyManagement from spring-xd-*.pom since it is not needed and basically duplicates every dependency
* Added dependencyManagement to spring-xd-module-parent.pom - since module projects can use this to ensure consistent versions
* Moved developer info to a global property in build.gradle to make it more visible and reusable
* Removed unnecessary setting $XD_HOME from mvn and gradle test configuration for custom modules
* Tested spring-xd-samples with new spring-xd-module-parent.pom and spring-xd-gradle plugin. The built module jars appear to be identical.

NOTE that the generated pom files require manual validation. I visually compared several poms and carefully inspected spring-xd-dirt and spring-xd-module-parent to verify dependency scope, exclusions, etc. 