### PR TITLE
[Sprint: 49] XD-3050 Add Reactor Stream support into Spring XD proper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ ext {
 			'spring-xd-analytics',
 			'spring-xd-analytics-ml',
 			'spring-xd-rxjava',
+			'spring-xd-reactor',
 			'spring-xd-tuple',
 			'spring-xd-module',
 			'spring-xd-rest-client',
@@ -378,6 +379,15 @@ project('spring-xd-rxjava') {
 	description = 'Spring XD RxJava'
 	dependencies {
 		compile "io.reactivex:rxjava"
+		compile "org.springframework.integration:spring-integration-core"
+		compile "org.springframework:spring-expression"
+	}
+}
+
+project('spring-xd-reactor') {
+	description = 'Spring XD Reactor'
+	dependencies {
+		compile "io.projectreactor:reactor-stream"
 		compile "org.springframework.integration:spring-integration-core"
 		compile "org.springframework:spring-expression"
 	}

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ include 'spring-xd-analytics'
 include 'spring-xd-analytics-ml'
 
 include 'spring-xd-rxjava'
+include 'spring-xd-reactor'
 
 include 'spring-xd-messagebus-spi'
 include 'spring-xd-messagebus-local'

--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/BroadcasterMessageHandler.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/BroadcasterMessageHandler.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.reactor;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.ResolvableType;
+import org.springframework.integration.handler.AbstractMessageProducingHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+import reactor.Environment;
+import reactor.fn.Consumer;
+import reactor.rx.Stream;
+import reactor.rx.action.Control;
+import reactor.rx.broadcast.Broadcaster;
+import reactor.rx.broadcast.SerializedBroadcaster;
+
+import java.lang.reflect.Method;
+
+/**
+ * Adapts the item at a time delivery of a {@link org.springframework.messaging.MessageHandler}
+ * by delegating processing to a {@link Stream}
+ * <p/>
+ * The outputStream of the processor is used to create a message and send it to the output channel. If the
+ * input channel and output channel are connected to the MessageBus, then data delivered to the input stream via
+ * a call to onNext is invoked on the dispatcher thread of the message bus and sending a message to the output
+ * channel will involve IO operations on the message bus.
+ * <p/>
+ * The implementation uses a {@link reactor.rx.broadcast.SerializedBroadcaster} with synchronous dispatch.
+ * This has the advantage that the state of the Stream can be shared across all the incoming dispatcher threads that
+ * are invoking onNext. It has the disadvantage that processing and sending to the output channel will execute serially
+ * on one of the dispatcher threads.
+ * <p/>
+ * The use of this handler makes for a very natural first experience when processing data. For example given
+ * the stream <code></code>http | reactor-processor | log</code> where the <code>reactor-processor</code> does does a
+ * <code>buffer(5)</code> and then produces a single value. Sending 10 messages to the http source will
+ * result in 2 messages in the log, no matter how many dispatcher threads are used.
+ * <p/>
+ * You can modify what thread the outputStream subscriber, which does the send to the output channel,
+ * will use by explicitly calling <code>observeOn</code> before returning the outputStream from your processor.
+ * <p/>
+ * Use {@link org.springframework.xd.reactor.MultipleBroadcasterMessageHandler} for concurrent execution on dispatcher
+ * threads spread across across multiple Observables.
+ * <p/>
+ * All error handling is the responsibility of the processor implementation.
+ *
+ * @author Mark Pollack
+ */
+public class BroadcasterMessageHandler extends AbstractMessageProducingHandler {
+
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    private final Broadcaster<Object> stream;
+
+    @SuppressWarnings("rawtypes")
+    private final Processor reactorProcessor;
+
+    private final ResolvableType inputType;
+
+    private final Control control;
+
+    /**
+     * Construct a new BroadcasterMessageHandler given the reactor based Processor to delegate
+     * processing to.
+     *
+     * @param processor The stream based reactor processor
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public BroadcasterMessageHandler(Processor processor) {
+        Assert.notNull(processor, "processor cannot be null.");
+        this.reactorProcessor = processor;
+        Environment.initializeIfEmpty(); // This by default uses SynchronousDispatcher
+        Method method = ReflectionUtils.findMethod(this.reactorProcessor.getClass(), "process", Stream.class);
+        this.inputType = ResolvableType.forMethodParameter(method, 0).getNested(2);
+
+        //Stream with a SynchronousDispatcher as this handler is called by Message Listener managed threads
+        this.stream = SerializedBroadcaster.create();
+
+        //user defined stream processing
+        Stream<?> outputStream = processor.process(stream);
+
+        //Simple log error handling
+        outputStream.when(Throwable.class, new Consumer<Throwable>() {
+            @Override
+            public void accept(Throwable throwable) {
+                logger.error(throwable);
+            }
+        });
+
+        this.control = outputStream.consume(new Consumer<Object>() {
+            @Override
+            public void accept(Object outputObject) {
+                if (ClassUtils.isAssignable(Message.class, outputObject.getClass())) {
+                    getOutputChannel().send((Message) outputObject);
+                } else {
+                    getOutputChannel().send(MessageBuilder.withPayload(outputObject).build());
+                }
+            }
+        });
+
+        if (logger.isDebugEnabled()) {
+            logger.debug(control.debug());
+        }
+
+    }
+
+    @Override
+    protected void handleMessageInternal(Message<?> message) throws Exception {
+
+        if (ClassUtils.isAssignable(inputType.getRawClass(), message.getClass())) {
+            stream.onNext(message);
+        } else if (ClassUtils.isAssignable(inputType.getRawClass(), message.getPayload().getClass())) {
+            //TODO handle type conversion of payload to input type if possible
+            stream.onNext(message.getPayload());
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug(control.debug());
+        }
+    }
+
+}

--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandler.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandler.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.reactor;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.core.ResolvableType;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.integration.expression.IntegrationEvaluationContextAware;
+import org.springframework.integration.handler.AbstractMessageProducingHandler;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+import reactor.Environment;
+import reactor.fn.Consumer;
+import reactor.rx.Stream;
+import reactor.rx.action.Control;
+import reactor.rx.broadcast.Broadcaster;
+import reactor.rx.broadcast.SerializedBroadcaster;
+
+import java.lang.reflect.Method;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Adapts the item at a time delivery of a {@link org.springframework.messaging.MessageHandler}
+ * by delegating processing to a Stream based on a partitionExpression.
+ * <p/>
+ * The specific Stream that the message is delegated to is determined by the partitionExpression value.
+ * Unless you change the scheduling of the inputStream in your processor, you should ensure that the
+ * partitionExpression does not map messages delivered on different message bus dispatcher threads to the same
+ * stream. This is due to the underlying use of a <code>Broadcaster</code>.
+ * <p/>
+ * For example, using the expression <code>T(java.lang.Thread).currentThread().getId()</code> would map the current
+ * dispatcher thread id to an instance of a Stream. If you wanted to have a Stream per
+ * Kafka partition, you can use the expression <code>header['kafka_partition_id']</code> since the MessageBus
+ * dispatcher thread will be the same for each partition.
+ * <p/>
+ * If the Stream mapped to the partitionExpression value has an error or completes, it will be recreated when the
+ * next message consumed maps to the same partitionExpression value.
+ * <p/>
+ * All error handling is the responsibility of the processor implementation.
+ *
+ * @author Mark Pollack
+ */
+public class MultipleBroadcasterMessageHandler extends AbstractMessageProducingHandler implements DisposableBean,
+        IntegrationEvaluationContextAware {
+
+    protected final Log logger = LogFactory.getLog(getClass());
+
+    private final ConcurrentMap<Object, Broadcaster<Object>> broadcasterMap =
+            new ConcurrentHashMap<Object, Broadcaster<Object>>();
+
+    private final Map<Object, Control> controlsMap = new Hashtable<Object, Control>();
+
+    private final Environment environment;
+
+    @SuppressWarnings("rawtypes")
+    private final Processor processor;
+
+    private final ResolvableType inputType;
+
+    private final Expression partitionExpression;
+
+    private final SpelExpressionParser spelExpressionParser = new SpelExpressionParser();
+
+    private EvaluationContext evaluationContext = new StandardEvaluationContext();
+
+    /**
+     * Construct a new SynchronousDispatcherMessageHandler given the reactor based Processor to delegate
+     * processing to.
+     *
+     * @param processor The stream based reactor processor
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public MultipleBroadcasterMessageHandler(Processor processor, String partitionExpression) {
+        Assert.notNull(processor, "processor cannot be null.");
+        Assert.notNull(partitionExpression, "Partition expression can not be null");
+        this.processor = processor;
+        this.partitionExpression = spelExpressionParser.parseExpression(partitionExpression);
+        environment = Environment.initializeIfEmpty(); // This by default uses SynchronousDispatcher
+        Method method = ReflectionUtils.findMethod(this.processor.getClass(), "process", Stream.class);
+        this.inputType = ResolvableType.forMethodParameter(method, 0).getNested(2);
+    }
+
+    @Override
+    protected void handleMessageInternal(Message<?> message) {
+        Broadcaster<Object> broadcasterToUse = getBroadcaster(message);
+        if (ClassUtils.isAssignable(inputType.getRawClass(), message.getClass())) {
+            broadcasterToUse.onNext(message);
+        } else if (ClassUtils.isAssignable(inputType.getRawClass(), message.getPayload().getClass())) {
+            broadcasterToUse.onNext(message.getPayload());
+        } else {
+            throw new MessageHandlingException(message, "Processor signature does not match [" + message.getClass()
+                    + "] or [" + message.getPayload().getClass() + "]");
+        }
+
+        if (logger.isDebugEnabled()) {
+            Object idToUse = partitionExpression.getValue(evaluationContext, message, Object.class);
+            Control controls = this.controlsMap.get(idToUse);
+            if (controls != null) {
+                logger.debug(controls.debug());
+            }
+        }
+    }
+
+
+    private Broadcaster<Object> getBroadcaster(Message<?> message) {
+        final Object idToUse = partitionExpression.getValue(evaluationContext, message, Object.class);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Partition Expression evaluated to " + idToUse);
+        }
+        Broadcaster<Object> broadcaster = broadcasterMap.get(idToUse);
+        if (broadcaster == null) {
+            Broadcaster<Object> existingBroadcaster = broadcasterMap.putIfAbsent(idToUse, SerializedBroadcaster.create());
+            if (existingBroadcaster == null) {
+                broadcaster = broadcasterMap.get(idToUse);
+                //user defined stream processing
+                Stream<?> outputStream = processor.process(broadcaster);
+
+                final Control control = outputStream.consume(new Consumer<Object>() {
+                    @Override
+                    public void accept(Object outputObject) {
+                        if (ClassUtils.isAssignable(Message.class, outputObject.getClass())) {
+                            getOutputChannel().send((Message) outputObject);
+                        } else {
+                            getOutputChannel().send(MessageBuilder.withPayload(outputObject).build());
+                        }
+                    }
+                });
+
+                outputStream.when(Throwable.class, new Consumer<Throwable>() {
+                    @Override
+                    public void accept(Throwable throwable) {
+                        logger.error(throwable);
+                        broadcasterMap.remove(idToUse);
+                    }
+                });
+
+                broadcaster.observeComplete(new Consumer<Void>() {
+                    @Override
+                    public void accept(Void aVoid) {
+                        logger.error("Consumer completed for [" + control + "]");
+                        broadcasterMap.remove(idToUse);
+                    }
+                });
+
+                controlsMap.put(idToUse, control);
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug(control.debug());
+                }
+            } else {
+                broadcaster = existingBroadcaster;
+            }
+        }
+        return broadcaster;
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        for (Control control : controlsMap.values()) {
+            control.cancel();
+        }
+        environment.shutdown();
+    }
+
+    @Override
+    public void setIntegrationEvaluationContext(EvaluationContext evaluationContext) {
+        this.evaluationContext = evaluationContext;
+    }
+}

--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/Processor.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/Processor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.reactor;
+
+import reactor.rx.Stream;
+
+/**
+ * Contract for performing stream processing using Reactor within an XD processor module
+ *
+ * @author Mark Pollack
+ */
+public interface Processor<I, O> {
+
+    /**
+     * Process a stream of messages and return an output stream.  The input
+     * and output stream will be mapped onto receive/send operations on the message bus.
+     *
+     * @param inputStream Input stream the receives messages from the message bus
+     * @return Output stream of messages sent to the message bus
+     */
+    Stream<O> process(Stream<I> inputStream);
+
+}

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractMessageHandlerTests.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractMessageHandlerTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.reactor;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Mark Pollack
+ */
+public abstract class AbstractMessageHandlerTests {
+
+	private final int numMessages = 10;
+	@Autowired
+	@Qualifier("outputChannel1")
+	PollableChannel outputChannel1;
+	@Autowired
+	@Qualifier("outputChannel2")
+	PollableChannel outputChannel2;
+	@Autowired
+	@Qualifier("toMessageHandlerChannel")
+	MessageChannel toMessageHandlerChannel;
+	@Autowired
+	@Qualifier("toStringHandlerChannel")
+	MessageChannel toStringHandlerChannel;
+
+	@Test
+	public void pojoBasedProcessor() throws IOException {
+		sendPojoMessages();
+		for (int i = 0; i < numMessages; i++) {
+			Message<?> outputMessage = outputChannel1.receive(500);
+			assertEquals("ping-pojopong", outputMessage.getPayload());
+		}
+	}
+
+	@Test
+	public void stringBasedProcessor() throws IOException {
+
+		sendStringMessages();
+		for (int i = 0; i < numMessages; i++) {
+			Message<?> outputMessage = outputChannel2.receive(500);
+			assertEquals("ping-stringpong", outputMessage.getPayload());
+		}
+	}
+
+	private void sendPojoMessages() {
+		Message<?> message = new GenericMessage<String>("ping");
+		for (int i = 0; i < numMessages; i++) {
+			toMessageHandlerChannel.send(message);
+		}
+	}
+
+	private void sendStringMessages() {
+		Message<?> message = new GenericMessage<String>("ping");
+		for (int i = 0; i < numMessages; i++) {
+			toStringHandlerChannel.send(message);
+		}
+	}
+}

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/BroadcasterMessageHandlerTests.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/BroadcasterMessageHandlerTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.reactor;
+
+import org.junit.runner.RunWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Test the {@link org.springframework.xd.reactor.MultipleBroadcasterMessageHandler} by using two types of
+ * {@link Processor}. The first is parameterized by
+ * {@link org.springframework.messaging.Message} and the second by String to test extracting payload types and
+ * wrapping return types in a Message.
+ *
+ * @author Mark Pollack
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@DirtiesContext
+public class BroadcasterMessageHandlerTests extends AbstractMessageHandlerTests {
+
+}

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandlerTests.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandlerTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.reactor;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Test the {@link MultipleBroadcasterMessageHandler} by using two types of
+ * {@link org.springframework.xd.reactor.Processor}. The first is parameterized by
+ * {@link org.springframework.messaging.Message} and the second by String to test extracting payload types and
+ * wrapping return types in a Message.
+ *
+ * @author Mark Pollack
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@DirtiesContext
+public class MultipleBroadcasterMessageHandlerTests extends AbstractMessageHandlerTests {
+
+}

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongMessageProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongMessageProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.reactor;
+
+import reactor.fn.Function;
+import reactor.rx.Stream;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+
+/**
+ * A simple stream processor that transforms messages by adding "-pong" to the payload.
+ *
+ * @author Mark Pollack
+ */
+@SuppressWarnings("rawtypes")
+public class PongMessageProcessor implements Processor<Message, Message> {
+
+    @Override
+    public Stream<Message> process(Stream<Message> inputStream) {
+        return inputStream.map(new Function<Message, Message>() {
+            @Override
+            public Message apply(Message message) {
+                return new GenericMessage<String>(message.getPayload() + "-pojopong");
+            }
+        });
+    }
+}

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongStringProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongStringProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.reactor;
+
+import reactor.fn.Function;
+import reactor.rx.Stream;
+
+/**
+ * A simple stream processor that transforms Strings by adding "-pong" to the string.
+ *
+ * @author Mark Pollack
+ */
+public class PongStringProcessor implements Processor<String, String> {
+
+    @Override
+    public Stream<String> process(Stream<String> inputStream) {
+        return inputStream.map(new Function<String, String>() {
+            @Override
+            public String apply(String message) {
+                return message + "-stringpong";
+            }
+        });
+    }
+}

--- a/spring-xd-reactor/src/test/resources/log4j.properties
+++ b/spring-xd-reactor/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootCategory=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p %t %c{2} - %m%n

--- a/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/BroadcasterMessageHandlerTests-context.xml
+++ b/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/BroadcasterMessageHandlerTests-context.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:int="http://www.springframework.org/schema/integration"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+
+    <import resource="reactor.xml"/>
+
+    <bean name="reactorMessageHandler" class="org.springframework.xd.reactor.BroadcasterMessageHandler">
+        <constructor-arg ref="messageProcessor"/>
+    </bean>
+
+    <bean name="reactorStringHandler" class="org.springframework.xd.reactor.BroadcasterMessageHandler">
+        <constructor-arg ref="stringProcessor"/>
+    </bean>
+
+
+</beans>

--- a/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/MultipleBroadcasterMessageHandlerTests-context.xml
+++ b/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/MultipleBroadcasterMessageHandlerTests-context.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:int="http://www.springframework.org/schema/integration"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+
+    <import resource="reactor.xml"/>
+
+    <bean name="reactorMessageHandler" class="org.springframework.xd.reactor.MultipleBroadcasterMessageHandler">
+        <constructor-arg ref="messageProcessor"/>
+        <constructor-arg value="T(java.lang.Thread).currentThread().getId()"/>
+    </bean>
+
+    <bean name="reactorStringHandler" class="org.springframework.xd.reactor.MultipleBroadcasterMessageHandler">
+        <constructor-arg ref="stringProcessor"/>
+        <constructor-arg value="T(java.lang.Thread).currentThread().getId()"/>
+    </bean>
+
+
+</beans>

--- a/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/reactor.xml
+++ b/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/reactor.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:int="http://www.springframework.org/schema/integration"
+       xmlns="http://www.springframework.org/schema/beans"
+       xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+
+    <int:channel id="outputChannel1">
+        <int:queue capacity="20"/>
+    </int:channel>
+
+    <int:channel id="outputChannel2">
+        <int:queue capacity="20"/>
+    </int:channel>
+
+
+    <int:channel id="toMessageHandlerChannel"/>
+
+    <int:channel id="toStringHandlerChannel"/>
+
+    <bean id="messageProcessor" class="org.springframework.xd.reactor.PongMessageProcessor"/>
+
+    <int:service-activator input-channel="toMessageHandlerChannel" ref="reactorMessageHandler"
+                           output-channel="outputChannel1"/>
+
+    <bean id="stringProcessor" class="org.springframework.xd.reactor.PongStringProcessor"/>
+
+
+    <int:service-activator input-channel="toStringHandlerChannel" ref="reactorStringHandler"
+                           output-channel="outputChannel2"/>
+
+
+</beans>


### PR DESCRIPTION
Added the contents of spring-xd-reactor from the spring-xd-modules repo into the main spring-xd project. Added the submodule to the build and `settings.gradle`. Version properties were already set to 2.0.1.RELEASE. Builds without error.