### PR TITLE
[Sprint: 49] XD-3030 Integrate RabbitMQ queue cleaning API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -906,6 +906,7 @@ project('spring-xd-rest-client') {
 		compile "org.codehaus.jackson:jackson-core-asl"
 		compile "joda-time:joda-time"
 		compile "org.apache.httpcomponents:httpclient"
+		testRuntime "javax.servlet:javax.servlet-api:3.1.0"
 	}
 }
 

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/ResourceOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/ResourceOperations.java
@@ -50,4 +50,10 @@ public interface ResourceOperations {
 	 */
 	public void destroyAll();
 
+	/**
+	 * Delete Queues and DLQs for a stream, and any exchanges created for taps.
+	 */
+	public void cleanBusResources(String name);
+
+
 }

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractMetricTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractMetricTemplate.java
@@ -1,0 +1,25 @@
+package org.springframework.xd.rest.client.impl;
+
+import org.springframework.hateoas.PagedResources;
+import org.springframework.xd.rest.domain.metrics.MetricResource;
+
+
+abstract class AbstractMetricTemplate extends AbstractTemplate {
+
+	private final String resourcesKey;
+
+	public AbstractMetricTemplate(AbstractTemplate other, String resourcesKey) {
+		super(other);
+		this.resourcesKey = resourcesKey;
+	}
+
+	public PagedResources<MetricResource> list() {
+		String url = resources.get(this.resourcesKey).toString() + "?size=10000";
+		return restTemplate.getForObject(url, MetricResource.Page.class);
+	}
+
+	public void delete(String name) {
+		String url = resources.get(this.resourcesKey).toString() + "/{name}";
+		restTemplate.delete(url, name);
+	}
+}

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractResourceTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractResourceTemplate.java
@@ -1,0 +1,90 @@
+package org.springframework.xd.rest.client.impl;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.xd.rest.client.ResourceOperations;
+import org.springframework.xd.rest.domain.support.DeploymentPropertiesFormat;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+
+abstract class AbstractResourceTemplate extends AbstractTemplate implements ResourceOperations {
+
+    private final String adminUri;
+
+    private final String password;
+
+    private final String resourceType;
+
+    private final String username;
+
+    private final String vhost;
+
+    public AbstractResourceTemplate(AbstractTemplate other, String adminUri, String password, String resourceType,
+                                    String username, String vhost) {
+        super(other);
+        this.adminUri = adminUri;
+        this.password = password;
+        this.resourceType = resourceType;
+        this.username = username;
+        this.vhost = vhost;
+    }
+
+    public void destroy(String name) {
+        // TODO: discover link by some other means (search by exact name on
+        // resources??)
+        String uriTemplate = resources.get(this.resourceType + "/definitions").toString() + "/{name}";
+        restTemplate.delete(uriTemplate, Collections.singletonMap("name", name));
+    }
+
+    public void deploy(String name, Map<String, String> properties) {
+        // TODO: discover link by some other means (search by exact name on
+        // resources??)
+        String uriTemplate = resources.get(this.resourceType + "/deployments").toString() + "/{name}";
+        MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
+        values.add("properties", DeploymentPropertiesFormat.formatDeploymentProperties(properties));
+        //TODO: Do we need ResourceDeploymentResource?
+        restTemplate.postForObject(uriTemplate, values, Object.class, name);
+    }
+
+    public void undeploy(String name) {
+        // TODO: discover link by some other means (search by exact name on
+        // /resources??)
+        String uriTemplate = resources.get(this.resourceType + "/deployments").toString() + "/{name}";
+        restTemplate.delete(uriTemplate, name);
+    }
+
+    public void undeployAll() {
+        restTemplate.delete(resources.get(this.resourceType + "/deployments").expand());
+    }
+
+    public void destroyAll() {
+        restTemplate.delete(resources.get(this.resourceType + "/definitions").expand());
+    }
+
+    public void cleanBusResources(String name) {
+        String rootUri = resources.get(this.resourceType + "/clean/rabbit").toString() + "/{name}";
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(rootUri);
+
+        if (this.adminUri != null) {
+            builder.queryParam("adminUri", this.adminUri);
+        }
+
+        if (this.password != null) {
+            builder.queryParam("pw", this.password);
+        }
+
+        if (this.username != null) {
+            builder.queryParam("user", this.username);
+        }
+
+        if (this.vhost != null) {
+            builder.queryParam("vhost", this.vhost);
+        }
+
+        URI uri = builder.buildAndExpand(Collections.singletonMap("name", name)).toUri();
+        restTemplate.delete(uri);
+    }
+}

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractSingleMetricTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractSingleMetricTemplate.java
@@ -1,0 +1,21 @@
+package org.springframework.xd.rest.client.impl;
+
+import org.springframework.xd.rest.domain.metrics.MetricResource;
+
+abstract class AbstractSingleMetricTemplate<T extends MetricResource> extends AbstractMetricTemplate {
+
+    private final String resourcesKey;
+
+    private final Class<T> resourceType;
+
+    public AbstractSingleMetricTemplate(AbstractTemplate other, String resourcesKey, Class<T> resourceType) {
+        super(other, resourcesKey);
+        this.resourcesKey = resourcesKey;
+        this.resourceType = resourceType;
+    }
+
+    public T retrieve(String name) {
+        String url = resources.get(this.resourcesKey).toString() + "/{name}";
+        return restTemplate.getForObject(url, this.resourceType, name);
+    }
+}

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AggregateCounterTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AggregateCounterTemplate.java
@@ -16,26 +16,23 @@
 
 package org.springframework.xd.rest.client.impl;
 
