### PR TITLE
[Sprint: 49] XD-2850 Improve file source to efficiently read files

### DIFF
--- a/modules/common/file-source-common-context.xml
+++ b/modules/common/file-source-common-context.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:file="http://www.springframework.org/schema/integration/file"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration
+		http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/integration/file
+		http://www.springframework.org/schema/integration/file/spring-integration-file.xsd">
+
+	<channel id="output" />
+
+	<channel id="files" />
+
+	<beans:bean id="trigger" class="org.springframework.scheduling.support.PeriodicTrigger">
+		<beans:constructor-arg value="${fixedDelay}" />
+		<beans:constructor-arg value="${timeUnit}" />
+		<beans:property name="initialDelay" value="${initialDelay} "/>
+	</beans:bean>
+
+	<beans:beans profile="use-ref">
+		<bridge input-channel="files" output-channel="output"/>
+	</beans:beans>
+
+	<beans:beans profile="use-contents">
+		<chain id="extractContents" input-channel="files" output-channel="output">
+			<header-enricher>
+				<header name="contentType" value="application/octet-stream"/>
+			</header-enricher>
+			<file:file-to-bytes-transformer />
+		</chain>
+	</beans:beans>
+
+	<beans:beans profile="use-contents-with-split">
+		<chain id="extractContentsAndSplit" input-channel="files" output-channel="output">
+			<header-enricher>
+				<header name="contentType" value="text/plain"/>
+				<header name="file_name"   expression="payload.name"/>
+			</header-enricher>
+			<splitter>
+				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter">
+					<beans:constructor-arg value="false"/>
+				</beans:bean>
+			</splitter>
+		</chain>
+	</beans:beans>
+
+</beans:beans>

--- a/modules/common/file-source-common-context.xml
+++ b/modules/common/file-source-common-context.xml
@@ -40,9 +40,7 @@
 				<header name="file_name"   expression="payload.name"/>
 			</header-enricher>
 			<splitter>
-				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter">
-					<beans:constructor-arg value="false"/>
-				</beans:bean>
+				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter"/>
 			</splitter>
 		</chain>
 	</beans:beans>

--- a/modules/processor/script/config/script.xml
+++ b/modules/processor/script/config/script.xml
@@ -10,7 +10,7 @@
 		http://www.springframework.org/schema/integration/groovy
 		http://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd">
 
-    <beans:import resource="../../../common/script-variable-generator.xml"/>
+	<beans:import resource="../../../common/script-variable-generator.xml"/>
 
 	<channel id="input" />
 

--- a/modules/source/file/config/file.xml
+++ b/modules/source/file/config/file.xml
@@ -39,7 +39,20 @@
 			</header-enricher>
 			<file:file-to-bytes-transformer />
 		</chain>
+	</beans:beans>
 
+	<beans:beans profile="use-contents-with-split">
+		<chain id="extractContentsAndSplit" input-channel="files" output-channel="output">
+			<header-enricher>
+				<header name="contentType" value="text/plain"/>
+				<header name="file_name"   expression="payload.name"/>
+			</header-enricher>
+			<splitter>
+				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter">
+					<beans:constructor-arg value="false"/>
+				</beans:bean>
+			</splitter>
+		</chain>
 	</beans:beans>
 
 </beans:beans>

--- a/modules/source/file/config/file.xml
+++ b/modules/source/file/config/file.xml
@@ -18,41 +18,6 @@
 		<poller trigger="trigger" />
 	</file:inbound-channel-adapter>
 
-	<channel id="output"/>
-
-	<channel id="files" />
-
-	<beans:bean id="trigger" class="org.springframework.scheduling.support.PeriodicTrigger">
-		<beans:constructor-arg value="${fixedDelay}" />
-		<beans:constructor-arg value="${timeUnit}" />
-		<beans:property name="initialDelay" value="${initialDelay} "/>
-	</beans:bean>
-
-	<beans:beans profile="use-ref">
-		<bridge input-channel="files" output-channel="output"/>
-	</beans:beans>
-
-	<beans:beans profile="use-contents">
-		<chain id="extractContents" input-channel="files" output-channel="output">
-			<header-enricher>
-				<header name="contentType" value="application/octet-stream"/>
-			</header-enricher>
-			<file:file-to-bytes-transformer />
-		</chain>
-	</beans:beans>
-
-	<beans:beans profile="use-contents-with-split">
-		<chain id="extractContentsAndSplit" input-channel="files" output-channel="output">
-			<header-enricher>
-				<header name="contentType" value="text/plain"/>
-				<header name="file_name"   expression="payload.name"/>
-			</header-enricher>
-			<splitter>
-				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter">
-					<beans:constructor-arg value="false"/>
-				</beans:bean>
-			</splitter>
-		</chain>
-	</beans:beans>
+	<beans:import resource="../../../common/file-source-common-context.xml"/>
 
 </beans:beans>

--- a/modules/source/ftp/config/ftp.xml
+++ b/modules/source/ftp/config/ftp.xml
@@ -16,10 +16,10 @@
 
 	<beans:bean id="ftpSessionFactory" class="org.springframework.integration.ftp.session.DefaultFtpSessionFactory">
 		<beans:property name="host" value="${host}" />
-        	<beans:property name="port" value="${port}" />
-        	<beans:property name="username" value="${username:#{null}}"/>
-        	<beans:property name="password" value="${password:#{null}}"/>
-        	<beans:property name="clientMode" value="${clientMode}"/>
+			<beans:property name="port" value="${port}" />
+			<beans:property name="username" value="${username:#{null}}"/>
+			<beans:property name="password" value="${password:#{null}}"/>
+			<beans:property name="clientMode" value="${clientMode}"/>
 	</beans:bean>
 
 	<int-ftp:inbound-channel-adapter auto-startup="false" channel="files" session-factory="ftpSessionFactory"
