### PR TITLE
[Sprint 50] XD-3098 Message bus optimizations

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -70,6 +70,7 @@
 #    kafka:
 #      brokers:                                 localhost:9092
 #      zkAddress:                               localhost:2181
+#      mode:                                    embeddedHeaders
 #      numOfKafkaPartitionsForCountEqualsZero:  10
 #      socketBufferSize:                        2097152
 #      offsetStoreTopic:                        SpringXdOffsets
@@ -84,7 +85,6 @@
 #      offsetUpdateCount:                       0
 #      offsetUpdateShutdownTimeout:             2000
 #      default:
-#        batchingEnabled:           false
 #        batchSize:                 16384
 #        batchTimeout:              0
 #        replicationFactor:         1
@@ -92,7 +92,8 @@
 #        requiredAcks:              1
 #        compressionCodec:          none
 #        autoCommitEnabled:         true
-#        queueSize:                 1000
+#        queueSize:                 1024
+#        maxWait:                   100
 #        fetchSize:                 1048576
 #        minPartitionCount:         1
 

--- a/spring-xd-benchmark/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportBenchmarkTests.java
+++ b/spring-xd-benchmark/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportBenchmarkTests.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.util.MimeTypeUtils;
 import org.springframework.util.StopWatch;
 import org.springframework.xd.dirt.integration.bus.serializer.AbstractCodec;
 import org.springframework.xd.dirt.integration.bus.serializer.CompositeCodec;