-import java.util.Date;
-
 import org.joda.time.DateTime;
-
-import org.springframework.hateoas.PagedResources;
 import org.springframework.util.Assert;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.xd.rest.client.AggregateCounterOperations;
 import org.springframework.xd.rest.domain.metrics.AggregateCountsResource;
-import org.springframework.xd.rest.domain.metrics.MetricResource;
+
+import java.util.Date;
 
 /**
  * Implementation of the Aggregate Counter part of the metrics API.
  * 
  * @author Ilayaperumal Gopinathan
  */
-public class AggregateCounterTemplate extends AbstractTemplate implements AggregateCounterOperations {
+public class AggregateCounterTemplate extends AbstractMetricTemplate implements AggregateCounterOperations {
 
 	public AggregateCounterTemplate(AbstractTemplate abstractTemplate) {
-		super(abstractTemplate);
+		super(abstractTemplate, "aggregate-counters");
 	}
 
 	@Override
@@ -48,18 +45,6 @@ public class AggregateCounterTemplate extends AbstractTemplate implements Aggreg
 		String uriString = UriComponentsBuilder.fromUriString(url).queryParam("resolution", resolution.toString())
 				.queryParam("from", fromParam).queryParam("to", toParam).build().toUriString();
 		return restTemplate.getForObject(uriString, AggregateCountsResource.class, name);
-	}
-
-	@Override
-	public PagedResources<MetricResource> list() {
-		String url = resources.get("aggregate-counters").toString() + "?size=10000";
-		return restTemplate.getForObject(url, MetricResource.Page.class);
-	}
-
-	@Override
-	public void delete(String name) {
-		String url = resources.get("aggregate-counters").toString() + "/{name}";
-		restTemplate.delete(url, name);
 	}
 
 }

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/CounterTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/CounterTemplate.java
@@ -16,38 +16,18 @@
 
 package org.springframework.xd.rest.client.impl;
 
-import org.springframework.hateoas.PagedResources;
 import org.springframework.xd.rest.client.CounterOperations;
 import org.springframework.xd.rest.domain.metrics.CounterResource;
-import org.springframework.xd.rest.domain.metrics.MetricResource;
 
 /**
  * Implements the {@link CounterOperations} part of the API.
- * 
+ *
  * @author Eric Bottard
  */