@@ -30,42 +30,7 @@
 		<poller trigger="trigger" />
 	</int-ftp:inbound-channel-adapter>
 
-	<beans:bean id="trigger" class="org.springframework.scheduling.support.PeriodicTrigger">
-		<beans:constructor-arg value="${fixedDelay}" />
-		<beans:constructor-arg value="${timeUnit}" />
-		<beans:property name="initialDelay" value="${initialDelay} "/>
-	</beans:bean>
-
-	<channel id="output" />
-
-	<channel id="files" />
-
-	<beans:beans profile="use-ref">
-		<bridge input-channel="files" output-channel="output"/>
-	</beans:beans>
-
-	<beans:beans profile="use-contents">
-		<chain id="extractContents" input-channel="files" output-channel="output">
-			<header-enricher>
-				<header name="contentType" value="application/octet-stream"/>
-			</header-enricher>
-			<file:file-to-bytes-transformer />
-		</chain>
-	</beans:beans>
-
-	<beans:beans profile="use-contents-with-split">
-		<chain id="extractContentsAndSplit" input-channel="files" output-channel="output">
-			<header-enricher>
-				<header name="contentType" value="text/plain"/>
-				<header name="file_name"   expression="payload.name"/>
-			</header-enricher>
-			<splitter>
-				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter">
-					<beans:constructor-arg value="false"/>
-				</beans:bean>
-			</splitter>
-		</chain>
-	</beans:beans>
+	<beans:import resource="../../../common/file-source-common-context.xml"/>
 
 </beans:beans>
 

--- a/modules/source/ftp/config/ftp.xml
+++ b/modules/source/ftp/config/ftp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
 	xmlns:file="http://www.springframework.org/schema/integration/file"
@@ -51,7 +51,20 @@
 			</header-enricher>
 			<file:file-to-bytes-transformer />
 		</chain>
+	</beans:beans>
 
+	<beans:beans profile="use-contents-with-split">
+		<chain id="extractContentsAndSplit" input-channel="files" output-channel="output">
+			<header-enricher>
+				<header name="contentType" value="text/plain"/>
+				<header name="file_name"   expression="payload.name"/>
+			</header-enricher>
+			<splitter>
+				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter">
+					<beans:constructor-arg value="false"/>
+				</beans:bean>
+			</splitter>
+		</chain>
 	</beans:beans>
 
 </beans:beans>

--- a/modules/source/sftp/config/sftp.xml
+++ b/modules/source/sftp/config/sftp.xml
@@ -31,42 +31,7 @@
 		<poller trigger="trigger" />
 	</int-sftp:inbound-channel-adapter>
 
-	<channel id="output" />
-
-	<channel id="files" />
-
-	<beans:bean id="trigger" class="org.springframework.scheduling.support.PeriodicTrigger">
-		<beans:constructor-arg value="${fixedDelay}" />
-		<beans:constructor-arg value="${timeUnit}" />
-		<beans:property name="initialDelay" value="${initialDelay} "/>
-	</beans:bean>
-
-	<beans:beans profile="use-ref">
-		<bridge input-channel="files" output-channel="output"/>
-	</beans:beans>
-
-	<beans:beans profile="use-contents">
-		<chain id="extractContents" input-channel="files" output-channel="output">
-			<header-enricher>
-				<header name="contentType" value="application/octet-stream"/>
-			</header-enricher>
-			<file:file-to-bytes-transformer />
-		</chain>
-	</beans:beans>
-
-	<beans:beans profile="use-contents-with-split">
-		<chain id="extractContentsAndSplit" input-channel="files" output-channel="output">
-			<header-enricher>
-				<header name="contentType" value="text/plain"/>
-				<header name="file_name"   expression="payload.name"/>
-			</header-enricher>
-			<splitter>
-				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter">
-					<beans:constructor-arg value="false"/>
-				</beans:bean>
-			</splitter>
-		</chain>
-	</beans:beans>
+	<beans:import resource="../../../common/file-source-common-context.xml"/>
 
 	<beans:beans profile="accept-all-files">
 		<beans:bean id="filter"

--- a/modules/source/sftp/config/sftp.xml
+++ b/modules/source/sftp/config/sftp.xml
@@ -52,7 +52,20 @@
 			</header-enricher>
 			<file:file-to-bytes-transformer />
 		</chain>
+	</beans:beans>
 
+	<beans:beans profile="use-contents-with-split">
+		<chain id="extractContentsAndSplit" input-channel="files" output-channel="output">
+			<header-enricher>
+				<header name="contentType" value="text/plain"/>
+				<header name="file_name"   expression="payload.name"/>
+			</header-enricher>
+			<splitter>
+				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter">
+					<beans:constructor-arg value="false"/>
+				</beans:bean>
+			</splitter>
+		</chain>
 	</beans:beans>
 
 	<beans:beans profile="accept-all-files">

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
@@ -39,7 +39,7 @@ public class FileAsRefMixin implements ProfileNamesProvider {
 		return fileReadingmode;
 	}
 
