### PR TITLE
XD-3103 Remove use of ResolvableType from SF and use custom helper class

### DIFF
--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandler.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandler.java
@@ -105,8 +105,7 @@ public class MultipleBroadcasterMessageHandler extends AbstractMessageProducingH
         // This by default create no dispatcher but provides for Timer if buffer(1, TimeUnit.Seconds) or similar is used
         Environment.initializeIfEmpty();
 
-        Method method = ReflectionUtils.findMethod(this.processor.getClass(), "process", Stream.class);
-        this.inputType = ResolvableType.forMethodParameter(method, 0).getNested(2).getRawClass();
+        this.inputType = ReactorReflectionUtils.extractGeneric(processor);
     }
 
     @Override

--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/ReactorReflectionUtils.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/ReactorReflectionUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.reactor;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Utility class for working with the reflection API for Reactor based processors.
+ *
+ * <p>Only intended for internal use.
+ *
+ * @author Stephane Maldini
+ * @author Mark Pollack
+ *
+ */
+public abstract class ReactorReflectionUtils {
+
+    /**
+     * Given the processor interface, determine it's input type parameter
+     * @param processor and instance of the processor interface
+     * @return the corresponding Class of the processor input type parameter, or null if can't
+     * be determined.
+     */
+    public static Class<?> extractGeneric(Processor<?, ?> processor) {
+        if (processor.getClass().getGenericInterfaces().length == 0) return null;
+
+        Type t = processor.getClass().getGenericInterfaces()[0];
+        if (ParameterizedType.class.isAssignableFrom(t.getClass())) {
+            ParameterizedType pt = (ParameterizedType) t;
+
+            if (pt.getActualTypeArguments().length == 0) return null;
+
+            t = pt.getActualTypeArguments()[0];
+            if (t instanceof ParameterizedType) {
+                return (Class) ((ParameterizedType) t).getRawType();
+            } else if (t instanceof Class) {
+                return (Class) t;
+            }
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
- Use of SoftReference in ResolvableType was introducing a NPE
- Add Messaging exception in the case of mismatched output type for processor