### PR TITLE
XD-3130 Create BusCleanerUtils

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleaner.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleaner.java
@@ -45,6 +45,7 @@ import org.apache.http.protocol.HttpContext;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.xd.dirt.integration.bus.BusCleaner;
+import org.springframework.xd.dirt.integration.bus.BusCleanerUtils;
 import org.springframework.xd.dirt.integration.bus.BusUtils;
 import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
 import org.springframework.xd.dirt.integration.bus.RabbitAdminException;
@@ -80,7 +81,7 @@ public class RabbitBusCleaner implements BusCleaner {
 
 	private Map<String, List<String>> doClean(String adminUri, String user, String pw, String vhost,
 			String busPrefix, String entity, boolean isJob) {
-		RestTemplate restTemplate = BusUtils.buildRestTemplate(adminUri, user, pw);
+		RestTemplate restTemplate = BusCleanerUtils.buildRestTemplate(adminUri, user, pw);
 		List<String> removedQueues = isJob
 				? findJobQueues(adminUri, vhost, busPrefix, entity, restTemplate)
 				: findStreamQueues(adminUri, vhost, busPrefix, entity, restTemplate);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleaner.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleaner.java
@@ -30,22 +30,11 @@ import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.AuthCache;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.protocol.HttpContext;
 
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.xd.dirt.integration.bus.BusCleaner;
-import org.springframework.xd.dirt.integration.bus.BusCleanerUtils;
+import org.springframework.xd.dirt.integration.bus.RabbitManagementUtils;
 import org.springframework.xd.dirt.integration.bus.BusUtils;
 import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
 import org.springframework.xd.dirt.integration.bus.RabbitAdminException;
@@ -81,7 +70,7 @@ public class RabbitBusCleaner implements BusCleaner {
 
 	private Map<String, List<String>> doClean(String adminUri, String user, String pw, String vhost,
 			String busPrefix, String entity, boolean isJob) {
-		RestTemplate restTemplate = BusCleanerUtils.buildRestTemplate(adminUri, user, pw);
+		RestTemplate restTemplate = RabbitManagementUtils.buildRestTemplate(adminUri, user, pw);
 		List<String> removedQueues = isJob
 				? findJobQueues(adminUri, vhost, busPrefix, entity, restTemplate)
 				: findStreamQueues(adminUri, vhost, busPrefix, entity, restTemplate);

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleanerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleanerTests.java
@@ -44,6 +44,7 @@ import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.xd.dirt.integration.bus.BusCleanerUtils;
 import org.springframework.xd.dirt.integration.bus.BusUtils;
 import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
 import org.springframework.xd.dirt.integration.bus.RabbitAdminException;
@@ -73,7 +74,7 @@ public class RabbitBusCleanerTests {
 	@Test
 	public void testCleanStream() {
 		final RabbitBusCleaner cleaner = new RabbitBusCleaner();
-		final RestTemplate template = BusUtils.buildRestTemplate("http://localhost:15672", "guest", "guest");
+		final RestTemplate template = BusCleanerUtils.buildRestTemplate("http://localhost:15672", "guest", "guest");
 		final String stream1 = UUID.randomUUID().toString();
 		String stream2 = stream1 + "-1";
 		String firstQueue = null;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleanerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleanerTests.java
@@ -44,7 +44,7 @@ import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.springframework.xd.dirt.integration.bus.BusCleanerUtils;
+import org.springframework.xd.dirt.integration.bus.RabbitManagementUtils;
 import org.springframework.xd.dirt.integration.bus.BusUtils;
 import org.springframework.xd.dirt.integration.bus.MessageBusSupport;
 import org.springframework.xd.dirt.integration.bus.RabbitAdminException;
@@ -74,7 +74,7 @@ public class RabbitBusCleanerTests {
 	@Test
 	public void testCleanStream() {
 		final RabbitBusCleaner cleaner = new RabbitBusCleaner();
-		final RestTemplate template = BusCleanerUtils.buildRestTemplate("http://localhost:15672", "guest", "guest");
+		final RestTemplate template = RabbitManagementUtils.buildRestTemplate("http://localhost:15672", "guest", "guest");
 		final String stream1 = UUID.randomUUID().toString();
 		String stream2 = stream1 + "-1";
 		String firstQueue = null;

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactory.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactory.java
@@ -34,6 +34,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.xd.dirt.integration.bus.BusCleanerUtils;
 import org.springframework.xd.dirt.integration.bus.BusUtils;
 
 
@@ -206,7 +207,7 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 	 * @return the template.
 	 */
 	protected RestTemplate createRestTemplate(String adminUri) {
-		return BusUtils.buildRestTemplate(adminUri, this.username, this.password);
+		return BusCleanerUtils.buildRestTemplate(adminUri, this.username, this.password);
 	}
 
 	/**

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactory.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactory.java
@@ -34,8 +34,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.springframework.xd.dirt.integration.bus.BusCleanerUtils;
-import org.springframework.xd.dirt.integration.bus.BusUtils;
+import org.springframework.xd.dirt.integration.bus.RabbitManagementUtils;
 
 
 /**
@@ -207,7 +206,7 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 	 * @return the template.
 	 */
 	protected RestTemplate createRestTemplate(String adminUri) {
-		return BusCleanerUtils.buildRestTemplate(adminUri, this.username, this.password);
+		return RabbitManagementUtils.buildRestTemplate(adminUri, this.username, this.password);
 	}
 
 	/**

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleanerUtils.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleanerUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.integration.bus;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HttpContext;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * @author Gary Russell
+ * @since 1.2
+ */
+public class BusCleanerUtils {
+
+	public static RestTemplate buildRestTemplate(String adminUri, String user, String password) {
+		BasicCredentialsProvider credsProvider = new BasicCredentialsProvider();
+		credsProvider.setCredentials(
+				new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT),
+				new UsernamePasswordCredentials(user, password));
+		HttpClient httpClient = HttpClients.custom().setDefaultCredentialsProvider(credsProvider).build();
+		// Set up pre-emptive basic Auth because the rabbit plugin doesn't currently support challenge/response for PUT
+		// Create AuthCache instance
+		AuthCache authCache = new BasicAuthCache();
+		// Generate BASIC scheme object and add it to the local; from the apache docs...
+		// auth cache
+		BasicScheme basicAuth = new BasicScheme();
+		URI uri;
+		try {
+			uri = new URI(adminUri);
+		}
+		catch (URISyntaxException e) {
+			throw new RabbitAdminException("Invalid URI", e);
+		}
+		authCache.put(new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()), basicAuth);
+		// Add AuthCache to the execution context
+		final HttpClientContext localContext = HttpClientContext.create();
+		localContext.setAuthCache(authCache);
+		RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient) {
+
+			@Override
+			protected HttpContext createHttpContext(HttpMethod httpMethod, URI uri) {
+				return localContext;
+			}
+
+		});
+		restTemplate.setMessageConverters(Collections.<HttpMessageConverter<?>>singletonList(
+				new MappingJackson2HttpMessageConverter()));
+		return restTemplate;
+	}
+
+}

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusUtils.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusUtils.java
@@ -16,30 +16,10 @@
 
 package org.springframework.xd.dirt.integration.bus;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.regex.Pattern;
 
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.AuthCache;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.protocol.HttpContext;
-
-import org.springframework.http.HttpMethod;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.RestTemplate;
 
 /**
  * Message Bus utilities.
@@ -105,42 +85,6 @@ public class BusUtils {
 
 	public static String constructTapPrefix(String group) {
 		return TAP_CHANNEL_PREFIX + "stream:" + group;
-	}
-
-	public static RestTemplate buildRestTemplate(String adminUri, String user, String password) {
-		BasicCredentialsProvider credsProvider = new BasicCredentialsProvider();
-		credsProvider.setCredentials(
-				new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT),
-				new UsernamePasswordCredentials(user, password));
-		HttpClient httpClient = HttpClients.custom().setDefaultCredentialsProvider(credsProvider).build();
-		// Set up pre-emptive basic Auth because the rabbit plugin doesn't currently support challenge/response for PUT
-		// Create AuthCache instance
-		AuthCache authCache = new BasicAuthCache();
-		// Generate BASIC scheme object and add it to the local; from the apache docs...
-		// auth cache
-		BasicScheme basicAuth = new BasicScheme();
-		URI uri;
-		try {
-			uri = new URI(adminUri);
-		}
-		catch (URISyntaxException e) {
-			throw new RabbitAdminException("Invalid URI", e);
-		}
-		authCache.put(new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()), basicAuth);
-		// Add AuthCache to the execution context
-		final HttpClientContext localContext = HttpClientContext.create();
-		localContext.setAuthCache(authCache);
-		RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient) {
-
-			@Override
-			protected HttpContext createHttpContext(HttpMethod httpMethod, URI uri) {
-				return localContext;
-			}
-
-		});
-		restTemplate.setMessageConverters(Collections.<HttpMessageConverter<?>> singletonList(
-				new MappingJackson2HttpMessageConverter()));
-		return restTemplate;
 	}
 
 }

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitManagementUtils.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitManagementUtils.java
@@ -41,7 +41,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Gary Russell
  * @since 1.2
  */
-public class BusCleanerUtils {
+public class RabbitManagementUtils {
 
 	public static RestTemplate buildRestTemplate(String adminUri, String user, String password) {
 		BasicCredentialsProvider credsProvider = new BasicCredentialsProvider();


### PR DESCRIPTION
 - Move `buildRestTemplate` method from `BusUtils` to a new class `BusCleanerUtils`
 - Since `Spark-streaming` uses `BusUtils`, this change would make Spark streaming not
to depend on `httpClient` that is used by the bus cleaner util method to build rest template