@@ -91,8 +90,8 @@ ms     %     Task name
 		Message<?> message = new GenericMessage(payload);
 		int ITERATIONS = 1000000;
 		for (int i = 0; i < ITERATIONS; i++) {
-			MessageValues msg = messageBusSupport.serializePayloadIfNecessary(message,
-					MimeTypeUtils.APPLICATION_OCTET_STREAM);
+			MessageValues msg = messageBusSupport.serializePayloadIfNecessary(message
+			);
 			messageBusSupport.deserializePayloadIfNecessary(msg.toMessage());
 			if (i > 0 && i % 100000 == 0) {
 				System.out.println("completed " + i + " iterations.");

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -150,7 +150,7 @@ xd:
     kafka:
       brokers:                                 localhost:9092
       zkAddress:                               localhost:2181
-      numOfKafkaPartitionsForCountEqualsZero:  10
+      mode:                                    embeddedHeaders
       socketBufferSize:                        2097152
       offsetStoreTopic:                        SpringXdOffsets
       offsetStoreSegmentSize:                  25000000
@@ -170,7 +170,8 @@ xd:
         requiredAcks:              1
         compressionCodec:          none
         autoCommitEnabled:         true
-        queueSize:                 1000
+        queueSize:                 1024 # must be a power of 2
+        maxWait:                   100
         fetchSize:                 1048576
         minPartitionCount:         1
   security:

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportTests.java
@@ -68,8 +68,8 @@ public class MessageBusSupportTests {
 	public void testBytesPassThru() {
 		byte[] payload = "foo".getBytes();
 		Message<byte[]> message = MessageBuilder.withPayload(payload).build();
-		MessageValues converted = messageBus.serializePayloadIfNecessary(message,
-				MimeTypeUtils.APPLICATION_OCTET_STREAM);
+		MessageValues converted = messageBus.serializePayloadIfNecessary(message
+		);
 		assertSame(payload, converted.getPayload());
 		Message<?> convertedMessage = converted.toMessage();
 		assertSame(payload, convertedMessage.getPayload());
@@ -87,8 +87,8 @@ public class MessageBusSupportTests {
 		Message<byte[]> message = MessageBuilder.withPayload(payload)
 				.setHeader(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE)
 				.build();
-		MessageValues messageValues = messageBus.serializePayloadIfNecessary(message,
-				MimeTypeUtils.APPLICATION_OCTET_STREAM);
+		MessageValues messageValues = messageBus.serializePayloadIfNecessary(message
+		);
 		Message<?> converted = messageValues.toMessage();
 		assertSame(payload, converted.getPayload());
 		assertEquals(MimeTypeUtils.APPLICATION_OCTET_STREAM,
@@ -104,7 +104,7 @@ public class MessageBusSupportTests {
 	@Test
 	public void testString() throws IOException {
 		MessageValues convertedValues = messageBus.serializePayloadIfNecessary(
-				new GenericMessage<String>("foo"), MimeTypeUtils.APPLICATION_OCTET_STREAM);
+				new GenericMessage<String>("foo"));
 
 		Message<?> converted = convertedValues.toMessage();
 		assertEquals(MimeTypeUtils.TEXT_PLAIN,
@@ -120,7 +120,7 @@ public class MessageBusSupportTests {
 				.copyHeaders(Collections.singletonMap(MessageHeaders.CONTENT_TYPE, MimeTypeUtils.APPLICATION_JSON))
 				.build();
 		MessageValues convertedValues = messageBus.serializePayloadIfNecessary(
-				inbound, MimeTypeUtils.APPLICATION_OCTET_STREAM);
+				inbound);
 
 		Message<?> converted = convertedValues.toMessage();
 
@@ -136,8 +136,8 @@ public class MessageBusSupportTests {
 	@Test
 	public void testPojoSerialization() {
 		MessageValues convertedValues = messageBus.serializePayloadIfNecessary(
-				new GenericMessage<Foo>(new Foo("bar")),
-				MimeTypeUtils.APPLICATION_OCTET_STREAM);
+				new GenericMessage<Foo>(new Foo("bar"))
+		);
 		Message<?> converted = convertedValues.toMessage();
 		MimeType mimeType = contentTypeResolver.resolve(converted.getHeaders());
 		assertEquals("application", mimeType.getType());
@@ -152,8 +152,8 @@ public class MessageBusSupportTests {
 	@Test
 	public void testPojoWithXJavaObjectMimeTypeNoType() {
 		MessageValues convertedValues = messageBus.serializePayloadIfNecessary(
-				new GenericMessage<Foo>(new Foo("bar")),
-				MimeTypeUtils.APPLICATION_OCTET_STREAM);
+				new GenericMessage<Foo>(new Foo("bar"))
+		);
 		Message<?> converted = convertedValues.toMessage();
 		MimeType mimeType = contentTypeResolver.resolve(converted.getHeaders());
 		assertEquals("application", mimeType.getType());
@@ -168,8 +168,8 @@ public class MessageBusSupportTests {
 	@Test
 	public void testPojoWithXJavaObjectMimeTypeExplicitType() {
 		MessageValues convertedValues = messageBus.serializePayloadIfNecessary(
-				new GenericMessage<Foo>(new Foo("bar")),
-				MimeTypeUtils.APPLICATION_OCTET_STREAM);
+				new GenericMessage<Foo>(new Foo("bar"))
+		);
 		Message<?> converted = convertedValues.toMessage();
 		MimeType mimeType = contentTypeResolver.resolve(converted.getHeaders());
 		assertEquals("application", mimeType.getType());
@@ -184,8 +184,8 @@ public class MessageBusSupportTests {
 	@Test
 	public void testTupleSerialization() {
 		Tuple payload = TupleBuilder.tuple().of("foo", "bar");
-		MessageValues convertedValues = messageBus.serializePayloadIfNecessary(new GenericMessage<Tuple>(payload),
-				MimeTypeUtils.APPLICATION_OCTET_STREAM);
+		MessageValues convertedValues = messageBus.serializePayloadIfNecessary(new GenericMessage<Tuple>(payload)
+		);
 		Message<?> converted = convertedValues.toMessage();
 		MimeType mimeType = contentTypeResolver.resolve(converted.getHeaders());
 		assertEquals("application", mimeType.getType());

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
@@ -75,9 +75,13 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 	@Override
 	protected MessageBus getMessageBus() {
 		if (messageBus == null) {
-			messageBus = new KafkaTestMessageBus(kafkaTestSupport, getCodec());
+			messageBus = createKafkaTestMessageBus();
 		}
 		return messageBus;
+	}
+
+	protected KafkaTestMessageBus createKafkaTestMessageBus() {
+		return new KafkaTestMessageBus(kafkaTestSupport, getCodec(), KafkaMessageBus.Mode.embeddedHeaders);
 	}
 
 	@Override
@@ -228,6 +232,7 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 		messageBus.unbindProducers("foo" + uniqueBindingId + ".0");
 		messageBus.unbindConsumers("foo" + uniqueBindingId + ".0");
 	}
+
 
 	@Test
 	@Ignore("Kafka message bus does not support direct binding")

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
@@ -43,11 +43,11 @@ import org.springframework.xd.tuple.Tuple;
 public class KafkaTestMessageBus extends AbstractTestMessageBus<KafkaMessageBus> {
 
 	public KafkaTestMessageBus(KafkaTestSupport kafkaTestSupport) {
-		this(kafkaTestSupport, getCodec());
+		this(kafkaTestSupport, getCodec(), KafkaMessageBus.Mode.embeddedHeaders);
 	}
 
 
-	public KafkaTestMessageBus(KafkaTestSupport kafkaTestSupport, MultiTypeCodec<Object> codec) {
+	public KafkaTestMessageBus(KafkaTestSupport kafkaTestSupport, MultiTypeCodec<Object> codec, KafkaMessageBus.Mode mode) {
 
 		try {
 			ZookeeperConnect zookeeperConnect = new ZookeeperConnect();
@@ -56,6 +56,7 @@ public class KafkaTestMessageBus extends AbstractTestMessageBus<KafkaMessageBus>
 					kafkaTestSupport.getBrokerAddress(),
 					kafkaTestSupport.getZkConnectString(), codec);
 			messageBus.setDefaultBatchingEnabled(false);
+			messageBus.setMode(mode);
 			messageBus.afterPropertiesSet();
 			GenericApplicationContext context = new GenericApplicationContext();
 			context.refresh();

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawKafkaPartitionTestSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawKafkaPartitionTestSupport.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus.kafka;
+
+import org.springframework.messaging.Message;
+import org.springframework.xd.dirt.integration.bus.PartitionKeyExtractorStrategy;
+import org.springframework.xd.dirt.integration.bus.PartitionSelectorStrategy;
+
+
+/**
+ * 
+ * @author Marius Bogoevici
+ */
+public class RawKafkaPartitionTestSupport implements PartitionKeyExtractorStrategy, PartitionSelectorStrategy {
+
+	@Override
+	public int selectPartition(Object key, int divisor) {
+		return ((byte[])key)[0] % divisor;
+	}
+
+	@Override
+	public Object extractKey(Message<?> message) {
+		return message.getPayload();
+	}
+
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright ${today.year} the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.integration.bus.kafka;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import jdk.nashorn.internal.ir.annotations.Ignore;
+import org.junit.Test;
+
+import org.springframework.amqp.utils.test.TestUtils;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.channel.interceptor.WireTap;
+import org.springframework.integration.endpoint.AbstractEndpoint;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.xd.dirt.integration.bus.Binding;
+import org.springframework.xd.dirt.integration.bus.BusProperties;
+import org.springframework.xd.dirt.integration.bus.MessageBus;
+import org.springframework.xd.dirt.integration.bus.XdHeaders;
+import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
+
+/**
+ * @author Marius Bogoevici
+ */
+public class RawModeKafkaMessageBusTests extends KafkaMessageBusTests {
+
+	@Override
+	protected KafkaTestMessageBus createKafkaTestMessageBus() {
+		return new KafkaTestMessageBus(kafkaTestSupport, getCodec(), KafkaMessageBus.Mode.raw);
+	}
+
+	@Test
+	@Override
+	public void testPartitionedModuleJava() throws Exception {
+		MessageBus bus = getMessageBus();
+		Properties properties = new Properties();
+		properties.put("partitionKeyExtractorClass", "org.springframework.xd.dirt.integration.bus.kafka.RawKafkaPartitionTestSupport");
+		properties.put("partitionSelectorClass", "org.springframework.xd.dirt.integration.bus.kafka.RawKafkaPartitionTestSupport");
+		properties.put("partitionCount", "3");
+		properties.put(BusProperties.NEXT_MODULE_CONCURRENCY, "2");
+
+		DirectChannel output = new DirectChannel();
+		output.setBeanName("test.output");
+		bus.bindProducer("partJ.0", output, properties);
+		@SuppressWarnings("unchecked")
+		List<Binding> bindings = TestUtils.getPropertyValue(bus, "messageBus.bindings", List.class);
+		assertEquals(1, bindings.size());
+
+		properties.clear();
+		properties.put("concurrency", "2");
+		properties.put("count","3");
+		properties.put("partitionIndex", "0");
+		QueueChannel input0 = new QueueChannel();
+		input0.setBeanName("test.input0J");
+		bus.bindConsumer("partJ.0", input0, properties);
+		properties.put("partitionIndex", "1");
+		QueueChannel input1 = new QueueChannel();
+		input1.setBeanName("test.input1J");
+		bus.bindConsumer("partJ.0", input1, properties);
+		properties.put("partitionIndex", "2");
+		QueueChannel input2 = new QueueChannel();
+		input2.setBeanName("test.input2J");
+		bus.bindConsumer("partJ.0", input2, properties);
+
+		output.send(new GenericMessage<>(new byte[]{(byte)0}));
+		output.send(new GenericMessage<>(new byte[]{(byte)1}));
+		output.send(new GenericMessage<>(new byte[]{(byte)2}));
+
+		Message<?> receive0 = input0.receive(1000);
+		assertNotNull(receive0);
+		Message<?> receive1 = input1.receive(1000);
+		assertNotNull(receive1);
+		Message<?> receive2 = input2.receive(1000);
+		assertNotNull(receive2);
+
+		assertThat(Arrays.asList(
+						((byte[]) receive0.getPayload())[0],
+						((byte[]) receive1.getPayload())[0],
+						((byte[]) receive2.getPayload())[0]),
+				containsInAnyOrder((byte)0, (byte)1, (byte)2));
+
+		bus.unbindConsumers("partJ.0");
+		bus.unbindProducers("partJ.0");
+	}
+
+	@Test
+	@Override
+	public void testPartitionedModuleSpEL() throws Exception {
+		MessageBus bus = getMessageBus();
+		Properties properties = new Properties();
+		properties.put("partitionKeyExpression", "payload[0]");
+		properties.put("partitionSelectorExpression", "hashCode()");
+		properties.put("partitionCount", "3");
+		properties.put(BusProperties.NEXT_MODULE_CONCURRENCY, "2");
+
+		DirectChannel output = new DirectChannel();
+		output.setBeanName("test.output");
+		bus.bindProducer("part.0", output, properties);
+		@SuppressWarnings("unchecked")
+		List<Binding> bindings = TestUtils.getPropertyValue(bus, "messageBus.bindings", List.class);
+		assertEquals(1, bindings.size());
+		try {
+			AbstractEndpoint endpoint = bindings.get(0).getEndpoint();
+			assertThat(getEndpointRouting(endpoint), containsString("part.0-' + headers['partition']"));
+		}
+		catch (UnsupportedOperationException ignored) {
+
+		}
+
+		properties.clear();
+		properties.put("concurrency", "2");
+		properties.put("partitionIndex", "0");
+		properties.put("count","3");
+		QueueChannel input0 = new QueueChannel();
+		input0.setBeanName("test.input0S");
+		bus.bindConsumer("part.0", input0, properties);
+		properties.put("partitionIndex", "1");
+		QueueChannel input1 = new QueueChannel();
+		input1.setBeanName("test.input1S");
+		bus.bindConsumer("part.0", input1, properties);
+		properties.put("partitionIndex", "2");
+		QueueChannel input2 = new QueueChannel();
+		input2.setBeanName("test.input2S");
+		bus.bindConsumer("part.0", input2, properties);
+
+		Message<byte[]> message2 = MessageBuilder.withPayload(new byte[]{2})
+				.setHeader(IntegrationMessageHeaderAccessor.CORRELATION_ID, "foo")
+				.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER, 42)
+				.setHeader(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, 43)
+				.setHeader("xdReplyChannel", "bar")
+				.build();
+		output.send(message2);
+		output.send(new GenericMessage<>(new byte[]{1}));
+		output.send(new GenericMessage<>(new byte[]{0}));
+
+		Message<?> receive0 = input0.receive(1000);
+		assertNotNull(receive0);
+		Message<?> receive1 = input1.receive(1000);
+		assertNotNull(receive1);
+		Message<?> receive2 = input2.receive(1000);
+		assertNotNull(receive2);
+
+
+		assertThat(Arrays.asList(
+						((byte[]) receive0.getPayload())[0],
+						((byte[]) receive1.getPayload())[0],
+						((byte[]) receive2.getPayload())[0]),
+				containsInAnyOrder((byte)0, (byte)1, (byte)2));
+
+		bus.unbindConsumers("part.0");
+		bus.unbindProducers("part.0");
+	}
+
+	@Test
+	@Override
+	public void createInboundPubSubBeforeOutboundPubSub() throws Exception {
+		MessageBus messageBus = getMessageBus();
+		DirectChannel moduleOutputChannel = new DirectChannel();
+		// Test pub/sub by emulating how StreamPlugin handles taps
+		DirectChannel tapChannel = new DirectChannel();
+		QueueChannel moduleInputChannel = new QueueChannel();
+		QueueChannel module2InputChannel = new QueueChannel();
+		QueueChannel module3InputChannel = new QueueChannel();
+		// Create the tap first
+		String fooTapName = messageBus.isCapable(MessageBus.Capability.DURABLE_PUBSUB) ? "foo.tap:baz.http" : "tap:baz.http";
+		messageBus.bindPubSubConsumer(fooTapName, module2InputChannel, null);
+
+		// Then create the stream
+		messageBus.bindProducer("baz.0", moduleOutputChannel, null);
+		messageBus.bindConsumer("baz.0", moduleInputChannel, null);
+		moduleOutputChannel.addInterceptor(new WireTap(tapChannel));
+		messageBus.bindPubSubProducer("tap:baz.http", tapChannel, null);
+
+		// Another new module is using tap as an input channel
+		String barTapName = messageBus.isCapable(MessageBus.Capability.DURABLE_PUBSUB) ? "bar.tap:baz.http" : "tap:baz.http";
+		messageBus.bindPubSubConsumer(barTapName, module3InputChannel, null);
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes()).setHeader(MessageHeaders.CONTENT_TYPE, "foo/bar").build();
+		boolean success = false;
+		boolean retried = false;
+		while (!success) {
+			moduleOutputChannel.send(message);
+			Message<?> inbound = moduleInputChannel.receive(5000);
+			assertNotNull(inbound);
+			assertEquals("foo", new String((byte[])inbound.getPayload()));
+			Message<?> tapped1 = module2InputChannel.receive(5000);
+			Message<?> tapped2 = module3InputChannel.receive(5000);
+			if (tapped1 == null || tapped2 == null) {
+				// listener may not have started
+				assertFalse("Failed to receive tap after retry", retried);
+				retried = true;
+				continue;
+			}
+			success = true;
+			assertEquals("foo", new String((byte[]) tapped1.getPayload()));
+			assertNull(tapped1.getHeaders().get(XdHeaders.XD_ORIGINAL_CONTENT_TYPE));
+			assertEquals("foo", new String((byte[])tapped2.getPayload()));
+		}
+		// delete one tap stream is deleted
+		messageBus.unbindConsumer(barTapName, module3InputChannel);
+		Message<?> message2 = MessageBuilder.withPayload("bar".getBytes()).setHeader(MessageHeaders.CONTENT_TYPE, "foo/bar").build();
+		moduleOutputChannel.send(message2);
+
+		// other tap still receives messages
+		Message<?> tapped = module2InputChannel.receive(5000);
+		assertNotNull(tapped);
+
+		// Removed tap does not
+		assertNull(module3InputChannel.receive(1000));
+
+		// when other tap stream is deleted
+		messageBus.unbindConsumer(fooTapName, module2InputChannel);
+		// Clean up as StreamPlugin would
+		messageBus.unbindConsumer("baz.0", moduleInputChannel);
+		messageBus.unbindProducer("baz.0", moduleOutputChannel);
+		messageBus.unbindProducers("tap:baz.http");
+		assertTrue(getBindings(messageBus).isEmpty());
+	}
+
+	@Test
+	@Override
+	public void testSendAndReceive() throws Exception {
+		MessageBus messageBus = getMessageBus();
+		DirectChannel moduleOutputChannel = new DirectChannel();
+		QueueChannel moduleInputChannel = new QueueChannel();
+		messageBus.bindProducer("foo.0", moduleOutputChannel, null);
+		messageBus.bindConsumer("foo.0", moduleInputChannel, null);
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes()).build();
+		// Let the consumer actually bind to the producer before sending a msg
+		busBindUnbindLatency();
+		moduleOutputChannel.send(message);
+		Message<?> inbound = moduleInputChannel.receive(5000);
+		assertNotNull(inbound);
+		assertEquals("foo", new String((byte[])inbound.getPayload()));
+		messageBus.unbindProducers("foo.0");
+		messageBus.unbindConsumers("foo.0");
+	}
+
+	// Ignored, since raw mode does not support headers
+	@Test
+	@Override
+	@Ignore
+	public void testSendAndReceiveNoOriginalContentType() throws Exception {
+
+	}
+
+	@Test
+	public void testSendAndReceivePubSub() throws Exception {
+		MessageBus messageBus = getMessageBus();
+		DirectChannel moduleOutputChannel = new DirectChannel();
+		// Test pub/sub by emulating how StreamPlugin handles taps
+		DirectChannel tapChannel = new DirectChannel();
+		QueueChannel moduleInputChannel = new QueueChannel();
+		QueueChannel module2InputChannel = new QueueChannel();
+		QueueChannel module3InputChannel = new QueueChannel();
+		messageBus.bindProducer("baz.0", moduleOutputChannel, null);
+		messageBus.bindConsumer("baz.0", moduleInputChannel, null);
+		moduleOutputChannel.addInterceptor(new WireTap(tapChannel));
+		messageBus.bindPubSubProducer("tap:baz.http", tapChannel, null);
+		// A new module is using the tap as an input channel
+		String fooTapName = messageBus.isCapable(MessageBus.Capability.DURABLE_PUBSUB) ? "foo.tap:baz.http" : "tap:baz.http";
+		messageBus.bindPubSubConsumer(fooTapName, module2InputChannel, null);
+		// Another new module is using tap as an input channel
+		String barTapName = messageBus.isCapable(MessageBus.Capability.DURABLE_PUBSUB) ? "bar.tap:baz.http" : "tap:baz.http";
+		messageBus.bindPubSubConsumer(barTapName, module3InputChannel, null);
+		Message<?> message = MessageBuilder.withPayload("foo".getBytes()).build();
+		boolean success = false;
+		boolean retried = false;
+		while (!success) {
+			moduleOutputChannel.send(message);
+			Message<?> inbound = moduleInputChannel.receive(5000);
+			assertNotNull(inbound);
+			assertEquals("foo", new String((byte[])inbound.getPayload()));
+
+			Message<?> tapped1 = module2InputChannel.receive(5000);
+			Message<?> tapped2 = module3InputChannel.receive(5000);
+			if (tapped1 == null || tapped2 == null) {
+				// listener may not have started
+				assertFalse("Failed to receive tap after retry", retried);
+				retried = true;
+				continue;
+			}
+			success = true;
+			assertEquals("foo", new String((byte[])tapped1.getPayload()));
+			assertEquals("foo", new String((byte[])tapped2.getPayload()));
+		}
+		// delete one tap stream is deleted
+		messageBus.unbindConsumer(barTapName, module3InputChannel);
+		Message<?> message2 = MessageBuilder.withPayload("bar".getBytes()).build();
+		moduleOutputChannel.send(message2);
+
+		// other tap still receives messages
+		Message<?> tapped = module2InputChannel.receive(5000);
+		assertNotNull(tapped);
+
+		// Removed tap does not
+		assertNull(module3InputChannel.receive(1000));
+
+		// when other tap stream is deleted
+		messageBus.unbindConsumer(fooTapName, module2InputChannel);
+		// Clean up as StreamPlugin would
+		messageBus.unbindConsumer("baz.0", moduleInputChannel);
+		messageBus.unbindProducer("baz.0", moduleOutputChannel);
+		messageBus.unbindProducers("tap:baz.http");
+		assertTrue(getBindings(messageBus).isEmpty());
+	}
+
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
@@ -383,7 +383,7 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 				if (bytes == null) {
 					return null;
 				}
-				bytes = embeddedHeadersMessageConverter.extractHeaders(new GenericMessage<byte[]>(bytes), false).getPayload();
+				bytes = (byte[]) embeddedHeadersMessageConverter.extractHeaders(new GenericMessage<byte[]>(bytes), false).getPayload();
 				return new String(bytes, "UTF-8");
 			}
 

--- a/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
+++ b/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
@@ -18,6 +18,8 @@
 		<constructor-arg ref="codec"/>
 		<constructor-arg value="#{new String[0]}"/>
 
+		<property name="mode" value="${xd.messagebus.kafka.mode}"/>
+
 		<!-- Producer properties -->
 		<property name="defaultBatchSize" value="${xd.messagebus.kafka.default.batchSize}"/>
 		<property name="defaultBatchTimeout" value="${xd.messagebus.kafka.default.batchTimeout}"/>

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -83,7 +83,6 @@ import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.MimeTypeUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.xd.dirt.integration.bus.AbstractBusPropertiesAccessor;
 import org.springframework.xd.dirt.integration.bus.Binding;
@@ -878,8 +877,8 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 
 		@Override
 		protected void handleMessageInternal(Message<?> message) throws Exception {
-			MessageValues messageToSend = serializePayloadIfNecessary(message,
-					MimeTypeUtils.APPLICATION_OCTET_STREAM);
+			MessageValues messageToSend = serializePayloadIfNecessary(message
+			);
 
 			if (replyTo != null) {
 				messageToSend.put(AmqpHeaders.REPLY_TO, this.replyTo);

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageValues.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageValues.java
@@ -46,6 +46,11 @@ public class MessageValues implements Map<String, Object> {
 		}
 	}
 
+	public MessageValues(Object payload, Map<String,Object> headers) {
+		this.payload = payload;
+		this.headers.putAll(headers);
+	}
+
 	/**
 	 * @return the payload
 	 */
@@ -138,5 +143,13 @@ public class MessageValues implements Map<String, Object> {
 	@Override
 	public Set<Entry<String, Object>> entrySet() {
 		return headers.entrySet();
+	}
+
+	public void copyHeadersIfAbsent(Map<String,Object> headersToCopy) {
+		for (Entry<String, Object> headersToCopyEntry	 : headersToCopy.entrySet()) {
+			if (!containsKey(headersToCopyEntry.getKey())) {
+				put(headersToCopyEntry.getKey(), headersToCopyEntry.getValue());
+			}
+		}
 	}
 }

--- a/spring-xd-messagebus-spi/src/test/java/org/springframework/xd/dirt/integration/bus/MessageConverterTests.java
+++ b/spring-xd-messagebus-spi/src/test/java/org/springframework/xd/dirt/integration/bus/MessageConverterTests.java
@@ -42,15 +42,15 @@ public class MessageConverterTests {
 				.setHeader("foo", "bar")
 				.setHeader("baz", "quxx")
 				.build();
-		Message<byte[]> converted = converter.embedHeaders(message, "foo", "baz");
-		assertEquals(0xff, converted.getPayload()[0] & 0xff);
+		byte[] embedded = converter.embedHeaders(new MessageValues(message), "foo", "baz");
+		assertEquals(0xff, embedded[0] & 0xff);
 		assertEquals("\u0002\u0003foo\u0000\u0000\u0000\u0005\"bar\"\u0003baz\u0000\u0000\u0000\u0006\"quxx\"Hello",
-				new String(converted.getPayload()).substring(1));
+				new String(embedded).substring(1));
 
-		converted = converter.extractHeaders(converted,false);
-		assertEquals("Hello", new String(converted.getPayload()));
-		assertEquals("bar", converted.getHeaders().get("foo"));
-		assertEquals("quxx", converted.getHeaders().get("baz"));
+		MessageValues extracted = converter.extractHeaders(MessageBuilder.withPayload(embedded).build(), false);
+		assertEquals("Hello", new String((byte[])extracted.getPayload()));
+		assertEquals("bar", extracted.get("foo"));
+		assertEquals("quxx", extracted.get("baz"));
 	}
 
 	@Test
@@ -59,10 +59,10 @@ public class MessageConverterTests {
 		Message<byte[]> message = MessageBuilder.withPayload("Hello".getBytes())
 				.setHeader("foo", "bar")
 				.build();
-		Message<byte[]> converted = converter.embedHeaders(message, "foo", "baz");
-		assertEquals(0xff, converted.getPayload()[0] & 0xff);
+		byte[] embedded = converter.embedHeaders(new MessageValues(message), "foo", "baz");
+		assertEquals(0xff, embedded[0] & 0xff);
 		assertEquals("\u0001\u0003foo\u0000\u0000\u0000\u0005\"bar\"Hello",
-				new String(converted.getPayload()).substring(1));
+				new String(embedded).substring(1));
 	}
 
 	@Test
@@ -70,10 +70,10 @@ public class MessageConverterTests {
 		EmbeddedHeadersMessageConverter converter = new EmbeddedHeadersMessageConverter();
 		byte[] bytes = "\u0002\u0003foo\u0003bar\u0003baz\u0004quxxHello".getBytes("UTF-8");
 		Message<byte[]> message = new GenericMessage<byte[]>(bytes);
-		Message<byte[]> converted = converter.extractHeaders(message,false);
-		assertEquals("Hello", new String(converted.getPayload()));
-		assertEquals("bar", converted.getHeaders().get("foo"));
-		assertEquals("quxx", converted.getHeaders().get("baz"));
+		MessageValues extracted = converter.extractHeaders(message,false);
+		assertEquals("Hello", new String((byte[])extracted.getPayload()));
+		assertEquals("bar", extracted.get("foo"));
+		assertEquals("quxx", extracted.get("baz"));
 	}
 
 	@Test

--- a/spring-xd-yarn/site/config/servers.yml
+++ b/spring-xd-yarn/site/config/servers.yml
@@ -163,7 +163,7 @@ xd:
 #    kafka:
 #      brokers:                                 localhost:9092
 #      zkAddress:                               localhost:2181
-#      numOfKafkaPartitionsForCountEqualsZero:  10
+#      mode:                                    embeddedHeaders
 #      socketBufferSize:                        2097152
 #      offsetStoreTopic:                        SpringXdOffsets
 #      offsetStoreSegmentSize:                  25000000
@@ -177,7 +177,6 @@ xd:
 #      offsetUpdateCount:                       0
 #      offsetUpdateShutdownTimeout:             2000
 #      default:
-#        batchingEnabled:           false
 #        batchSize:                 16384
 #        batchTimeout:              0
 #        replicationFactor:         1


### PR DESCRIPTION
- Optimize mimetype determination: avoid parsing for each incoming mesage
- Optmize embed headers: embed without creating new `Message` instances
- Consumer improvements: preserve existing functionality while minimizing `Message` instances creation
- Kafka Message Bus improvements : add 'mode' for header- and synchronization-less bus transport;
- Add wait time parameter for Kafka client
- Fix configurability of buffered bytes for Kafka message bus producer
- Add tests