-public class CounterTemplate extends AbstractTemplate implements CounterOperations {
+public class CounterTemplate extends AbstractSingleMetricTemplate<CounterResource> implements CounterOperations {
 
-	public CounterTemplate(AbstractTemplate abstractTemplate) {
-		super(abstractTemplate);
-	}
-
-	@Override
-	public CounterResource retrieve(String name) {
-		String url = resources.get("counters").toString() + "/{name}";
-		return restTemplate.getForObject(url, CounterResource.class, name);
-	}
-
-	@Override
-	public PagedResources<MetricResource> list() {
-		String url = resources.get("counters").toString() + "?size=10000";
-		return restTemplate.getForObject(url, MetricResource.Page.class);
-	}
-
-	@Override
-	public void delete(String name) {
-		String url = resources.get("counters").toString() + "/{name}";
-		restTemplate.delete(url, name);
-	}
+    public CounterTemplate(AbstractTemplate abstractTemplate) {
+        super(abstractTemplate, "counters", CounterResource.class);
+    }
 
 }

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/FieldValueCounterTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/FieldValueCounterTemplate.java
@@ -16,38 +16,19 @@
 
 package org.springframework.xd.rest.client.impl;
 
-import org.springframework.hateoas.PagedResources;
 import org.springframework.xd.rest.client.FieldValueCounterOperations;
 import org.springframework.xd.rest.domain.metrics.FieldValueCounterResource;
-import org.springframework.xd.rest.domain.metrics.MetricResource;
 
 /**
  * Implementation of the Field Value Counter part of the metrics API.
- * 
+ *
  * @author Eric Bottard
  */
-public class FieldValueCounterTemplate extends AbstractTemplate implements FieldValueCounterOperations {
+public class FieldValueCounterTemplate extends AbstractSingleMetricTemplate<FieldValueCounterResource>
+        implements FieldValueCounterOperations {
 
-	public FieldValueCounterTemplate(AbstractTemplate abstractTemplate) {
-		super(abstractTemplate);
-	}
-
-	@Override
-	public FieldValueCounterResource retrieve(String name) {
-		String url = resources.get("field-value-counters").toString() + "/{name}";
-		return restTemplate.getForObject(url, FieldValueCounterResource.class, name);
-	}
-
-	@Override
-	public PagedResources<MetricResource> list() {
-		String url = resources.get("field-value-counters").toString() + "?page=10000";
-		return restTemplate.getForObject(url, MetricResource.Page.class);
-	}
-
-	@Override
-	public void delete(String name) {
-		String url = resources.get("field-value-counters").toString() + "/{name}";
-		restTemplate.delete(url, name);
-	}
+    public FieldValueCounterTemplate(AbstractTemplate abstractTemplate) {
+        super(abstractTemplate, "field-value-counters", FieldValueCounterResource.class);
+    }
 
 }

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/GaugeTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/GaugeTemplate.java
@@ -16,38 +16,18 @@
 
 package org.springframework.xd.rest.client.impl;
 
-import org.springframework.hateoas.PagedResources;
 import org.springframework.xd.rest.client.GaugeOperations;
 import org.springframework.xd.rest.domain.metrics.GaugeResource;
-import org.springframework.xd.rest.domain.metrics.MetricResource;
 
 /**
  * Implementation of the Gauge part of the metrics API.
  * 
  * @author Ilayaperumal Gopinathan
  */
-public class GaugeTemplate extends AbstractTemplate implements GaugeOperations {
+public class GaugeTemplate extends AbstractSingleMetricTemplate<GaugeResource> implements GaugeOperations {
 
 	public GaugeTemplate(AbstractTemplate abstractTemplate) {
-		super(abstractTemplate);
-	}
-
-	@Override
-	public GaugeResource retrieve(String name) {
-		String url = resources.get("gauges").toString() + "/{name}";
-		return restTemplate.getForObject(url, GaugeResource.class, name);
-	}
-
-	@Override
-	public PagedResources<MetricResource> list() {
-		String url = resources.get("gauges").toString() + "?page=10000";
-		return restTemplate.getForObject(url, MetricResource.Page.class);
-	}
-
-	@Override
-	public void delete(String name) {
-		String url = resources.get("gauges").toString() + "/{name}";
-		restTemplate.delete(url, name);
+		super(abstractTemplate, "gauges", GaugeResource.class);
 	}
 
 }

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/JobTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/JobTemplate.java
@@ -16,11 +16,6 @@
 
 package org.springframework.xd.rest.client.impl;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.xd.rest.client.JobOperations;
@@ -29,7 +24,9 @@ import org.springframework.xd.rest.domain.JobExecutionInfoResource;
 import org.springframework.xd.rest.domain.JobInstanceInfoResource;
 import org.springframework.xd.rest.domain.StepExecutionInfoResource;
 import org.springframework.xd.rest.domain.StepExecutionProgressInfoResource;
-import org.springframework.xd.rest.domain.support.DeploymentPropertiesFormat;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Implementation of the Job-related part of the API.
@@ -39,10 +36,10 @@ import org.springframework.xd.rest.domain.support.DeploymentPropertiesFormat;
  * @author Gunnar Hillert
  * @author Eric Bottard
  */
-public class JobTemplate extends AbstractTemplate implements JobOperations {
+public class JobTemplate extends AbstractResourceTemplate implements JobOperations {
 
-	JobTemplate(AbstractTemplate source) {
-		super(source);
+	JobTemplate(AbstractTemplate source, String adminUri, String password, String username, String vhost) {
+		super(source, adminUri, password, "jobs", username, vhost);
 	}
 
 	@Override
@@ -56,21 +53,6 @@ public class JobTemplate extends AbstractTemplate implements JobOperations {
 		JobDefinitionResource job = restTemplate.postForObject(resources.get("jobs/definitions").expand(), values,
 				JobDefinitionResource.class);
 		return job;
-	}
-
-	@Override
-	public void destroy(String name) {
-		String uriTemplate = resources.get("jobs/definitions").toString() + "/{name}";
-		restTemplate.delete(uriTemplate, Collections.singletonMap("name", name));
-	}
-
-	@Override
-	public void deploy(String name, Map<String, String> properties) {
-		String uriTemplate = resources.get("jobs/deployments").toString() + "/{name}";
-		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
-		values.add("properties", DeploymentPropertiesFormat.formatDeploymentProperties(properties));
-		//TODO: Do we need JobDeploymentResource?
-		restTemplate.postForObject(uriTemplate, values, Object.class, name);
 	}
 
 	@Override
@@ -109,27 +91,11 @@ public class JobTemplate extends AbstractTemplate implements JobOperations {
 	}
 
 	@Override
-	public void undeploy(String name) {
-		String uriTemplate = resources.get("jobs/deployments").toString() + "/{name}";
-		restTemplate.delete(uriTemplate, name);
-	}
-
-	@Override
 	public JobDefinitionResource.Page list() {
 		String uriTemplate = resources.get("jobs/definitions").toString();
 		// TODO handle pagination at the client side
 		uriTemplate = uriTemplate + "?size=10000&deployments=true";
 		return restTemplate.getForObject(uriTemplate, JobDefinitionResource.Page.class);
-	}
-
-	@Override
-	public void undeployAll() {
-		restTemplate.delete(resources.get("jobs/deployments").expand());
-	}
-
-	@Override
-	public void destroyAll() {
-		restTemplate.delete(resources.get("jobs/definitions").expand());
 	}
 
 	@Override

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/RichGaugeTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/RichGaugeTemplate.java
@@ -16,9 +16,7 @@
 
 package org.springframework.xd.rest.client.impl;
 
-import org.springframework.hateoas.PagedResources;
 import org.springframework.xd.rest.client.RichGaugeOperations;
-import org.springframework.xd.rest.domain.metrics.MetricResource;
 import org.springframework.xd.rest.domain.metrics.RichGaugeResource;
 
 /**
@@ -26,28 +24,10 @@ import org.springframework.xd.rest.domain.metrics.RichGaugeResource;
  * 
  * @author Ilayaperumal Gopinathan
  */
-public class RichGaugeTemplate extends AbstractTemplate implements RichGaugeOperations {
+public class RichGaugeTemplate extends AbstractSingleMetricTemplate<RichGaugeResource> implements RichGaugeOperations {
 
 	public RichGaugeTemplate(AbstractTemplate abstractTemplate) {
-		super(abstractTemplate);
-	}
-
-	@Override
-	public RichGaugeResource retrieve(String name) {
-		String url = resources.get("rich-gauges").toString() + "/{name}";
-		return restTemplate.getForObject(url, RichGaugeResource.class, name);
-	}
-
-	@Override
-	public PagedResources<MetricResource> list() {
-		String url = resources.get("rich-gauges").toString() + "?page=10000";
-		return restTemplate.getForObject(url, MetricResource.Page.class);
-	}
-
-	@Override
-	public void delete(String name) {
-		String url = resources.get("rich-gauges").toString() + "/{name}";
-		restTemplate.delete(url, name);
+		super(abstractTemplate, "rich-gauges", RichGaugeResource.class);
 	}
 
 }

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/StreamTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/StreamTemplate.java
@@ -16,14 +16,10 @@
 
 package org.springframework.xd.rest.client.impl;
 
-import java.util.Collections;
-import java.util.Map;
-
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.xd.rest.client.StreamOperations;
 import org.springframework.xd.rest.domain.StreamDefinitionResource;
-import org.springframework.xd.rest.domain.support.DeploymentPropertiesFormat;
 
 /**
  * Implementation of the Stream-related part of the API.
@@ -31,10 +27,10 @@ import org.springframework.xd.rest.domain.support.DeploymentPropertiesFormat;
  * @author Eric Bottard
  * @author Ilayaperumal Gopinathan
  */
-public class StreamTemplate extends AbstractTemplate implements StreamOperations {
+public class StreamTemplate extends AbstractResourceTemplate implements StreamOperations {
 
-	StreamTemplate(AbstractTemplate source) {
-		super(source);
+	StreamTemplate(AbstractTemplate source, String adminUri, String password, String username, String vhost) {
+		super(source, adminUri, password, "streams", username, vhost);
 	}
 
 	@Override
@@ -51,48 +47,10 @@ public class StreamTemplate extends AbstractTemplate implements StreamOperations
 	}
 
 	@Override
-	public void destroy(String name) {
-		// TODO: discover link by some other means (search by exact name on
-		// /streams??)
-		String uriTemplate = resources.get("streams/definitions").toString() + "/{name}";
-		restTemplate.delete(uriTemplate, Collections.singletonMap("name", name));
-	}
-
-	@Override
-	public void deploy(String name, Map<String, String> properties) {
-		// TODO: discover link by some other means (search by exact name on
-		// /streams??)
-		String uriTemplate = resources.get("streams/deployments").toString() + "/{name}";
-		MultiValueMap<String, Object> values = new LinkedMultiValueMap<String, Object>();
-		values.add("properties", DeploymentPropertiesFormat.formatDeploymentProperties(properties));
-		//TODO: Do we need StreamDeploymentResource?
-		restTemplate.postForObject(uriTemplate, values, Object.class, name);
-	}
-
-	@Override
-	public void undeploy(String name) {
-		// TODO: discover link by some other means (search by exact name on
-		// /streams??)
-		String uriTemplate = resources.get("streams/deployments").toString() + "/{name}";
-		restTemplate.delete(uriTemplate, name);
-
-	}
-
-	@Override
 	public StreamDefinitionResource.Page list() {
 		String uriTemplate = resources.get("streams/definitions").toString();
 		uriTemplate = uriTemplate + "?size=10000";
 		return restTemplate.getForObject(uriTemplate, StreamDefinitionResource.Page.class);
-	}
-
-	@Override
-	public void undeployAll() {
-		restTemplate.delete(resources.get("streams/deployments").expand());
-	}
-
-	@Override
-	public void destroyAll() {
-		restTemplate.delete(resources.get("streams/definitions").expand());
 	}
 
 }

--- a/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/JobTemplateTest.java
+++ b/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/JobTemplateTest.java
@@ -1,0 +1,52 @@
+package org.springframework.xd.rest.client.impl;
+
+import org.junit.Test;
+import org.springframework.hateoas.UriTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.client.MockMvcClientHttpRequestFactory;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+public final class JobTemplateTest {
+	private final JobTemplate jobTemplate;
+
+	private final MockRestServiceServer mockServer;
+
+	public JobTemplateTest() {
+		MockMvc mockMvc = standaloneSetup(StubController.class).build();
+		ClientHttpRequestFactory clientHttpRequestFactory = new MockMvcClientHttpRequestFactory(mockMvc);
+		AbstractTemplate abstractTemplate = new AbstractTemplate(clientHttpRequestFactory);
+		abstractTemplate.resources.put("jobs/clean/rabbit", new UriTemplate("/jobs/clean/rabbit"));
+
+		this.jobTemplate = new JobTemplate(abstractTemplate, "test-admin-uri", "test-password", "test-username",
+				"test-vhost");
+		this.mockServer = MockRestServiceServer.createServer(this.jobTemplate.restTemplate);
+	}
+
+	@Test
+	public void deleteQueue() {
+		this.mockServer
+				.expect(requestTo("/jobs/clean/rabbit/test-queue-name?adminUri=test-admin-uri&pw=test-password&user=test-username&vhost=test-vhost"))
+				.andExpect(method(HttpMethod.DELETE))
+				.andRespond(withStatus(HttpStatus.OK));
+
+		this.jobTemplate.cleanBusResources("test-queue-name");
+
+		this.mockServer.verify();
+	}
+
+	@Controller
+	private static final class StubController {
+	}
+
+}

--- a/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/StreamTemplateTest.java
+++ b/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/StreamTemplateTest.java
@@ -1,0 +1,53 @@
+package org.springframework.xd.rest.client.impl;
+
+import org.junit.Test;
+import org.springframework.hateoas.UriTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.client.MockMvcClientHttpRequestFactory;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+public final class StreamTemplateTest {
+
+	private final StreamTemplate streamTemplate;
+
+	private final MockRestServiceServer mockServer;
+
+	public StreamTemplateTest() {
+		MockMvc mockMvc = standaloneSetup(StubController.class).build();
+		ClientHttpRequestFactory clientHttpRequestFactory = new MockMvcClientHttpRequestFactory(mockMvc);
+		AbstractTemplate abstractTemplate = new AbstractTemplate(clientHttpRequestFactory);
+		abstractTemplate.resources.put("streams/clean/rabbit", new UriTemplate("/streams/clean/rabbit"));
+
+		this.streamTemplate = new StreamTemplate(abstractTemplate, "test-admin-uri", "test-password", "test-username",
+				"test-vhost");
+		this.mockServer = MockRestServiceServer.createServer(this.streamTemplate.restTemplate);
+	}
+
+	@Test
+	public void deleteQueue() {
+		this.mockServer
+				.expect(requestTo("/streams/clean/rabbit/test-queue-name?adminUri=test-admin-uri&pw=test-password&user=test-username&vhost=test-vhost"))
+				.andExpect(method(HttpMethod.DELETE))
+				.andRespond(withStatus(HttpStatus.OK));
+
+		this.streamTemplate.cleanBusResources("test-queue-name");
+
+		this.mockServer.verify();
+	}
+
+	@Controller
+	private static final class StubController {
+	}
+
+}


### PR DESCRIPTION
Previously Spring XD required the user to access a stand-alone REST API to delete RabbitMQ queues that had been created by Spring XD. This change adds support for the API call to SpringXDTemplate.