### PR TITLE
[Sprint: 49] XD-3063: Support maxMessages in Polled Sources

### DIFF
--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcSourceModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcSourceModuleOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,28 @@
 
 package org.springframework.xd.jdbc;
 
+import javax.validation.constraints.Min;
+
 import org.hibernate.validator.constraints.NotBlank;
+
+import org.springframework.xd.module.options.mixins.MaxMessagesDefaultOneMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
 import org.springframework.xd.module.options.spi.ProfileNamesProvider;
-
-import javax.validation.constraints.Min;
 
 /**
  * Captures options for the {@code jdbc} source module.
  *
  * @author Eric Bottard
  * @author Thomas Risberg
+ * @author Gary Russell
  */
-@Mixin({JdbcConnectionMixin.class, JdbcConnectionPoolMixin.class})
+@Mixin({ JdbcConnectionMixin.class, JdbcConnectionPoolMixin.class, MaxMessagesDefaultOneMixin.class })
 public class JdbcSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
-	private static final String[] USE_SPLITTER = new String[]{"use-splitter"};
-	private static final String[] DONT_USE_SPLITTER = new String[]{"dont-use-splitter"};
+	private static final String[] USE_SPLITTER = new String[] { "use-splitter" };
+
+	private static final String[] DONT_USE_SPLITTER = new String[] { "dont-use-splitter" };
 
 
 	private String query;

--- a/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailSourceOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import org.springframework.xd.module.options.mixins.MaxMessagesDefaultOneMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
 import org.springframework.xd.module.options.spi.ProfileNamesProvider;
@@ -30,10 +31,11 @@ import org.springframework.xd.module.options.spi.ProfileNamesProvider;
 
 /**
  * Captures options for the {@code mail} source module.
- * 
+ *
  * @author Eric Bottard
+ * @author Gary Russell
  */
