### PR TITLE
[Sprint 50]XD-3124 Propagate `minPartitionCount` to consumer properties

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/StreamRuntimePropertiesProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/StreamRuntimePropertiesProvider.java
@@ -81,6 +81,10 @@ public class StreamRuntimePropertiesProvider extends RuntimeModuleDeploymentProp
 			if (hasPartitionKeyProperty(previousProperties)) {
 				properties.put("consumer." + BusProperties.PARTITION_INDEX, String.valueOf(moduleSequence - 1));
 			}
+			String minPartitionCount = previousProperties.get("producer." + BusProperties.MIN_PARTITION_COUNT);
+			if (minPartitionCount != null) {
+				properties.put("consumer." + BusProperties.MIN_PARTITION_COUNT, minPartitionCount);
+			}
 		}
 		// Not last
 		if (moduleIndex + 1 < streamModules.size()) {

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
@@ -157,11 +157,13 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 
 		DirectChannel moduleOutputChannel = new DirectChannel();
 		QueueChannel moduleInputChannel = new QueueChannel();
-		Properties props = new Properties();
-		props.put(KafkaMessageBus.KAFKA_MIN_PARTITION_COUNT, "10");
+		Properties producerProperties = new Properties();
+		producerProperties.put(BusProperties.MIN_PARTITION_COUNT, "10");
+		Properties consumerProperties = new Properties();
+		consumerProperties.put(BusProperties.MIN_PARTITION_COUNT, "10");
 		long uniqueBindingId = System.currentTimeMillis();
-		messageBus.bindProducer("foo" + uniqueBindingId + ".0", moduleOutputChannel, props);
-		messageBus.bindConsumer("foo" + uniqueBindingId + ".0", moduleInputChannel, null);
+		messageBus.bindProducer("foo" + uniqueBindingId + ".0", moduleOutputChannel, producerProperties);
+		messageBus.bindConsumer("foo" + uniqueBindingId + ".0", moduleInputChannel, consumerProperties);
 		Message<?> message = org.springframework.integration.support.MessageBuilder.withPayload(ratherBigPayload).build();
 		// Let the consumer actually bind to the producer before sending a msg
 		busBindUnbindLatency();
@@ -185,12 +187,15 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 
 		DirectChannel moduleOutputChannel = new DirectChannel();
 		QueueChannel moduleInputChannel = new QueueChannel();
-		Properties props = new Properties();
-		props.put(KafkaMessageBus.KAFKA_MIN_PARTITION_COUNT, "5");
-		props.put(BusProperties.NEXT_MODULE_COUNT,"6");
+		Properties producerProps = new Properties();
+		producerProps.put(BusProperties.MIN_PARTITION_COUNT, "5");
+		producerProps.put(BusProperties.NEXT_MODULE_CONCURRENCY, "6");
+		Properties consumerProps = new Properties();
+		consumerProps.put(BusProperties.MIN_PARTITION_COUNT, "5");
+		consumerProps.put(BusProperties.CONCURRENCY, "6");
 		long uniqueBindingId = System.currentTimeMillis();
-		messageBus.bindProducer("foo" + uniqueBindingId + ".0", moduleOutputChannel, props);
-		messageBus.bindConsumer("foo" + uniqueBindingId + ".0", moduleInputChannel, null);
+		messageBus.bindProducer("foo" + uniqueBindingId + ".0", moduleOutputChannel, producerProps);
+		messageBus.bindConsumer("foo" + uniqueBindingId + ".0", moduleInputChannel, consumerProps);
 		Message<?> message = org.springframework.integration.support.MessageBuilder.withPayload(ratherBigPayload).build();
 		// Let the consumer actually bind to the producer before sending a msg
 		busBindUnbindLatency();
@@ -213,13 +218,15 @@ public class KafkaMessageBusTests extends PartitionCapableBusTests {
 
 		DirectChannel moduleOutputChannel = new DirectChannel();
 		QueueChannel moduleInputChannel = new QueueChannel();
-		Properties props = new Properties();
-		props.put(KafkaMessageBus.KAFKA_MIN_PARTITION_COUNT, "3");
-		props.put(BusProperties.PARTITION_COUNT,"5");
-		props.put(BusProperties.PARTITION_KEY_EXPRESSION,"payload");
+		Properties producerProperties = new Properties();
+		producerProperties.put(BusProperties.MIN_PARTITION_COUNT, "3");
+		producerProperties.put(BusProperties.PARTITION_COUNT, "5");
+		producerProperties.put(BusProperties.PARTITION_KEY_EXPRESSION, "payload");
+		Properties consumerProperties = new Properties();
+		consumerProperties.put(BusProperties.MIN_PARTITION_COUNT, "3");
 		long uniqueBindingId = System.currentTimeMillis();
-		messageBus.bindProducer("foo" + uniqueBindingId + ".0", moduleOutputChannel, props);
-		messageBus.bindConsumer("foo" + uniqueBindingId + ".0", moduleInputChannel, null);
+		messageBus.bindProducer("foo" + uniqueBindingId + ".0", moduleOutputChannel, producerProperties);
+		messageBus.bindConsumer("foo" + uniqueBindingId + ".0", moduleInputChannel, consumerProperties);
 		Message<?> message = org.springframework.integration.support.MessageBuilder.withPayload(ratherBigPayload).build();
 		// Let the consumer actually bind to the producer before sending a msg
 		busBindUnbindLatency();

--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -150,8 +150,6 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 	private static final String DEFAULT_COMPRESSION_CODEC = "none";
 
-	public static final String KAFKA_MIN_PARTITION_COUNT = "minPartitionCount";
-
 	private static final int DEFAULT_REQUIRED_ACKS = 1;
 
 	private static final boolean DEFAULT_AUTO_COMMIT_ENABLED = true;
@@ -195,11 +193,16 @@ public class KafkaMessageBus extends MessageBusSupport {
 	 */
 	private static final String POINT_TO_POINT_SEMANTICS_CONSUMER_GROUP = "springXD";
 
+	private static final Set<Object> KAFKA_CONSUMER_PROPERTIES = new SetBuilder()
+			.add(BusProperties.MIN_PARTITION_COUNT)
+			.build();
+
 	/**
 	 * Basic + concurrency + partitioning.
 	 */
 	private static final Set<Object> SUPPORTED_CONSUMER_PROPERTIES = new SetBuilder()
 			.addAll(CONSUMER_STANDARD_PROPERTIES)
+			.addAll(KAFKA_CONSUMER_PROPERTIES)
 			.add(BusProperties.PARTITION_INDEX) // Not actually used
 			.add(BusProperties.COUNT) // Not actually used
 			.add(BusProperties.CONCURRENCY)
@@ -207,7 +210,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 			.build();
 
 	private static final Set<Object> KAFKA_PRODUCER_PROPERTIES = new SetBuilder()
-			.add(KAFKA_MIN_PARTITION_COUNT)
+			.add(BusProperties.MIN_PARTITION_COUNT)
 			.build();
 
 	/**
@@ -619,8 +622,8 @@ public class KafkaMessageBus extends MessageBusSupport {
 		int concurrency = accessor.getConcurrency(defaultConcurrency);
 		String topic = escapeTopicName(name);
 
-		Collection<Partition> allPartitions = ensureTopicCreated(topic, accessor.getCount() * concurrency,
-				defaultReplicationFactor, false);
+		int numPartitions = accessor.getNumberOfKafkaPartitionsForConsumer();
+		Collection<Partition> allPartitions = ensureTopicCreated(topic, numPartitions, defaultReplicationFactor, false);
 
 		Decoder<byte[]> valueDecoder = new DefaultDecoder(null);
 		Decoder<byte[]> keyDecoder = new DefaultDecoder(null);
@@ -645,9 +648,6 @@ public class KafkaMessageBus extends MessageBusSupport {
 					int moduleSequence = accessor.getSequence();
 					if (moduleCount == 0) {
 						throw new IllegalArgumentException("This type of transport does not support 0-count modules");
-					}
-					if (moduleCount == 1) {
-						listenedPartitions.add(partition);
 					}
 					else {
 						// sequence numbers are zero-based
@@ -793,7 +793,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 		public int getNumberOfKafkaPartitionsForProducer() {
 			int concurrency = getProperty(NEXT_MODULE_CONCURRENCY, defaultConcurrency);
-			int kafkaPartitions = getKafkaPartitionCount(defaultMinPartitionCount);
+			int kafkaPartitions = getMinPartitionCount(defaultMinPartitionCount);
 			if (isPartitionedModule()) {
 				return Math.max(kafkaPartitions, getPartitionCount() * concurrency);
 			}
@@ -804,6 +804,16 @@ public class KafkaMessageBus extends MessageBusSupport {
 				}
 				return Math.max(kafkaPartitions, nextModuleCount * concurrency);
 			}
+		}
+
+		public int getNumberOfKafkaPartitionsForConsumer() {
+			int concurrency = getConcurrency(defaultConcurrency);
+			int minKafkaPartitions = getMinPartitionCount(defaultMinPartitionCount);
+			int moduleCount = getCount();
+			if (moduleCount == 0) {
+				throw new IllegalArgumentException("Module count cannot be zero");
+			}
+			return Math.max(minKafkaPartitions, moduleCount * concurrency);
 		}
 
 		public boolean isPartitionedModule() {
@@ -822,8 +832,8 @@ public class KafkaMessageBus extends MessageBusSupport {
 			return getProperty(AUTO_COMMIT_ENABLED, defaultAutoCommitEnabled);
 		}
 
-		public int getKafkaPartitionCount(int defaultPartitionCount) {
-			return getProperty(KAFKA_MIN_PARTITION_COUNT, defaultPartitionCount);
+		public int getMinPartitionCount(int defaultPartitionCount) {
+			return getProperty(MIN_PARTITION_COUNT, defaultPartitionCount);
 		}
 
 	}

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
@@ -141,4 +141,9 @@ public interface BusProperties {
 	 */
 	public static final String DURABLE = "durableSubscription";
 
+	/**
+	 * Minimum partition count, if the transport supports partitioning natively (e.g. Kafka)
+	 */
+	public static final String MIN_PARTITION_COUNT = "minPartitionCount";
+
 }


### PR DESCRIPTION
- ensure that the consumer end of the bus is in sync with the producer on the expected partition count
- update tests