### PR TITLE
[Sprint 50] XD-3107 build fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,7 @@ configure(javaProjects) { subproject ->
 	dependencies {
 		versionManagement files(rootProject.file('dependencies.properties'))
 	}
+	startScripts.enabled = false
 
 	bootRepackage {
 		enabled = false
@@ -565,7 +566,7 @@ project('spring-xd-dirt') {
 	}
 
 	// skip the startScripts task to avoid default start script generation
-	startScripts.setEnabled(false)
+	startScripts.enabled = false
 	mainClassName = "org.springframework.xd.dirt.server.singlenode.SingleNodeApplication"
 
 	test {
@@ -799,10 +800,10 @@ project('spring-xd-gemfire-server') {
 	}
 	apply plugin: 'application'
 	// skip the startScripts task to avoid default start script generation
-	startScripts.setEnabled(false)
+	startScripts.enabled = false
 
 	task(launch, dependsOn: 'classes', type: JavaExec) {
-		main = 'org.springframework.xd.gemfire.CacheServer'
+		main = 'org.springframework.xd.gemfire.server.CacheServer'
 		classpath = sourceSets.test.runtimeClasspath
 		if (rootProject.hasProperty('config')) {
 			args = [
@@ -1174,7 +1175,7 @@ project('spring-xd-shell') {
 	}
 
 	// skip the startScripts task to avoid default start script generation
-	startScripts.setEnabled(false)
+	startScripts.enabled = false
 
 	task scriptFiles {
 		def scripts = file("$rootDir/scripts/shell")
@@ -1205,7 +1206,7 @@ project('spring-xd-batch') {
 	}
 	apply plugin: 'application'
 	// skip the startScripts task to avoid default start script generation
-	startScripts.setEnabled(false)
+	startScripts.enabled = false
 
 	task scriptFiles {
 		def scripts = file("$rootDir/scripts/hsqldb")

--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,7 @@ configure(javaProjects) { subproject ->
 		versionManagement files(rootProject.file('dependencies.properties'))
 	}
 	startScripts.enabled = false
+	distZip.enabled = false
 
 	bootRepackage {
 		enabled = false

--- a/documentation-toolchain/src/main/resources/logback.xml
+++ b/documentation-toolchain/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{ISO8601} %5p %t %c{2}:%L - %m%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="org.springframework.web.client.RestTemplate" level="ERROR"/>
+  <logger name="org.apache.hadoop.util.NativeCodeLoader" level="ERROR"/>
+  <root level="WARN">
+    <appender-ref ref="stdout"/>
+  </root>
+</configuration>

--- a/gradle/build-dist.gradle
+++ b/gradle/build-dist.gradle
@@ -85,13 +85,15 @@ task copyXDShellInstall(type: Copy, dependsOn: ["copyXDInstall", ":spring-xd-she
 
 task copyHadoopLibs {}
 
-[
+def hadoopDistros = [
 	'hadoop26',
 	'cdh5',
 	'hdp22',
 	'phd21',
 	'phd30'
-].each { distro ->
+]
+
+hadoopDistros.each { distro ->
 	tasks.create(name: "copyHadoopLibs-$distro", type: Copy) {
 		from project(":spring-xd-hadoop:$distro").copyToLib.outputs.files
 		into "$buildDir/dist/spring-xd/xd/lib/$distro"
@@ -321,7 +323,6 @@ task distYarnZip(type: Zip, dependsOn: [copyInstall, yarnZip, yarnModulesZip, ya
 task dist(dependsOn: assemble) {
 	group = 'Distribution'
 	description = 'Builds XD binary and reference docs distribution archives.'
-
 	artifacts {
 		archives distZip
 		archives distYarnZip
@@ -329,6 +330,8 @@ task dist(dependsOn: assemble) {
 		archives distShellZip
 	}
 }
+
+def excludedMavenProjects = hadoopDistros << 'documentation-toolchain' << rootProject.name
 
 artifactory {
 	contextUrl = 'http://repo.spring.io'
@@ -342,12 +345,14 @@ artifactory {
 			// Reference to Gradle publications defined in the build script.
 			// This is how we tell the Artifactory Plugin which artifacts should be
 			// published to Artifactory.
-			publications('mavenCustom')
-			publishArtifacts = true
-			properties {
-				archives '*:*:*:*@zip', 'zip.name':'spring-xd', 'zip.displayname':'Spring XD', 'zip.deployed':false
-				archives '*:*:*:docs@zip', 'zip.type':'docs'
-				archives '*:*:*:dist@zip', 'zip.type':'dist'
+			if (!excludedMavenProjects.contains(project.name)) {
+				publications('mavenCustom')
+				publishArtifacts = true
+				properties {
+					archives '*:*:*:*@zip', 'zip.name':'spring-xd', 'zip.displayname':'Spring XD', 'zip.deployed':false
+					archives '*:*:*:docs@zip', 'zip.type':'docs'
+					archives '*:*:*:dist@zip', 'zip.type':'dist'
+				}
 			}
 		}
 	}

--- a/gradle/build-dist.gradle
+++ b/gradle/build-dist.gradle
@@ -321,6 +321,13 @@ task distYarnZip(type: Zip, dependsOn: [copyInstall, yarnZip, yarnModulesZip, ya
 task dist(dependsOn: assemble) {
 	group = 'Distribution'
 	description = 'Builds XD binary and reference docs distribution archives.'
+
+	artifacts {
+		archives distZip
+		archives distYarnZip
+		archives docsZip
+		archives distShellZip
+	}
 }
 
 artifactory {

--- a/gradle/build-docs.gradle
+++ b/gradle/build-docs.gradle
@@ -17,6 +17,7 @@ buildscript {
 def docsDir = rootProject.file('src/docs/asciidoc') // Will be default with newer asciidoctor plugin
 
 project('documentation-toolchain') {
+	startScripts.enabled = false
 	description = 'Utilities for generating/verifying documentation'
 	dependencies {
 		compile project(':spring-xd-dirt')

--- a/gradle/build-modules.gradle
+++ b/gradle/build-modules.gradle
@@ -15,7 +15,7 @@ configure(moduleProjects) { moduleProject ->
     // the 'build' directory, etc)
     apply plugin: 'spring-boot'
     startScripts.enabled = false
-
+    distZip.enabled = false
     bootRepackage {
         enabled = false
     }

--- a/gradle/build-modules.gradle
+++ b/gradle/build-modules.gradle
@@ -14,6 +14,7 @@ configure(moduleProjects) { moduleProject ->
     // contain java code, so reset everything (prevents creation of
     // the 'build' directory, etc)
     apply plugin: 'spring-boot'
+    startScripts.enabled = false
 
     bootRepackage {
         enabled = false


### PR DESCRIPTION
This fixes gradle 'dist' and 'distZip'. Also removes some extraneous output messages from the build. Prior to this, 'dist' appears to work correctly on CI, but doesn't do any work (thinks it's up to date) on the command line.  'distZip' resulted in 'startScripts' errors, but once those were corrected, created build/distributions/*-dist.zip for every project. The net effect was that spring-xd-dist.zip and spring-xd-yarn-dist.zip, created by 'dist', were huge due to including the module artifacts created by running 'distZip'.  So, this disables distZip for all subprojects and also disables startScripts.  Note that these issues are not observed in the CI Publish build which configures the Gradle artifactory plugin.

Added some logic to exclude hadoopDistros, 'documentation-toolchain' and the rootProject from publications('mavenCustom'). Also added logback.xml to the document-toolchain classpath to supress DEBUG and INFO log messages.