-@Mixin({ MailServerMixin.class })
+@Mixin({ MailServerMixin.class, MaxMessagesDefaultOneMixin.class })
 public class MailSourceOptionsMetadata implements ProfileNamesProvider {
 
 	private int fixedDelay = 60;

--- a/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/TcpClientSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/TcpClientSourceOptionsMetadata.java
@@ -19,6 +19,7 @@ package org.springframework.xd.tcp;
 import javax.validation.constraints.Min;
 
 import org.springframework.xd.module.options.mixins.ExpressionOrScriptMixin;
+import org.springframework.xd.module.options.mixins.MaxMessagesDefaultOneMixin;
 import org.springframework.xd.module.options.mixins.ToStringCharsetMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
@@ -27,13 +28,14 @@ import org.springframework.xd.tcp.EncoderDecoderMixins.DecoderMixin;
 
 /**
  * Captures options available to the {@code tcp-client} source module.
- * 
+ *
  * @author Eric Bottard
  */
 @Mixin({ ExpressionOrScriptMixin.class,
 	ClientTcpConnectionFactoryOptionsMetadataMixin.class,
 	DecoderMixin.class,
-	ToStringCharsetMixin.class })
+	ToStringCharsetMixin.class,
+	MaxMessagesDefaultOneMixin.class })
 public class TcpClientSourceOptionsMetadata {
 
 	private int fixedDelay = 5;

--- a/modules/source/file/config/file.xml
+++ b/modules/source/file/config/file.xml
@@ -15,7 +15,7 @@
 			channel="files" directory="${dir}"
 			prevent-duplicates="${preventDuplicates}"
 			filename-pattern="${pattern}">
-		<poller trigger="trigger" />
+		<poller trigger="trigger" max-messages-per-poll="${maxMessages}" />
 	</file:inbound-channel-adapter>
 
 	<beans:import resource="../../../common/file-source-common-context.xml"/>

--- a/modules/source/ftp/config/ftp.xml
+++ b/modules/source/ftp/config/ftp.xml
@@ -27,7 +27,7 @@
 		remote-file-separator="${remoteFileSeparator}" preserve-timestamp="${preserveTimestamp}"
 		auto-create-local-directory="${autoCreateLocalDir}"
 		temporary-file-suffix="${tmpFileSuffix}" delete-remote-files="${deleteRemoteFiles}">
-		<poller trigger="trigger" />
+		<poller trigger="trigger" max-messages-per-poll="${maxMessages}" />
 	</int-ftp:inbound-channel-adapter>
 
 	<beans:import resource="../../../common/file-source-common-context.xml"/>

--- a/modules/source/jdbc/config/jdbc.xml
+++ b/modules/source/jdbc/config/jdbc.xml
@@ -19,7 +19,7 @@
 			update="${update:#{null}}"
 			max-rows-per-poll="${maxRowsPerPoll}"
 			auto-startup="false">
-		<poller fixed-delay="${fixedDelay}" time-unit="SECONDS">
+		<poller fixed-delay="${fixedDelay}" time-unit="SECONDS" max-messages-per-poll="${maxMessages}">
 			<transactional />
 		</poller>
 	</int-jdbc:inbound-channel-adapter>

--- a/modules/source/mail/config/mail.xml
+++ b/modules/source/mail/config/mail.xml
@@ -20,7 +20,7 @@
 			store-uri="${protocol}://${username:}:${password:}@${host}:${port}/${folder}"
 			channel="transform" should-mark-messages-as-read="${markAsRead}"
 			should-delete-messages="${delete}">
-			<poller fixed-delay="${fixedDelay}" time-unit="SECONDS">
+			<poller fixed-delay="${fixedDelay}" time-unit="SECONDS" max-messages-per-poll="${maxMessages}">
 				<advice-chain>
 					<beans:bean
 						class="org.springframework.xd.dirt.module.support.ThreadContextClassLoaderSetterAdvice" />

--- a/modules/source/sftp/config/sftp.xml
+++ b/modules/source/sftp/config/sftp.xml
@@ -28,7 +28,7 @@
 		filter="filter" remote-directory="${remoteDir}" local-directory="${localDir}"
 		auto-create-local-directory="${autoCreateLocalDir}"
 		temporary-file-suffix="${tmpFileSuffix}" delete-remote-files="${deleteRemoteFiles}">
-		<poller trigger="trigger" />
+		<poller trigger="trigger" max-messages-per-poll="${maxMessages}" />
 	</int-sftp:inbound-channel-adapter>
 
 	<beans:import resource="../../../common/file-source-common-context.xml"/>

--- a/modules/source/tcp-client/config/tcp-client.xml
+++ b/modules/source/tcp-client/config/tcp-client.xml
@@ -32,7 +32,7 @@
 	<bean id="counter" class="java.util.concurrent.atomic.AtomicInteger" />
 
 	<int:inbound-channel-adapter channel="commandsTrigger" expression="@counter.incrementAndGet()" auto-startup="false">
-		<int:poller fixed-delay="${fixedDelay}" time-unit="SECONDS" />
+		<int:poller fixed-delay="${fixedDelay}" time-unit="SECONDS" max-messages-per-poll="${maxMessages}" />
 	</int:inbound-channel-adapter>
 	
 

--- a/modules/source/time/config/time.xml
+++ b/modules/source/time/config/time.xml
@@ -10,7 +10,7 @@
 	<inbound-channel-adapter channel="output"
 			auto-startup="false"
 			expression="new java.text.SimpleDateFormat('${format}').format(new java.util.Date())">
-		<poller trigger="fixedDelayTrigger" />
+		<poller trigger="fixedDelayTrigger" max-messages-per-poll="${maxMessages}" />
 	</inbound-channel-adapter>
 
 	<beans:bean id="fixedDelayTrigger" class="org.springframework.scheduling.support.PeriodicTrigger">

--- a/modules/source/trigger/config/trigger.xml
+++ b/modules/source/trigger/config/trigger.xml
@@ -8,7 +8,7 @@
 
 	<int:inbound-channel-adapter channel="output"
 		auto-startup="false" expression="'${payload}'">
-		<int:poller trigger="trigger" />
+		<int:poller trigger="trigger" max-messages-per-poll="${maxMessages}" />
 	</int:inbound-channel-adapter>
 
 	<beans profile="use-date">

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileSourceOptionsMetadata.java
@@ -22,6 +22,7 @@ import javax.validation.constraints.Min;
 
 import org.hibernate.validator.constraints.NotBlank;
 
+import org.springframework.xd.module.options.mixins.MaxMessagesDefaultUnlimitedMixin;
 import org.springframework.xd.module.options.mixins.PeriodicTriggerMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
@@ -31,9 +32,10 @@ import org.springframework.xd.module.options.spi.ModulePlaceholders;
  * Holds module options metadata about the {@code file} source.
  *
  * @author Eric Bottard
+ * @author Gary Russell
  */
 
-@Mixin({FileAsRefMixin.class, PeriodicTriggerMixin.class})
+@Mixin({ FileAsRefMixin.class, PeriodicTriggerMixin.class, MaxMessagesDefaultUnlimitedMixin.class })
 public class FileSourceOptionsMetadata {
 
 	private String dir = "/tmp/xd/input/" + ModulePlaceholders.XD_STREAM_NAME;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpSourceOptionsMetadata.java
@@ -21,6 +21,7 @@ import javax.validation.constraints.Min;
 import org.hibernate.validator.constraints.NotBlank;
 
 import org.springframework.xd.module.options.mixins.FtpConnectionMixin;
+import org.springframework.xd.module.options.mixins.MaxMessagesDefaultUnlimitedMixin;
 import org.springframework.xd.module.options.mixins.PeriodicTriggerMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
@@ -31,7 +32,8 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * @author Franck Marchand
  * @author Eric Bottard
  */
-@Mixin({ FtpConnectionMixin.class, PeriodicTriggerMixin.class, FileAsRefMixin.class })
+@Mixin({ FtpConnectionMixin.class, PeriodicTriggerMixin.class, FileAsRefMixin.class,
+	MaxMessagesDefaultUnlimitedMixin.class })
 public class FtpSourceOptionsMetadata {
 
 	private int clientMode = 0;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/SftpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/SftpSourceOptionsMetadata.java
@@ -21,6 +21,7 @@ import javax.validation.constraints.AssertTrue;
 import org.hibernate.validator.constraints.NotBlank;
 
 import org.springframework.util.StringUtils;
+import org.springframework.xd.module.options.mixins.MaxMessagesDefaultUnlimitedMixin;
 import org.springframework.xd.module.options.mixins.PeriodicTriggerMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
@@ -32,9 +33,10 @@ import org.springframework.xd.module.options.spi.ProfileNamesProvider;
  *
  * @author Ilayaperumal Gopinathan
  * @author Eric Bottard
+ * @author Gary Russell
  */
 
-@Mixin({PeriodicTriggerMixin.class, FileAsRefMixin.class})
+@Mixin({ PeriodicTriggerMixin.class, FileAsRefMixin.class, MaxMessagesDefaultUnlimitedMixin.class })
 public class SftpSourceOptionsMetadata implements ProfileNamesProvider {
 
 	private static final String ACCEPT_ALL_FILES = "accept-all-files";

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TimeSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TimeSourceOptionsMetadata.java
@@ -16,6 +16,7 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
+import org.springframework.xd.module.options.mixins.MaxMessagesDefaultOneMixin;
 import org.springframework.xd.module.options.mixins.PeriodicTriggerMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
@@ -27,7 +28,7 @@ import org.springframework.xd.module.options.validation.DateFormat;
  * @author Eric Bottard
  * @author Gary Russell
  */
-@Mixin(PeriodicTriggerMixin.class)
+@Mixin({ PeriodicTriggerMixin.class, MaxMessagesDefaultOneMixin.class })
 public class TimeSourceOptionsMetadata {
 
 	private String format = "yyyy-MM-dd HH:mm:ss";

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TriggerSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TriggerSourceOptionsMetadata.java
@@ -23,6 +23,7 @@ import javax.validation.groups.Default;
 
 import org.hibernate.validator.constraints.NotBlank;
 
+import org.springframework.xd.module.options.mixins.MaxMessagesDefaultOneMixin;
 import org.springframework.xd.module.options.mixins.PeriodicTriggerMixin;
 import org.springframework.xd.module.options.spi.Mixin;
 import org.springframework.xd.module.options.spi.ModuleOption;
@@ -40,15 +41,15 @@ import org.springframework.xd.module.options.validation.Exclusives;
  * @author Florent Biville
  * @author Gary Russell
  */
-@Mixin(PeriodicTriggerMixin.class)
+@Mixin({ PeriodicTriggerMixin.class, MaxMessagesDefaultOneMixin.class })
 @DateWithCustomFormat(groups = TriggerSourceOptionsMetadata.DateHasBeenSet.class)
 public class TriggerSourceOptionsMetadata implements ProfileNamesProvider, ValidationGroupsProvider {
 
-	private static final String[] USE_CRON = new String[] {"use-cron"};
+	private static final String[] USE_CRON = new String[] { "use-cron" };
 
-	private static final String[] USE_DELAY = new String[] {"use-delay"};
+	private static final String[] USE_DELAY = new String[] { "use-delay" };
 
-	private static final String[] USE_DATE = new String[] {"use-date"};
+	private static final String[] USE_DATE = new String[] { "use-date" };
 
 	public static final String DEFAULT_DATE = "The current time";
 
@@ -137,6 +138,6 @@ public class TriggerSourceOptionsMetadata implements ProfileNamesProvider, Valid
 
 	@Override
 	public Class<?>[] groupsToValidate() {
-		return DEFAULT_DATE.equals(date) ? DEFAULT_GROUP : new Class<?>[] {Default.class, DateHasBeenSet.class};
+		return DEFAULT_DATE.equals(date) ? DEFAULT_GROUP : new Class<?>[] { Default.class, DateHasBeenSet.class };
 	}
 }

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/FromMongoDbOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/FromMongoDbOptionMixin.java
@@ -26,6 +26,7 @@ import org.springframework.xd.module.options.spi.ProfileNamesProvider;
  * An option class to mix-in when reading from MongoDB.
  *
  * @author Abhinav Gandhi
+ * @author Gary Russell
  */
 public abstract class FromMongoDbOptionMixin implements ProfileNamesProvider {
 
@@ -40,15 +41,13 @@ public abstract class FromMongoDbOptionMixin implements ProfileNamesProvider {
 
 	private int fixedDelay = 1000;
 
-	private int maxMessages = 1;
-
 	private boolean split = true;
 
 
 	/**
 	 * Has {@code collectionName} default to ${xd.job.name}.
 	 */
-	@Mixin({ MongoDbConnectionMixin.class, PeriodicTriggerMixin.class })
+	@Mixin({ MongoDbConnectionMixin.class, PeriodicTriggerMixin.class, MaxMessagesDefaultOneMixin.class })
 	public static class Job extends FromMongoDbOptionMixin {
 
 		public Job() {
@@ -59,7 +58,7 @@ public abstract class FromMongoDbOptionMixin implements ProfileNamesProvider {
 	/**
 	 * Has {@code collectionName} default to ${xd.stream.name}.
 	 */
-	@Mixin({ MongoDbConnectionMixin.class, PeriodicTriggerMixin.class })
+	@Mixin({ MongoDbConnectionMixin.class, PeriodicTriggerMixin.class, MaxMessagesDefaultOneMixin.class })
 	public static class Stream extends FromMongoDbOptionMixin {
 
 		public Stream() {
@@ -84,11 +83,6 @@ public abstract class FromMongoDbOptionMixin implements ProfileNamesProvider {
 		this.fixedDelay = fixedDelay;
 	}
 
-	@ModuleOption("the maximum number of messages to get at a time")
-	public void setMaxMessages(int maxMessages) {
-		this.maxMessages = maxMessages;
-	}
-
 	@ModuleOption("the query to make to the mongo db")
 	public void setQuery(String query) {
 		this.query = query;
@@ -101,10 +95,6 @@ public abstract class FromMongoDbOptionMixin implements ProfileNamesProvider {
 
 	public int getFixedDelay() {
 		return this.fixedDelay;
-	}
-
-	public int getMaxMessages() {
-		return this.maxMessages;
 	}
 
 	public String getQuery() {

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MaxMessagesDefaultOneMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MaxMessagesDefaultOneMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.module.options.mixins;
+
+import org.springframework.xd.module.options.spi.ModuleOption;
+
+
+/**
+ * Mixin for polled sources where the default is 1 message per poll.
+ *
+ * @author Gary Russell
+ */
+public class MaxMessagesDefaultOneMixin {
+
+	long maxMessages = 1;
+
+	public long getMaxMessages() {
+		return this.maxMessages;
+	}
+
+	@ModuleOption("the maximum messages per poll; -1 for unlimited")
+	public void setMaxMessages(long maxMessages) {
+		this.maxMessages = maxMessages;
+	}
+
+}

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MaxMessagesDefaultUnlimitedMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MaxMessagesDefaultUnlimitedMixin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.module.options.mixins;
+
+import org.springframework.xd.module.options.spi.ModuleOption;
+
+
+/**
+ * Mixin for polled sources where the default is unlimited messages per poll.
+ *
+ * @author Gary Russell
+ */
+public class MaxMessagesDefaultUnlimitedMixin {
+
+	long maxMessages = -1;
+
+	public long getMaxMessages() {
+		return this.maxMessages;
+	}
+
+	@ModuleOption("the maximum messages per poll; -1 for unlimited")
+	public void setMaxMessages(long maxMessages) {
+		this.maxMessages = maxMessages;
+	}
+
+}

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -126,6 +126,7 @@ $$fixedDelay$$:: $$the rate at which to poll the remote directory$$ *($$int$$, d
 $$host$$:: $$the host name for the FTP server$$ *($$String$$, default: `localhost`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
 $$localDir$$:: $$set the local directory the remote files are transferred to$$ *($$String$$, default: `/tmp/xd/ftp`)*
+$$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$, default: `-1`)*
 $$mode$$:: $$specifies how the file is being read. By default the content of a file is provided as byte array$$ *($$FileReadingMode$$, default: `contents`, possible values: `ref,lines,contents`)*
 $$password$$:: $$the password for the FTP connection$$ *($$Password$$, no default)*
 $$port$$:: $$the port for the FTP server$$ *($$int$$, default: `21`)*
@@ -163,6 +164,7 @@ $$fixedDelay$$:: $$fixed delay in SECONDS to poll the remote directory$$ *($$int
 $$host$$:: $$the remote host to connect to$$ *($$String$$, default: `localhost`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
 $$localDir$$:: $$set the local directory the remote files are transferred to$$ *($$String$$, default: `/tmp/xd/output`)*
+$$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$, default: `-1`)*
 $$mode$$:: $$specifies how the file is being read. By default the content of a file is provided as byte array$$ *($$FileReadingMode$$, default: `contents`, possible values: `ref,lines,contents`)*
 $$passPhrase$$:: $$the passphrase to use$$ *($$String$$, default: ``)*
 $$password$$:: $$the password for the provided user$$ *($$String$$, default: ``)*
@@ -280,6 +282,7 @@ The **$$file$$** $$source$$ has the following options:
 $$dir$$:: $$the absolute path to the directory to monitor for files$$ *($$String$$, default: `/tmp/xd/input/<stream name>`)*
 $$fixedDelay$$:: $$the fixed delay polling interval specified in seconds$$ *($$int$$, default: `5`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
+$$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$, default: `-1`)*
 $$mode$$:: $$specifies how the file is being read. By default the content of a file is provided as byte array$$ *($$FileReadingMode$$, default: `contents`, possible values: `ref,lines,contents`)*
 $$pattern$$:: $$a filter expression (Ant style) to accept only files that match the pattern$$ *($$String$$, default: `*`)*
 $$preventDuplicates$$:: $$whether to prevent the same file from being processed twice$$ *($$boolean$$, default: `true`)*
@@ -312,6 +315,7 @@ $$fixedDelay$$:: $$the polling interval used for looking up messages (s)$$ *($$i
 $$folder$$:: $$the folder to take emails from$$ *($$String$$, default: `INBOX`)*
 $$host$$:: $$the hostname of the mail server$$ *($$String$$, default: `localhost`)*
 $$markAsRead$$:: $$whether to mark emails as read once they’ve been fetched$$ *($$boolean$$, default: `false`)*
+$$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$, default: `1`)*
 $$password$$:: $$the password to use to connect to the mail server $$ *($$String$$, no default)*
 $$port$$:: $$the port of the mail server$$ *($$int$$, default: `25`)*
 $$protocol$$:: $$the protocol to use to retrieve messages$$ *($$MailProtocol$$, default: `imap`, possible values: `imap,imaps,pop3,pop3s`)*
@@ -812,6 +816,7 @@ $$encoder$$:: $$the encoder to use when sending messages$$ *($$Encoding$$, defau
 $$expression$$:: $$a SpEL expression used to transform messages$$ *($$String$$, default: `payload.toString()`)*
 $$fixedDelay$$:: $$the rate at which stimulus messages will be emitted (seconds)$$ *($$int$$, default: `5`)*
 $$host$$:: $$the remote host to connect to$$ *($$String$$, default: `localhost`)*
+$$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$, default: `1`)*
 $$nio$$:: $$whether or not to use NIO$$ *($$boolean$$, default: `false`)*
 $$port$$:: $$the port on the remote host to connect to$$ *($$int$$, default: `1234`)*
 $$propertiesLocation$$:: $$the path of a properties file containing custom script variable bindings$$ *($$String$$, no default)*
@@ -1002,6 +1007,7 @@ The **$$time$$** $$source$$ has the following options:
 $$fixedDelay$$:: $$time delay between messages, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `1`)*
 $$format$$:: $$how to render the current time, using SimpleDateFormat$$ *($$String$$, default: `yyyy-MM-dd HH:mm:ss`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
+$$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$, default: `1`)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
 //$source.time
 
@@ -1150,6 +1156,7 @@ $$logAbandoned$$:: $$flag to log stack traces for application code which abandon
 $$maxActive$$:: $$maximum number of active connections that can be allocated from this pool at the same time$$ *($$int$$, default: `100`)*
 $$maxAge$$:: $$time in milliseconds to keep this connection$$ *($$int$$, default: `0`)*
 $$maxIdle$$:: $$maximum number of connections that should be kept in the pool at all times$$ *($$int$$, default: `100`)*
+$$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$, default: `1`)*
 $$maxRowsPerPoll$$:: $$max numbers of rows to process for each poll$$ *($$int$$, default: `0`)*
 $$maxWait$$:: $$maximum number of milliseconds that the pool will wait for a connection$$ *($$int$$, default: `30000`)*
 $$minEvictableIdleTimeMillis$$:: $$minimum amount of time an object may sit idle in the pool before it is eligible for eviction$$ *($$int$$, default: `60000`)*
@@ -1195,7 +1202,7 @@ $$databaseName$$:: $$the MongoDB database name$$ *($$String$$, default: `xd`)*
 $$fixedDelay$$:: $$the time delay between polls for data, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `1000`)*
 $$host$$:: $$the MongoDB host to connect to$$ *($$String$$, default: `localhost`)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
-$$maxMessages$$:: $$the maximum number of messages to get at a time$$ *($$int$$, default: `1`)*
+$$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$, default: `1`)*
 $$password$$:: $$the MongoDB password used for connecting$$ *($$String$$, default: ``)*
 $$port$$:: $$the MongoDB port to connect to$$ *($$int$$, default: `27017`)*
 $$query$$:: $$the query to make to the mongo db$$ *($$String$$, default: `{}`)*
@@ -1219,6 +1226,7 @@ $$date$$:: $$a one-time date when the trigger should fire; only applies if 'fixe
 $$dateFormat$$:: $$the format specifying how the 'date' should be parsed$$ *($$String$$, default: `MM/dd/yy HH:mm:ss`)*
 $$fixedDelay$$:: $$time delay between executions, expressed in TimeUnits (seconds by default)$$ *($$Integer$$, no default)*
 $$initialDelay$$:: $$an initial delay when using a fixed delay trigger, expressed in TimeUnits (seconds by default)$$ *($$int$$, default: `0`)*
+$$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$, default: `1`)*
 $$payload$$:: $$the message that will be sent when the trigger fires$$ *($$String$$, default: ``)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
 //$source.trigger


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-3063

Use default `-1` (unlimited) for file-based pollers and 1 (the current default)
for others.