### PR TITLE
[Sprint 49] XD-3083 Support running DSLs from cmd file

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
@@ -17,6 +17,7 @@
 package org.springframework.xd.dirt.rest;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +64,6 @@ public class JobsController extends
 		super(jobDeployer, new JobDefinitionResourceAssembler(), DeploymentUnitType.Job);
 	}
 
-	@Override
 	@RequestMapping(value = "/definitions", method = RequestMethod.POST)
 	@ResponseStatus(HttpStatus.CREATED)
 	public void save(@RequestParam("name") String name, @RequestParam("definition") String definition,
@@ -72,7 +72,11 @@ public class JobsController extends
 		if (distributedJobLocator.getJobNames().contains(name)) {
 			throw new BatchJobAlreadyExistsException(name);
 		}
-		super.save(name, definition, deploy);
+		validator.validateBeforeSave(name, definition);
+		deployer.save(new JobDefinition(name, definition));
+		if (deploy) {
+			publishDeploymentMessage(name, Collections.<String, String>emptyMap());
+		}
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
@@ -16,6 +16,7 @@
 
 package org.springframework.xd.dirt.rest;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -85,6 +86,23 @@ public class StreamsController extends
 			@RequestParam(required = false) String vhost,
 			@RequestParam(required = false) String busPrefix) {
 		return cleanRabbitBus(stream, adminUri, user, pw, vhost, busPrefix, false);
+	}
+
+	/**
+	 * Create a new resource definition.
+	 *
+	 * @param name The name of the entity to create (required)
+	 * @param definition The entity definition, expressed in the XD DSL (required)
+	 */
+	@RequestMapping(value = "/definitions", method = RequestMethod.POST)
+	@ResponseStatus(HttpStatus.CREATED)
+	public void save(@RequestParam("name") String name, @RequestParam("definition") String definition,
+			@RequestParam(value = "deploy", defaultValue = "true") boolean deploy) throws Exception {
+		validator.validateBeforeSave(name, definition);
+		deployer.save(new StreamDefinition(name, definition));
+		if (deploy) {
+			publishDeploymentMessage(name, Collections.<String, String>emptyMap());
+		}
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentAction.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentAction.java
@@ -21,8 +21,6 @@ package org.springframework.xd.dirt.server.admin.deployment;
  * @author Ilayaperumal Gopinathan
  */
 public enum DeploymentAction {
-	create,
-	createAndDeploy,
 	deploy,
 	undeploy,
 	destroy,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentMessageConsumer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentMessageConsumer.java
@@ -16,8 +16,6 @@
 
 package org.springframework.xd.dirt.server.admin.deployment.zk;
 
-import java.util.Collections;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.curator.framework.CuratorFramework;
@@ -28,9 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.xd.dirt.core.ResourceDeployer;
 import org.springframework.xd.dirt.server.admin.deployment.DeploymentAction;
 import org.springframework.xd.dirt.server.admin.deployment.DeploymentMessage;
-import org.springframework.xd.dirt.stream.JobDefinition;
 import org.springframework.xd.dirt.stream.JobDeployer;
-import org.springframework.xd.dirt.stream.StreamDefinition;
 import org.springframework.xd.dirt.stream.StreamDeployer;
 
 /**
@@ -86,19 +82,6 @@ public class DeploymentMessageConsumer implements QueueConsumer<DeploymentMessag
 		DeploymentAction deploymentAction = deploymentMessage.getDeploymentAction();
 		String name = deploymentMessage.getUnitName();
 		switch (deploymentAction) {
-			case create:
-			case createAndDeploy: {
-				if (deployer instanceof StreamDeployer) {
-					deployer.save(new StreamDefinition(name, deploymentMessage.getDefinition()));
-				}
-				else if (deployer instanceof JobDeployer) {
-					deployer.save(new JobDefinition(name, deploymentMessage.getDefinition()));
-				}
-				if (DeploymentAction.createAndDeploy.equals(deploymentAction)) {
-					deployer.deploy(name, Collections.<String, String>emptyMap());
-				}
-				break;
-			}
 			case deploy:
 				deployer.deploy(name, deploymentMessage.getDeploymentProperties());
 				break;


### PR DESCRIPTION
 - Now the Streams/JobsController saves the stream/job definitions while all
the deployment requests are published into ZK distributed queue.
 - Remove `create` and `createAndDeploy` actions from DeploymentAction enum