### PR TITLE
[Sprint: 50] XD-3117: Add Logging to ZooKeeperContainerRepository

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperContainerRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperContainerRepository.java
@@ -30,6 +30,8 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.utils.ThreadUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEvent;
@@ -63,6 +65,11 @@ import org.springframework.xd.dirt.zookeeper.ZooKeeperUtils;
  * @author Patrick Peralta
  */
 public class ZooKeeperContainerRepository implements ContainerRepository, ApplicationListener<ApplicationEvent> {
+
+	/**
+	 * Logger.
+	 */
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
 	/**
 	 * ZooKeeper connection.
@@ -153,6 +160,7 @@ public class ZooKeeperContainerRepository implements ContainerRepository, Applic
 						@Override
 						public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) {
 							// shut down the cache if ZooKeeper connection goes away
+							ZooKeeperUtils.logCacheEvent(logger, event);
 							if (event.getType() == PathChildrenCacheEvent.Type.CONNECTION_SUSPENDED ||
 									event.getType() == PathChildrenCacheEvent.Type.CONNECTION_LOST) {
 								closeCache();

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -21,6 +21,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Map;
 
 import org.apache.curator.framework.recipes.cache.ChildData;
@@ -146,7 +147,14 @@ public abstract class ZooKeeperUtils {
 		}
 		builder.append("type=").append(event.getType());
 
-		logger.info(builder.toString());
+		if (EnumSet.of(PathChildrenCacheEvent.Type.CONNECTION_SUSPENDED,
+				PathChildrenCacheEvent.Type.CONNECTION_LOST).contains(event.getType())) {
+			logger.warn(builder.toString());
+		}
+		else {
+			logger.info(builder.toString());
+		}
+
 		if (data != null && logger.isTraceEnabled()) {
 			String content;
 			byte[] bytes = data.getData();

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -1118,7 +1118,7 @@ $$offsetUpdateCount$$:: $$frequency, in number of messages, with which offsets a
 $$offsetUpdateShutdownTimeout$$:: $$timeout for ensuring that all offsets have been written, on shutdown$$ *($$int$$, default: `2000`)*
 $$offsetUpdateTimeWindow$$:: $$frequency (in milliseconds) with which offsets are persisted mutually exclusive with the count-based offset update option (use 0 to disable either)$$ *($$int$$, default: `10000`)*
 $$partitions$$:: $$comma separated list of partition IDs to listen on$$ *($$String$$, default: ``)*
-$$queueSize$$:: $$the maximum number of messages held internally and waiting for processing, per concurrent handler. Value must be a power of 2.$$ *($$int$$, default: `1024`)*
+$$queueSize$$:: $$the maximum number of messages held internally and waiting for processing, per concurrent handler. Value must be a power of 2$$ *($$int$$, default: `1024`)*
 $$socketBufferBytes$$:: $$socket receive buffer for network requests$$ *($$int$$, default: `2097152`)*
 $$socketTimeout$$:: $$sock timeout for network requests in milliseconds$$ *($$int$$, default: `30000`)*
 $$streams$$:: $$number of streams in the topic$$ *($$int$$, default: `1`)*


### PR DESCRIPTION
If the `PathChildrenCache` for containers is closed due to a `PathChildrenCacheEvent` indicating a ZooKeeper disconnect, the null assert will fail. This change is for the event to log a message so that it becomes clear that the assert failed because of a closed or suspended connection.