### PR TITLE
[Sprint: 50] XD-3079 Hadoop kerberos config not used in jobs

### DIFF
--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests-context.xml
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests-context.xml
@@ -3,23 +3,13 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
 		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
 		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
-
-	<context:property-placeholder properties-ref="props"/>
-
-	<util:properties id="props">
-		<prop key="restartable">false</prop>
-		<prop key="xd.config.home">file:../../config</prop>
-		<prop key="partitionResultsTimeout">3600000</prop>
-	</util:properties>
 
 	<import resource="file:../../modules/job/ftphdfs/config/ftphdfs.xml" />
 

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests.java
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -35,7 +36,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -46,6 +46,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.data.hadoop.test.context.HadoopDelegatingSmartContextLoader;
 import org.springframework.data.hadoop.test.context.MiniHadoopCluster;
 import org.springframework.integration.file.remote.session.Session;
@@ -103,6 +104,12 @@ public class RemoteFileToHadoopTests {
 		ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext();
 		ctx.setConfigLocations("org/springframework/batch/integration/x/RemoteFileToHadoopTests-context.xml",
 				"org/springframework/batch/integration/x/miniclusterconfig.xml");
+		Properties properties = new Properties();
+		properties.setProperty("restartable", "false");
+		properties.setProperty("xd.config.home", "file:../../config");
+		properties.setProperty("partitionResultsTimeout", "3600000");
+		PropertiesPropertySource propertiesPropertySource = new PropertiesPropertySource("props", properties);
+		ctx.getEnvironment().getPropertySources().addLast(propertiesPropertySource);
 		ctx.setParent(context);
 		ctx.refresh();
 

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests-context.xml
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests-context.xml
@@ -3,24 +3,15 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
 		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
 
 	<import resource="file:../../modules/job/ftphdfs/config/ftphdfs.xml" />
-
-	<context:property-placeholder properties-ref="props"/>
-
-	<util:properties id="props">
-		<prop key="restartable">false</prop>
-		<prop key="partitionResultsTimeout">3600000</prop>
-	</util:properties>
 
 	<bean id="jobLauncher" class="org.springframework.batch.core.launch.support.SimpleJobLauncher">
 		<property name="jobRepository" ref="jobRepository" />

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests.java
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests.java
@@ -38,7 +38,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -60,6 +59,7 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
@@ -72,6 +72,7 @@ import org.springframework.xd.dirt.integration.bus.local.LocalMessageBus;
  * @author Gary Russell
  */
 @ContextConfiguration
+@TestPropertySource(properties = { "restartable = false", "partitionResultsTimeout = 3600000", "xd.config.home = file:../../config" })
 @RunWith(SpringJUnit4ClassRunner.class)
 public class RemoteFileToTmpTests {
 

--- a/modules/job/filepollhdfs/config/filepollhdfs.xml
+++ b/modules/job/filepollhdfs/config/filepollhdfs.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
 		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
 
@@ -57,7 +59,16 @@
 		<property name="configuration" ref="hadoopConfiguration"/>
 	</bean>
 
-	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
+	<context:property-placeholder location="${xd.config.home}/hadoop.properties"/>
+
+	<hdp:configuration
+		register-url-handler="false"
+		properties-location="${xd.config.home}/hadoop.properties"
+		security-method="${spring.hadoop.security.authMethod:}"
+		user-keytab="${spring.hadoop.security.userKeytab:}"
+		user-principal="${spring.hadoop.security.userPrincipal:}"
+		namenode-principal="${spring.hadoop.security.namenodePrincipal:}"
+		rm-manager-principal="${spring.hadoop.security.rmManagerPrincipal:}">
 		fs.defaultFS=${spring.hadoop.fsUri}
 	</hdp:configuration>
 

--- a/modules/job/ftphdfs/config/ftphdfs.xml
+++ b/modules/job/ftphdfs/config/ftphdfs.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:int-ftp="http://www.springframework.org/schema/integration/ftp"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration/ftp http://www.springframework.org/schema/integration/ftp/spring-integration-ftp-4.0.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
@@ -51,7 +53,16 @@
 		<constructor-arg ref="sessionFactory" />
 	</bean>
 
-	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
+	<context:property-placeholder location="${xd.config.home}/hadoop.properties"/>
+
+	<hdp:configuration
+		register-url-handler="false"
+		properties-location="${xd.config.home}/hadoop.properties"
+		security-method="${spring.hadoop.security.authMethod:}"
+		user-keytab="${spring.hadoop.security.userKeytab:}"
+		user-principal="${spring.hadoop.security.userPrincipal:}"
+		namenode-principal="${spring.hadoop.security.namenodePrincipal:}"
+		rm-manager-principal="${spring.hadoop.security.rmManagerPrincipal:}">
 		fs.defaultFS=${fsUri}
 	</hdp:configuration>
 	<hdp:resource-loader id="hadoopResourceLoader"/>

--- a/modules/job/hdfsjdbc/config/hdfsjdbc.xml
+++ b/modules/job/hdfsjdbc/config/hdfsjdbc.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	xmlns:batch="http://www.springframework.org/schema/batch"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
 		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
 
@@ -95,7 +97,16 @@
 		<property name="configuration" ref="hadoopConfiguration"/>
 	</bean>
 
-	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
+	<context:property-placeholder location="${xd.config.home}/hadoop.properties"/>
+
+	<hdp:configuration
+		register-url-handler="false"
+		properties-location="${xd.config.home}/hadoop.properties"
+		security-method="${spring.hadoop.security.authMethod:}"
+		user-keytab="${spring.hadoop.security.userKeytab:}"
+		user-principal="${spring.hadoop.security.userPrincipal:}"
+		namenode-principal="${spring.hadoop.security.namenodePrincipal:}"
+		rm-manager-principal="${spring.hadoop.security.rmManagerPrincipal:}">
 		fs.defaultFS=${fsUri}
 	</hdp:configuration>
 	<hdp:resource-loader id="hadoopResourceLoader"/>

--- a/modules/job/hdfsmongodb/config/hdfsmongodb.xml
+++ b/modules/job/hdfsmongodb/config/hdfsmongodb.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:hdp="http://www.springframework.org/schema/hadoop"
 	   xmlns:mongo="http://www.springframework.org/schema/data/mongo"
 	   xmlns:batch="http://www.springframework.org/schema/batch"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
 		http://www.springframework.org/schema/data/mongo http://www.springframework.org/schema/data/mongo/spring-mongo.xsd
 		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
@@ -52,7 +54,16 @@
 		<property name="configuration" ref="hadoopConfiguration"/>
 	</bean>
 
-	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
+	<context:property-placeholder location="${xd.config.home}/hadoop.properties"/>
+
+	<hdp:configuration
+		register-url-handler="false"
+		properties-location="${xd.config.home}/hadoop.properties"
+		security-method="${spring.hadoop.security.authMethod:}"
+		user-keytab="${spring.hadoop.security.userKeytab:}"
+		user-principal="${spring.hadoop.security.userPrincipal:}"
+		namenode-principal="${spring.hadoop.security.namenodePrincipal:}"
+		rm-manager-principal="${spring.hadoop.security.rmManagerPrincipal:}">
 		fs.defaultFS=${fsUri}
 	</hdp:configuration>
 	<hdp:resource-loader id="hadoopResourceLoader"/>

--- a/modules/job/jdbchdfs/config/jdbchdfs.xml
+++ b/modules/job/jdbchdfs/config/jdbchdfs.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
+		xmlns:context="http://www.springframework.org/schema/context"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:hdp="http://www.springframework.org/schema/hadoop"
 		xmlns:batch="http://www.springframework.org/schema/batch"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		http://www.springframework.org/schema/hadoop http://www.springframework.org/schema/hadoop/spring-hadoop.xsd
 		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
 
@@ -108,7 +110,16 @@
 		<property name="configuration" ref="hadoopConfiguration"/>
 	</bean>
 
-	<hdp:configuration register-url-handler="false" properties-location="${xd.config.home}/hadoop.properties">
+	<context:property-placeholder location="${xd.config.home}/hadoop.properties"/>
+
+	<hdp:configuration
+		register-url-handler="false"
+		properties-location="${xd.config.home}/hadoop.properties"
+		security-method="${spring.hadoop.security.authMethod:}"
+		user-keytab="${spring.hadoop.security.userKeytab:}"
+		user-principal="${spring.hadoop.security.userPrincipal:}"
+		namenode-principal="${spring.hadoop.security.namenodePrincipal:}"
+		rm-manager-principal="${spring.hadoop.security.rmManagerPrincipal:}">
 		fs.defaultFS=${fsUri}
 	</hdp:configuration>
 


### PR DESCRIPTION
- In XD-3079 user complained that kerberos tickets are
  not renewed. Due to missing kerberos config, these jobs
  doesn't even work with kerberized hdfs if job is only
  one accessing hdfs. Because hadoop sec config is a system
  wide setting in hadoop classes, jobs can access kerberized
  hdfs if i.e. hdfs sink first did a login.
- Having this proper sec config should allow jobs to work
  beyond kerberos tgt expire and renew times.
- Adding same sec config from hdfs sink to hdfsmongodb,
  hdfsjdbc, jdbchdfs, ftphdfs and filepollhdfs jobs.
- In hdfs/hdfs-dataset sinks we support security settings in both
  hadoop.properties and servers.yml, so property-placeholder
  is needed solely for hadoop.properties.
- In tests remove property-placeholder bean in favor of registering
  needed properties in context for everything to
  work with property-placeholder beans in job xml's.