### PR TITLE
[Sprint 49] XD-3054 Validate when processing deployment message

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -89,11 +89,13 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 	@Override
 	public D save(D definition) {
 		Assert.notNull(definition, "Definition may not be null");
+		String name = definition.getName();
+		String def = definition.getDefinition();
+		validateBeforeSave(name, def);
 		if (repository.findOne(definition.getName()) != null) {
 			throwDefinitionAlreadyExistsException(definition);
 		}
-		List<ModuleDescriptor> moduleDescriptors = parser.parse(definition.getName(),
-				definition.getDefinition(), definitionKind);
+		List<ModuleDescriptor> moduleDescriptors = parser.parse(name, def, definitionKind);
 
 		// todo: the result of parse() should already have correct (polymorphic) definitions
 		List<ModuleDefinition> moduleDefinitions = createModuleDefinitions(moduleDescriptors);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -92,9 +92,6 @@ public abstract class AbstractDeployer<D extends BaseDefinition> implements Reso
 		String name = definition.getName();
 		String def = definition.getDefinition();
 		validateBeforeSave(name, def);
-		if (repository.findOne(definition.getName()) != null) {
-			throwDefinitionAlreadyExistsException(definition);
-		}
 		List<ModuleDescriptor> moduleDescriptors = parser.parse(name, def, definitionKind);
 
 		// todo: the result of parse() should already have correct (polymorphic) definitions

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractInstancePersistingDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractInstancePersistingDeployer.java
@@ -67,33 +67,15 @@ public abstract class AbstractInstancePersistingDeployer<D extends BaseDefinitio
 
 	@Override
 	public void undeploy(String name) {
-		Assert.hasText(name, "name cannot be blank or null");
 		validateBeforeUndeploy(name);
 		logger.trace("Undeploying {}", name);
-
-		D definition = getDefinitionRepository().findOne(name);
-		if (definition == null) {
-			throwNoSuchDefinitionException(name);
-		}
-
-		final I instance = instanceRepository.findOne(name);
-		if (instance == null) {
-			throwNotDeployedException(name);
-		}
-
-		instanceRepository.delete(instance);
+		instanceRepository.delete(instanceRepository.findOne(name));
 		undeployResource(name);
 	}
 
 	@Override
 	public void deploy(String name, Map<String, String> properties) {
-		Assert.hasText(name, "name cannot be blank or null");
-		Assert.notNull(properties, "properties cannot be null");
 		validateBeforeDeploy(name, properties);
-
-		if (instanceRepository.exists(name)) {
-			throwAlreadyDeployedException(name);
-		}
 
 		final D definition = basicDeploy(name, properties);
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractInstancePersistingDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractInstancePersistingDeployer.java
@@ -59,6 +59,7 @@ public abstract class AbstractInstancePersistingDeployer<D extends BaseDefinitio
 
 	@Override
 	protected void beforeDelete(D definition) {
+		validateBeforeDelete(definition.getName());
 		if (instanceRepository.exists(definition.getName())) {
 			undeploy(definition.getName());
 		}
@@ -67,6 +68,7 @@ public abstract class AbstractInstancePersistingDeployer<D extends BaseDefinitio
 	@Override
 	public void undeploy(String name) {
 		Assert.hasText(name, "name cannot be blank or null");
+		validateBeforeUndeploy(name);
 		logger.trace("Undeploying {}", name);
 
 		D definition = getDefinitionRepository().findOne(name);
@@ -85,9 +87,9 @@ public abstract class AbstractInstancePersistingDeployer<D extends BaseDefinitio
 
 	@Override
 	public void deploy(String name, Map<String, String> properties) {
-
 		Assert.hasText(name, "name cannot be blank or null");
 		Assert.notNull(properties, "properties cannot be null");
+		validateBeforeDeploy(name, properties);
 
 		if (instanceRepository.exists(name)) {
 			throwAlreadyDeployedException(name);


### PR DESCRIPTION
- Add deployment validation when the deployment message is consumed
by the deployment message consumer. Previously this check was only when
the deployment message is published.