-	@ModuleOption("Specifies how the file is being read. By default the content of a file is provided as byte array.")
+	@ModuleOption("specifies how the file is being read. By default the content of a file is provided as byte array")
 	public void setMode(FileReadingMode mode) {
 		this.fileReadingmode = mode;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
@@ -18,7 +18,7 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
-import org.hibernate.validator.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import org.springframework.xd.module.options.spi.ModuleOption;
 import org.springframework.xd.module.options.spi.ProfileNamesProvider;
@@ -32,16 +32,16 @@ import org.springframework.xd.module.options.spi.ProfileNamesProvider;
  */
 public class FileAsRefMixin implements ProfileNamesProvider {
 
-	private FileReadingMode fileReadingmode = FileReadingMode.FILE_AS_BYTES;
+	private FileReadingMode fileReadingmode = FileReadingMode.contents;
 
-	@NotBlank
-	public String getMode() {
-		return this.fileReadingmode != null ? fileReadingmode.getKey() : null;
+	@NotNull
+	public FileReadingMode getMode() {
+		return fileReadingmode;
 	}
 
-	@ModuleOption("set to to ref, textLine or fileAsBytes")
-	public void setMode(String key) {
-		this.fileReadingmode = FileReadingMode.fromKey(key);
+	@ModuleOption("Specifies how the file is being read. By default the content of a file is provided as byte array.")
+	public void setMode(FileReadingMode mode) {
+		this.fileReadingmode = mode;
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
@@ -18,6 +18,8 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
+import org.hibernate.validator.constraints.NotBlank;
+
 import org.springframework.xd.module.options.spi.ModuleOption;
 import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 
@@ -26,27 +28,24 @@ import org.springframework.xd.module.options.spi.ProfileNamesProvider;
  * the choice to pass along the File itself or its contents.
  *
  * @author Eric Bottard
+ * @author Gunnar Hillert
  */
 public class FileAsRefMixin implements ProfileNamesProvider {
 
-	private static final String USE_REF = "use-ref";
+	private FileReadingMode fileReadingmode = FileReadingMode.FILE_AS_BYTES;
 
-	private static final String USE_CONTENT = "use-contents";
-
-	private boolean ref = false;
-
-
-	public boolean isRef() {
-		return ref;
+	@NotBlank
+	public String getMode() {
+		return this.fileReadingmode != null ? fileReadingmode.getKey() : null;
 	}
 
-	@ModuleOption("set to true to output the File object itself")
-	public void setRef(boolean ref) {
-		this.ref = ref;
+	@ModuleOption("set to to ref, textLine or fileAsBytes")
+	public void setMode(String key) {
+		this.fileReadingmode = FileReadingMode.fromKey(key);
 	}
 
 	@Override
 	public String[] profilesToActivate() {
-		return ref ? new String[] { USE_REF } : new String[] { USE_CONTENT };
+		return new String[] { this.fileReadingmode.getProfile() };
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileReadingMode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileReadingMode.java
@@ -16,13 +16,6 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
-import java.util.Arrays;
-
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
 
 /**
  *
@@ -31,12 +24,10 @@ import com.google.common.collect.Collections2;
  */
 
 public enum FileReadingMode {
-
-	REF("ref", "use-ref"),
-	TEXT_LINE("textLine", "use-contents-with-split"),
-	FILE_AS_BYTES("fileAsBytes", "use-contents");
-
-	private String key;
+	//ref, textLine, fileAsBytes
+	ref("use-ref"),
+	lines("use-contents-with-split"),
+	contents("use-contents");
 
 	private String profile;
 
@@ -44,42 +35,12 @@ public enum FileReadingMode {
 	 * Constructor.
 	 *
 	 */
-	FileReadingMode(final String key, final String profile) {
-		this.key = key;
+	FileReadingMode(final String profile) {
 		this.profile = profile;
-	}
-
-	public String getKey() {
-		return key;
 	}
 
 	public String getProfile() {
 		return profile;
-	}
-
-	private static Function<FileReadingMode, String> func = new Function<FileReadingMode, String>() {
-
-		@Override
-		public String apply(FileReadingMode input) {
-			return input.key;
-		}
-	};
-
-	public static FileReadingMode fromKey(String key) {
-
-		Assert.hasText(key, "FileReadingMode key must neither be null nor empty.");
-
-		for (FileReadingMode fileReadingMode : FileReadingMode.values()) {
-			if (fileReadingMode.getKey().equalsIgnoreCase(key)) {
-				return fileReadingMode;
-			}
-		}
-
-		throw new IllegalArgumentException(String.format(
-				"Not a valid mode '%s'. Acceptable values are: %s",
-				key,
-				StringUtils.collectionToCommaDelimitedString(Collections2.transform(
-						Arrays.asList(FileReadingMode.values()), func))));
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileReadingMode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileReadingMode.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.modules.metadata;
+
+import java.util.Arrays;
+
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+
+/**
+ *
+ * @author Gunnar Hillert
+ * @since 1.2
+ */
+
+public enum FileReadingMode {
+
+	REF("ref", "use-ref"),
+	TEXT_LINE("textLine", "use-contents-with-split"),
+	FILE_AS_BYTES("fileAsBytes", "use-contents");
+
+	private String key;
+
+	private String profile;
+
+	/**
+	 * Constructor.
+	 *
+	 */
+	FileReadingMode(final String key, final String profile) {
+		this.key = key;
+		this.profile = profile;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public String getProfile() {
+		return profile;
+	}
+
+	private static Function<FileReadingMode, String> func = new Function<FileReadingMode, String>() {
+
+		@Override
+		public String apply(FileReadingMode input) {
+			return input.key;
+		}
+	};
+
+	public static FileReadingMode fromKey(String key) {
+
+		Assert.hasText(key, "FileReadingMode key must neither be null nor empty.");
+
+		for (FileReadingMode fileReadingMode : FileReadingMode.values()) {
+			if (fileReadingMode.getKey().equalsIgnoreCase(key)) {
+				return fileReadingMode;
+			}
+		}
+
+		throw new IllegalArgumentException(String.format(
+				"Not a valid mode '%s'. Acceptable values are: %s",
+				key,
+				StringUtils.collectionToCommaDelimitedString(Collections2.transform(
+						Arrays.asList(FileReadingMode.values()), func))));
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileReadingMode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileReadingMode.java
@@ -18,13 +18,15 @@ package org.springframework.xd.dirt.modules.metadata;
 
 
 /**
+ * Defines the supported modes of reading and processing files for the
+ * {@code File}, {@code FTP} and {@code SFTP} sources. The modes are triggered
+ * through Spring Application Context profiles that whose names are accessible via {@link #profile}.
  *
  * @author Gunnar Hillert
  * @since 1.2
  */
-
 public enum FileReadingMode {
-	//ref, textLine, fileAsBytes
+
 	ref("use-ref"),
 	lines("use-contents-with-split"),
 	contents("use-contents");
@@ -33,12 +35,14 @@ public enum FileReadingMode {
 
 	/**
 	 * Constructor.
-	 *
 	 */
 	FileReadingMode(final String profile) {
 		this.profile = profile;
 	}
 
+	/**
+	 * @return Spring Application Context profile name that provides the functionality of the respective mode.
+	 */
 	public String getProfile() {
 		return profile;
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/FileSourceModuleTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/FileSourceModuleTests.java
@@ -95,7 +95,7 @@ public class FileSourceModuleTests extends StreamTestSupport {
 	@Test
 	public void testFileContentsUsingDefaultMode() throws IOException {
 		deployStream(
-				"filecontents",
+				"filecontentsdefault",
 				"file --dir=" + sourceDirName + " --fixedDelay=0 | sink");
 		MessageTest test = new MessageTest() {
 
@@ -108,10 +108,10 @@ public class FileSourceModuleTests extends StreamTestSupport {
 						contentTypeResolver.resolve(message.getHeaders()));
 			}
 		};
-		StreamTestSupport.getSinkInputChannel("filecontents").subscribe(test);
+		StreamTestSupport.getSinkInputChannel("filecontentsdefault").subscribe(test);
 		dropFile("foo.txt");
 		test.waitForCompletion(1000);
-		undeployStream("filecontents");
+		undeployStream("filecontentsdefault");
 		assertTrue(test.getMessageHandled());
 	}
 

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/StreamTestSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/StreamTestSupport.java
@@ -32,8 +32,8 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
 import org.springframework.xd.dirt.module.ResourceModuleRegistry;
 import org.springframework.xd.dirt.module.WritableModuleRegistry;
-import org.springframework.xd.dirt.server.singlenode.SingleNodeApplication;
 import org.springframework.xd.dirt.server.TestApplicationBootstrap;
+import org.springframework.xd.dirt.server.singlenode.SingleNodeApplication;
 import org.springframework.xd.dirt.test.SingleNodeIntegrationTestSupport;
 import org.springframework.xd.module.core.CompositeModule;
 import org.springframework.xd.module.core.Module;
@@ -193,7 +193,7 @@ public class StreamTestSupport {
 
 	protected static abstract class MessageTest implements MessageHandler {
 
-		private boolean messageHandled;
+		protected boolean messageHandled;
 
 		public boolean getMessageHandled() {
 			return this.messageHandled;

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FilePollHdfsTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FilePollHdfsTest.java
@@ -58,7 +58,7 @@ public class FilePollHdfsTest extends AbstractJobTest {
 		String sourceFileName = UUID.randomUUID().toString() + ".out";
 		String sourceDir = "/tmp/xd/" + FilePollHdfsJob.DEFAULT_FILE_NAME;
 
-		SimpleFileSource fileSource = sources.file(sourceDir, sourceFileName).reference(true);
+		SimpleFileSource fileSource = sources.file(sourceDir, sourceFileName).mode(SimpleFileSource.Mode.REF);
 		job(jobName, jobs.filePollHdfsJob(DEFAULT_NAMES).toDSL(), true);
 		stream(fileSource + XD_TAP_DELIMITER + " queue:job:" + jobName);
 		//Since the job may be on a different container you will have to copy the file to the job's container.

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/FtpModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/FtpModulesTests.java
@@ -58,7 +58,7 @@ public class FtpModulesTests extends AbstractStreamIntegrationTest {
 	}
 
 	@Test
-	public void testModeOptionEqualsFileAsBytes() throws Exception {
+	public void testModeOptionEqualsContents() throws Exception {
 		FtpSource ftpSource = newFtpSource();
 		FileSink fileSink = newFileSink();
 
@@ -69,7 +69,7 @@ public class FtpModulesTests extends AbstractStreamIntegrationTest {
 
 		ftpSource.ensureStarted();
 
-		stream().create(generateStreamName(), "%s --mode=fileAsBytes | transform --expression=payload.getClass() | %s",
+		stream().create(generateStreamName(), "%s --mode=contents | transform --expression=payload.getClass() | %s",
 				ftpSource, fileSink);
 
 		assertThat(fileSink, eventually(hasContentsThat(equalTo("byte[]\n"))));
@@ -77,7 +77,7 @@ public class FtpModulesTests extends AbstractStreamIntegrationTest {
 	}
 
 	@Test
-	public void testModeOptionEqualsDefaultFileAsBytes() throws Exception {
+	public void testModeOptionEqualsDefaultContents() throws Exception {
 		FtpSource ftpSource = newFtpSource();
 		FileSink fileSink = newFileSink();
 
@@ -115,7 +115,7 @@ public class FtpModulesTests extends AbstractStreamIntegrationTest {
 	}
 
 	@Test
-	public void testModeOptionEqualsTextLine() throws Exception {
+	public void testModeOptionEqualsLines() throws Exception {
 		FtpSource ftpSource = newFtpSource();
 		FileSink fileSink = newFileSink();
 
@@ -126,7 +126,7 @@ public class FtpModulesTests extends AbstractStreamIntegrationTest {
 
 		ftpSource.ensureStarted();
 
-		stream().create(generateStreamName(), "%s --mode=textLine | transform --expression=payload.getClass() | %s",
+		stream().create(generateStreamName(), "%s --mode=lines | transform --expression=payload.getClass() | %s",
 				ftpSource, fileSink);
 
 		assertThat(fileSink, eventually(hasContentsThat(equalTo("java.lang.String\n"))));

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/FtpModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/FtpModulesTests.java
@@ -18,77 +18,119 @@
 
 package org.springframework.xd.shell.command;
 
-import org.junit.Test;
-import org.springframework.xd.test.fixtures.FileSink;
-import org.springframework.xd.test.fixtures.FtpSource;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.springframework.xd.shell.command.fixtures.XDMatchers.eventually;
 import static org.springframework.xd.shell.command.fixtures.XDMatchers.hasContentsThat;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.springframework.xd.test.fixtures.FileSink;
+import org.springframework.xd.test.fixtures.FtpSource;
+
 /**
  * Tests for the FTP source.
  *
  * @author Eric Bottard
+ * @author Gunnar Hillert
  */
 public class FtpModulesTests extends AbstractStreamIntegrationTest {
 
-    @Test
-    public void testBasicModuleBehavior() throws IOException {
-        FtpSource ftpSource = newFtpSource();
-        FileSink fileSink = newFileSink();
+	@Test
+	public void testBasicModuleBehavior() throws IOException {
+		FtpSource ftpSource = newFtpSource();
+		FileSink fileSink = newFileSink();
 
-        File file = new File(ftpSource.getRemoteServerDirectory(), "hello.txt");
-        FileWriter fileWriter = new FileWriter(file);
-        fileWriter.write("foobar");
-        fileWriter.close();
+		File file = new File(ftpSource.getRemoteServerDirectory(), "hello.txt");
+		FileWriter fileWriter = new FileWriter(file);
+		fileWriter.write("foobar");
+		fileWriter.close();
 
-        ftpSource.ensureStarted();
+		ftpSource.ensureStarted();
 
-        stream().create(generateStreamName(), "%s | %s --inputType=text/plain", ftpSource, fileSink);
+		stream().create(generateStreamName(), "%s | %s --inputType=text/plain", ftpSource, fileSink);
 
-        assertThat(fileSink, eventually(hasContentsThat(equalTo("foobar\n"))));
-    }
+		assertThat(fileSink, eventually(hasContentsThat(equalTo("foobar\n"))));
+	}
 
-    @Test
-    public void testRefOptionEqualsFalse() throws Exception {
-        FtpSource ftpSource = newFtpSource();
-        FileSink fileSink = newFileSink();
+	@Test
+	public void testModeOptionEqualsFileAsBytes() throws Exception {
+		FtpSource ftpSource = newFtpSource();
+		FileSink fileSink = newFileSink();
 
-        File file = new File(ftpSource.getRemoteServerDirectory(), "hello.txt");
-        FileWriter fileWriter = new FileWriter(file);
-        fileWriter.write("foobar");
-        fileWriter.close();
+		File file = new File(ftpSource.getRemoteServerDirectory(), "hello.txt");
+		FileWriter fileWriter = new FileWriter(file);
+		fileWriter.write("foobar");
+		fileWriter.close();
 
-        ftpSource.ensureStarted();
+		ftpSource.ensureStarted();
 
-        stream().create(generateStreamName(), "%s --ref=false | transform --expression=payload.getClass() | %s", ftpSource, fileSink);
+		stream().create(generateStreamName(), "%s --mode=fileAsBytes | transform --expression=payload.getClass() | %s",
+				ftpSource, fileSink);
 
-        assertThat(fileSink, eventually(hasContentsThat(equalTo("byte[]\n"))));
+		assertThat(fileSink, eventually(hasContentsThat(equalTo("byte[]\n"))));
 
-    }
+	}
 
-    @Test
-    public void testRefOptionEqualsTrue() throws Exception {
-        FtpSource ftpSource = newFtpSource();
-        FileSink fileSink = newFileSink();
+	@Test
+	public void testModeOptionEqualsDefaultFileAsBytes() throws Exception {
+		FtpSource ftpSource = newFtpSource();
+		FileSink fileSink = newFileSink();
 
-        File file = new File(ftpSource.getRemoteServerDirectory(), "hello.txt");
-        FileWriter fileWriter = new FileWriter(file);
-        fileWriter.write("foobar");
-        fileWriter.close();
+		File file = new File(ftpSource.getRemoteServerDirectory(), "hello.txt");
+		FileWriter fileWriter = new FileWriter(file);
+		fileWriter.write("foobar");
+		fileWriter.close();
 
-        ftpSource.ensureStarted();
+		ftpSource.ensureStarted();
 
-        stream().create(generateStreamName(), "%s --ref=true | transform --expression=payload.getClass() | %s", ftpSource, fileSink);
+		stream().create(generateStreamName(), "%s | transform --expression=payload.getClass() | %s",
+				ftpSource, fileSink);
 
-        assertThat(fileSink, eventually(hasContentsThat(equalTo("java.io.File\n"))));
+		assertThat(fileSink, eventually(hasContentsThat(equalTo("byte[]\n"))));
 
-    }
+	}
+
+	@Test
+	public void testModeOptionEqualsRef() throws Exception {
+		FtpSource ftpSource = newFtpSource();
+		FileSink fileSink = newFileSink();
+
+		File file = new File(ftpSource.getRemoteServerDirectory(), "hello.txt");
+		FileWriter fileWriter = new FileWriter(file);
+		fileWriter.write("foobar");
+		fileWriter.close();
+
+		ftpSource.ensureStarted();
+
+		stream().create(generateStreamName(), "%s --mode=ref | transform --expression=payload.getClass() | %s",
+				ftpSource, fileSink);
+
+		assertThat(fileSink, eventually(hasContentsThat(equalTo("java.io.File\n"))));
+
+	}
+
+	@Test
+	public void testModeOptionEqualsTextLine() throws Exception {
+		FtpSource ftpSource = newFtpSource();
+		FileSink fileSink = newFileSink();
+
+		File file = new File(ftpSource.getRemoteServerDirectory(), "hello.txt");
+		FileWriter fileWriter = new FileWriter(file);
+		fileWriter.write("foobar");
+		fileWriter.close();
+
+		ftpSource.ensureStarted();
+
+		stream().create(generateStreamName(), "%s --mode=textLine | transform --expression=payload.getClass() | %s",
+				ftpSource, fileSink);
+
+		assertThat(fileSink, eventually(hasContentsThat(equalTo("java.lang.String\n"))));
+
+	}
 
 }

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleFileSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleFileSource.java
@@ -59,7 +59,7 @@ public class SimpleFileSource extends AbstractModuleFixture<SimpleFileSource> {
 	 * @param fileName file name
 	 */
 	public SimpleFileSource(String dir, String fileName) {
-		this(dir, fileName, Mode.FILE_AS_BYTES);
+		this(dir, fileName, Mode.CONTENTS);
 	}
 
 	/**
@@ -85,8 +85,8 @@ public class SimpleFileSource extends AbstractModuleFixture<SimpleFileSource> {
 	public enum Mode {
 
 		REF("ref"),
-		TEXT_LINE("textLine"),
-		FILE_AS_BYTES("fileAsBytes");
+		LINES("lines"),
+		CONTENTS("contents");
 
 		private String value;
 

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleFileSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleFileSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,11 @@ import org.springframework.xd.test.fixtures.util.FixtureUtils;
 
 
 /**
- * A FileSource for integraiton tests. Note it does not need to implement {@link DisposableFileSupport}
+ * A FileSource for integration tests. Note it does not need to implement {@link DisposableFileSupport}
  *
  * @author Glenn Renfro
  * @author Mark Pollack
+ * @author Gunnar Hillert
  */
 public class SimpleFileSource extends AbstractModuleFixture<SimpleFileSource> {
 
@@ -32,7 +33,7 @@ public class SimpleFileSource extends AbstractModuleFixture<SimpleFileSource> {
 
 	private final String fileName;
 
-	private boolean reference;
+	private Mode mode;
 
 
 	/**
@@ -40,14 +41,15 @@ public class SimpleFileSource extends AbstractModuleFixture<SimpleFileSource> {
 	 *
 	 * @param dir directory name
 	 * @param fileName file name
-	 * @param reference false if file content should be sent to output channel, true if file object should be sent.
+	 * @param mode 'FILE_AS_BYTES' if file content should be sent to output channel, 'REF' if file object should be sent, 'TEXT_LINE' for splitting the file into Strings (1 per line).
 	 */
-	public SimpleFileSource(String dir, String fileName, boolean reference) {
+	public SimpleFileSource(String dir, String fileName, Mode mode) {
 		Assert.hasText(dir, "dir must not be null or empty");
 		Assert.hasText(fileName, "fileName must not be null or empty");
+		Assert.notNull(mode, "mode must not be null");
 		this.dir = dir;
 		this.fileName = fileName;
-		this.reference = reference;
+		this.mode = mode;
 	}
 
 	/**
@@ -57,7 +59,7 @@ public class SimpleFileSource extends AbstractModuleFixture<SimpleFileSource> {
 	 * @param fileName file name
 	 */
 	public SimpleFileSource(String dir, String fileName) {
-		this(dir, fileName, false);
+		this(dir, fileName, Mode.FILE_AS_BYTES);
 	}
 
 	/**
@@ -66,19 +68,38 @@ public class SimpleFileSource extends AbstractModuleFixture<SimpleFileSource> {
 	@Override
 	protected String toDSL() {
 		String dsl = FixtureUtils.labelOrEmpty(label);
-		dsl += String.format("file --dir=%s --pattern='%s' --ref=%s", dir, fileName, reference);
+		dsl += String.format("file --dir=%s --pattern='%s' --mode=%s", dir, fileName, mode);
 		return dsl;
 	}
 
 	/**
 	 * Determines if the file object or the content of the file should be sent to the output channel.
-	 * @param reference Set to true to output the File object itself. False if content should be sent.
+	 * @param mode 'FILE_AS_BYTES' if file content should be sent to output channel, 'REF' if file object should be sent, 'TEXT_LINE' for splitting the file into Strings (1 per line).
 	 * @return the current instance of the SimpleFileSource fixture.
 	 */
-	public SimpleFileSource reference(boolean reference) {
-		this.reference = reference;
+	public SimpleFileSource mode(Mode mode) {
+		this.mode = mode;
 		return this;
 	}
 
+	public enum Mode {
 
+		REF("ref"),
+		TEXT_LINE("textLine"),
+		FILE_AS_BYTES("fileAsBytes");
+
+		private String value;
+
+		/**
+		 * Constructor.
+		 */
+		Mode(final String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+	}
 }

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -121,7 +121,7 @@ $$fixedDelay$$:: $$the rate at which to poll the remote directory$$ *($$int$$, d
 $$host$$:: $$the host name for the FTP server$$ *($$String$$, default: `localhost`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
 $$localDir$$:: $$set the local directory the remote files are transferred to$$ *($$String$$, default: `/tmp/xd/ftp`)*
-$$mode$$:: $$set to to ref, textLine or fileAsBytes$$ *($$String$$, default: `fileAsBytes`)*
+$$mode$$:: $$Specifies how the file is being read. By default the contents of a file is provided as byte array.$$ *($$FileReadingMode$$, default: `fileAsBytes`, possible values: `ref,textLine,fileAsBytes`)*
 $$password$$:: $$the password for the FTP connection$$ *($$Password$$, no default)*
 $$port$$:: $$the port for the FTP server$$ *($$int$$, default: `21`)*
 $$preserveTimestamp$$:: $$whether to preserve the timestamp of files retrieved$$ *($$boolean$$, default: `true`)*
@@ -152,7 +152,7 @@ $$fixedDelay$$:: $$fixed delay in SECONDS to poll the remote directory$$ *($$int
 $$host$$:: $$the remote host to connect to$$ *($$String$$, default: `localhost`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
 $$localDir$$:: $$set the local directory the remote files are transferred to$$ *($$String$$, default: `/tmp/xd/output`)*
-$$mode$$:: $$set to to ref, textLine or fileAsBytes$$ *($$String$$, default: `fileAsBytes`)*
+$$mode$$:: $$Specifies how the file is being read. By default the contents of a file is provided as byte array.$$ *($$FileReadingMode$$, default: `fileAsBytes`, possible values: `ref,textLine,fileAsBytes`)*
 $$passPhrase$$:: $$the passphrase to use$$ *($$String$$, default: ``)*
 $$password$$:: $$the password for the provided user$$ *($$String$$, default: ``)*
 $$pattern$$:: $$simple filename pattern to apply to the filter$$ *($$String$$, no default)*
@@ -269,7 +269,7 @@ The **$$file$$** $$source$$ has the following options:
 $$dir$$:: $$the absolute path to the directory to monitor for files$$ *($$String$$, default: `/tmp/xd/input/<stream name>`)*
 $$fixedDelay$$:: $$the fixed delay polling interval specified in seconds$$ *($$int$$, default: `5`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
-$$mode$$:: $$set to to ref, textLine or fileAsBytes$$ *($$String$$, default: `fileAsBytes`)*
+$$mode$$:: $$Specifies how the file is being read. By default the contents of a file is provided as byte array.$$ *($$FileReadingMode$$, default: `fileAsBytes`, possible values: `ref,textLine,fileAsBytes`)*
 $$pattern$$:: $$a filter expression (Ant style) to accept only files that match the pattern$$ *($$String$$, default: `*`)*
 $$preventDuplicates$$:: $$whether to prevent the same file from being processed twice$$ *($$boolean$$, default: `true`)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -121,7 +121,7 @@ $$fixedDelay$$:: $$the rate at which to poll the remote directory$$ *($$int$$, d
 $$host$$:: $$the host name for the FTP server$$ *($$String$$, default: `localhost`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
 $$localDir$$:: $$set the local directory the remote files are transferred to$$ *($$String$$, default: `/tmp/xd/ftp`)*
-$$mode$$:: $$Specifies how the file is being read. By default the contents of a file is provided as byte array.$$ *($$FileReadingMode$$, default: `fileAsBytes`, possible values: `ref,textLine,fileAsBytes`)*
+$$mode$$:: $$specifies how the file is being read. By default the content of a file is provided as byte array$$ *($$FileReadingMode$$, default: `contents`, possible values: `ref,lines,contents`)*
 $$password$$:: $$the password for the FTP connection$$ *($$Password$$, no default)*
 $$port$$:: $$the port for the FTP server$$ *($$int$$, default: `21`)*
 $$preserveTimestamp$$:: $$whether to preserve the timestamp of files retrieved$$ *($$boolean$$, default: `true`)*
@@ -152,7 +152,7 @@ $$fixedDelay$$:: $$fixed delay in SECONDS to poll the remote directory$$ *($$int
 $$host$$:: $$the remote host to connect to$$ *($$String$$, default: `localhost`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
 $$localDir$$:: $$set the local directory the remote files are transferred to$$ *($$String$$, default: `/tmp/xd/output`)*
-$$mode$$:: $$Specifies how the file is being read. By default the contents of a file is provided as byte array.$$ *($$FileReadingMode$$, default: `fileAsBytes`, possible values: `ref,textLine,fileAsBytes`)*
+$$mode$$:: $$specifies how the file is being read. By default the content of a file is provided as byte array$$ *($$FileReadingMode$$, default: `contents`, possible values: `ref,lines,contents`)*
 $$passPhrase$$:: $$the passphrase to use$$ *($$String$$, default: ``)*
 $$password$$:: $$the password for the provided user$$ *($$String$$, default: ``)*
 $$pattern$$:: $$simple filename pattern to apply to the filter$$ *($$String$$, no default)*
@@ -269,7 +269,7 @@ The **$$file$$** $$source$$ has the following options:
 $$dir$$:: $$the absolute path to the directory to monitor for files$$ *($$String$$, default: `/tmp/xd/input/<stream name>`)*
 $$fixedDelay$$:: $$the fixed delay polling interval specified in seconds$$ *($$int$$, default: `5`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
-$$mode$$:: $$Specifies how the file is being read. By default the contents of a file is provided as byte array.$$ *($$FileReadingMode$$, default: `fileAsBytes`, possible values: `ref,textLine,fileAsBytes`)*
+$$mode$$:: $$specifies how the file is being read. By default the content of a file is provided as byte array$$ *($$FileReadingMode$$, default: `contents`, possible values: `ref,lines,contents`)*
 $$pattern$$:: $$a filter expression (Ant style) to accept only files that match the pattern$$ *($$String$$, default: `*`)*
 $$preventDuplicates$$:: $$whether to prevent the same file from being processed twice$$ *($$boolean$$, default: `true`)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -121,10 +121,10 @@ $$fixedDelay$$:: $$the rate at which to poll the remote directory$$ *($$int$$, d
 $$host$$:: $$the host name for the FTP server$$ *($$String$$, default: `localhost`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
 $$localDir$$:: $$set the local directory the remote files are transferred to$$ *($$String$$, default: `/tmp/xd/ftp`)*
+$$mode$$:: $$set to to ref, textLine or fileAsBytes$$ *($$String$$, default: `fileAsBytes`)*
 $$password$$:: $$the password for the FTP connection$$ *($$Password$$, no default)*
 $$port$$:: $$the port for the FTP server$$ *($$int$$, default: `21`)*
 $$preserveTimestamp$$:: $$whether to preserve the timestamp of files retrieved$$ *($$boolean$$, default: `true`)*
-$$ref$$:: $$set to true to output the File object itself$$ *($$boolean$$, default: `false`)*
 $$remoteDir$$:: $$the remote directory to transfer the files from$$ *($$String$$, default: `/`)*
 $$remoteFileSeparator$$:: $$file separator to use on the remote side$$ *($$String$$, default: `/`)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
@@ -152,12 +152,12 @@ $$fixedDelay$$:: $$fixed delay in SECONDS to poll the remote directory$$ *($$int
 $$host$$:: $$the remote host to connect to$$ *($$String$$, default: `localhost`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
 $$localDir$$:: $$set the local directory the remote files are transferred to$$ *($$String$$, default: `/tmp/xd/output`)*
+$$mode$$:: $$set to to ref, textLine or fileAsBytes$$ *($$String$$, default: `fileAsBytes`)*
 $$passPhrase$$:: $$the passphrase to use$$ *($$String$$, default: ``)*
 $$password$$:: $$the password for the provided user$$ *($$String$$, default: ``)*
 $$pattern$$:: $$simple filename pattern to apply to the filter$$ *($$String$$, no default)*
 $$port$$:: $$the remote port to connect to$$ *($$int$$, default: `22`)*
 $$privateKey$$:: $$the private key location (a valid Spring Resource URL)$$ *($$String$$, default: ``)*
-$$ref$$:: $$set to true to output the File object itself$$ *($$boolean$$, default: `false`)*
 $$regexPattern$$:: $$filename regex pattern to apply to the filter$$ *($$String$$, no default)*
 $$remoteDir$$:: $$the remote directory to transfer the files from$$ *($$String$$, no default)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
@@ -238,7 +238,12 @@ Some platforms, such as linux, send status messages to `stderr`. The tail module
 [[file]]
 === File
 
-The file source provides the contents of a File as a byte array by default but may be configured to provide the file reference itself.
+The file source provides the contents of a File as a byte array by default. However, this can be
+customzied using the `--mode` option:
+
+- *ref* Provides a `java.io.File` reference
+- *textLine* Will split files line-by-line and emit a new message for each line
+- *fileAsBytes* The default. Provides the contents of a file as a byte array
 
 To log the contents of a file create a stream definition using the XD shell
 
@@ -264,9 +269,9 @@ The **$$file$$** $$source$$ has the following options:
 $$dir$$:: $$the absolute path to the directory to monitor for files$$ *($$String$$, default: `/tmp/xd/input/<stream name>`)*
 $$fixedDelay$$:: $$the fixed delay polling interval specified in seconds$$ *($$int$$, default: `5`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
+$$mode$$:: $$set to to ref, textLine or fileAsBytes$$ *($$String$$, default: `fileAsBytes`)*
 $$pattern$$:: $$a filter expression (Ant style) to accept only files that match the pattern$$ *($$String$$, default: `*`)*
 $$preventDuplicates$$:: $$whether to prevent the same file from being processed twice$$ *($$boolean$$, default: `true`)*
-$$ref$$:: $$set to true to output the File object itself$$ *($$boolean$$, default: `false`)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
 //$source.file
 

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -104,7 +104,12 @@ Since this properties file contains sensitive information, it will typically be 
 
 This source module supports transfer of files using the FTP protocol.
 Files are transferred from the `remote` directory to the `local` directory where the module is deployed.
-Messages emitted by the source can be the local +File+ object or its contents.
+Messages emitted by the source are provided as a byte array by default. However, this can be
+customized using the `--mode` option:
+
+- *ref* Provides a `java.io.File` reference
+- *lines* Will split files line-by-line and emit a new message for each line
+- *contents* The default. Provides the contents of a file as a byte array
 
 ==== Options
 
@@ -137,7 +142,13 @@ $$username$$:: $$the username for the FTP connection$$ *($$String$$, no default)
 
 This source module supports transfer of files using the SFTP protocol.
 Files are transferred from the `remote` directory to the `local` directory where the module is deployed.
-Messages emitted by the source can be the local +File+ object or its contents.
+
+Messages emitted by the source are provided as a byte array by default. However, this can be
+customized using the `--mode` option:
+
+- *ref* Provides a `java.io.File` reference
+- *lines* Will split files line-by-line and emit a new message for each line
+- *contents* The default. Provides the contents of a file as a byte array
 
 ==== Options
 
@@ -239,11 +250,11 @@ Some platforms, such as linux, send status messages to `stderr`. The tail module
 === File
 
 The file source provides the contents of a File as a byte array by default. However, this can be
-customzied using the `--mode` option:
+customized using the `--mode` option:
 
 - *ref* Provides a `java.io.File` reference
-- *textLine* Will split files line-by-line and emit a new message for each line
-- *fileAsBytes* The default. Provides the contents of a file as a byte array
+- *lines* Will split files line-by-line and emit a new message for each line
+- *contents* The default. Provides the contents of a file as a byte array
 
 To log the contents of a file create a stream definition using the XD shell
 


### PR DESCRIPTION
* replace `ref` option with a `mode` option
* `mode` can accept
  - `ref` (same behavior as the former `ref=true`)
  - `fileAsBytes` (same behavior as the former `ref=false`)
  - textLine (New option, will split files line-by-line and emit a new message for each line)
* Add tests
* Refactor several existing tests
* Update documentation