### PR TITLE
[Sprint: 49] XD-3072 Parser endpoint

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/DocumentParseResultResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/DocumentParseResultResourceAssembler.java
@@ -18,6 +18,8 @@
 
 package org.springframework.xd.dirt.rest;
 
+import com.google.common.collect.Lists;
+
 import org.springframework.hateoas.ResourceAssembler;
 import org.springframework.xd.dirt.stream.DocumentParseResult;
 import org.springframework.xd.dirt.stream.dsl.StreamDefinitionException;
@@ -25,15 +27,12 @@ import org.springframework.xd.module.ModuleDescriptor;
 import org.springframework.xd.rest.domain.DocumentParseResultResource;
 import org.springframework.xd.rest.domain.RESTModuleType;
 
-import com.google.common.collect.Lists;
-
 /**
  * This class is responsible for creating a REST representation of a DocumentParseResult.
  *
  * @author Eric Bottard
  */
-public class DocumentParseResultResourceAssembler implements
-		ResourceAssembler<DocumentParseResult, DocumentParseResultResource> {
+public class DocumentParseResultResourceAssembler implements ResourceAssembler<DocumentParseResult, DocumentParseResultResource> {
 
 	@Override
 	public DocumentParseResultResource toResource(DocumentParseResult entity) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DocumentParseResult.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DocumentParseResult.java
@@ -31,7 +31,7 @@ import org.springframework.xd.module.ModuleDescriptor;
  *
  * @author Eric Bottard
  */
-public class DocumentParseResult implements Iterable<DocumentParseResult.Line>{
+public class DocumentParseResult implements Iterable<DocumentParseResult.Line> {
 
 	private List<Line> lines;
 
@@ -39,8 +39,8 @@ public class DocumentParseResult implements Iterable<DocumentParseResult.Line>{
 		lines = new ArrayList<>(size);
 	}
 
-	public void success(List<ModuleDescriptor> descriptors) {
-		lines.add(new Line(descriptors));
+	public void success(List<ModuleDescriptor> descriptors, List<Exception> errors) {
+		lines.add(new Line(descriptors, errors));
 	}
 
 	public void failure(Exception e) {
@@ -58,22 +58,29 @@ public class DocumentParseResult implements Iterable<DocumentParseResult.Line>{
 	 * @author Eric Bottard
 	 */
 	public static class Line {
+
 		private final List<ModuleDescriptor> descriptors;
 
-		private final Exception exception;
+		private final List<Exception> exceptions;
 
 		private Line(Exception e) {
-			this.exception = e;
+			this.exceptions = new ArrayList<>();
+			this.exceptions.add(e);
 			this.descriptors = null;
+		}
+
+		private Line(List<ModuleDescriptor> moduleDescriptors, List<Exception> errors) {
+			this.descriptors = moduleDescriptors;
+			this.exceptions = errors.size() > 0 ? errors : null;
 		}
 
 		private Line(List<ModuleDescriptor> moduleDescriptors) {
 			this.descriptors = moduleDescriptors;
-			this.exception = null;
+			this.exceptions = null;
 		}
 
-		public Exception getException() {
-			return exception;
+		public List<Exception> getExceptions() {
+			return exceptions;
 		}
 
 		public List<ModuleDescriptor> getDescriptors() {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
@@ -188,9 +188,9 @@ public class XDStreamParser implements XDParser {
 			catch (NoSuchModuleException nsme) {
 				if (errorAccumulator != null) {
 					errorAccumulator.add(nsme);
-					// 'processor' below effectively indicates 'unknown' - a caller passing an error accumulator
-					// should be aware that this can happen (the accumulator will contain
-					// the exception that indicates it did)
+					// 'processor' below effectively indicates 'unknown' - a caller passing an
+					// error accumulator should be aware that this can happen (the accumulator
+					// will contain the exception that indicates it did)
 					moduleType = ModuleType.processor;
 				}
 				else {
@@ -201,8 +201,8 @@ public class XDStreamParser implements XDParser {
 
 			ModuleDefinition moduleDefinition = moduleRegistry.findDefinition(builder.getModuleName(),
 					builder.getType());
-			builder.setModuleDefinition(moduleDefinition);
 			if (moduleDefinition != null) {
+				builder.setModuleDefinition(moduleDefinition);
 				ModuleOptionsMetadata optionsMetadata = moduleOptionsMetadataResolver.resolve(moduleDefinition);
 				if (parsingContext.shouldBindAndValidate()) {
 					try {
@@ -397,7 +397,7 @@ public class XDStreamParser implements XDParser {
 					}
 					List<Exception> errorAccumulator = new ArrayList<Exception>();
 					List<ModuleDescriptor> moduleDescriptors = delegate.buildModuleDescriptors(streamName,
-							nameAndDefinitionPair, ParsingContext.stream, stream, errorAccumulator);
+							nameAndDefinitionPair, ParsingContext.partial_stream, stream, errorAccumulator);
 					BaseDefinition streamDefinition = new StreamDefinition(streamName, nameAndDefinitionPair);
 					transientRepository.save(streamDefinition);
 					result.success(moduleDescriptors, errorAccumulator);

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DocumentParseResultResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DocumentParseResultResource.java
@@ -19,7 +19,6 @@
 package org.springframework.xd.rest.domain;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,8 +49,6 @@ public class DocumentParseResultResource extends ResourceSupport {
 	 * @author Eric Bottard
 	 */
 	public static class Line {
-
-		private String group;
 
 		private List<Error> errors;
 
@@ -113,6 +110,11 @@ public class DocumentParseResultResource extends ResourceSupport {
 	public static class ModuleDescriptor {
 
 		/**
+		 * The group to which this module belongs.
+		 */
+		private String group;
+
+		/**
 		 * The effective label which uniquely identifies this module in the group. May be different from the name.
 		 */
 		private String label;
@@ -144,13 +146,19 @@ public class DocumentParseResultResource extends ResourceSupport {
 		 */
 		private String sinkChannelName;
 
-		public ModuleDescriptor(String moduleLabel, RESTModuleType type, String name, String sourceChannelName, String sinkChannelName, Map<String, String> options) {
+		public ModuleDescriptor(String group, String moduleLabel, RESTModuleType type, String name,
+				String sourceChannelName, String sinkChannelName, Map<String, String> options) {
+			this.group = group;
 			this.label = moduleLabel;
 			this.type = type;
 			this.name = name;
 			this.sourceChannelName = sourceChannelName;
 			this.sinkChannelName = sinkChannelName;
 			this.options = options;
+		}
+
+		public String getGroup() {
+			return group;
 		}
 
 		public String getLabel() {


### PR DESCRIPTION
Modifications to the parse endpoint to make it work better for tools. It now:

- attempts to continue processing in the case of an error.

- records a parsed structure in the response and all exceptions that occurred (not just the first one)

If there is something still lacking it is that the NoSuchModuleException does not get record the position in the DSL string of where the problem module is. But let's get this first bit done first.


With these changes, this will actually return a structure:

     curl http://localhost:9393/tools/parse\?definitions\=time

as will this:

     curl http://localhost:9393/tools/parse\?definitions\=foo\=time\|l:%20log%20--name2\=foo