### PR TITLE
[Sprint: 50] XD-3131 Disable tap listener for spark streaming plugin

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
@@ -107,8 +107,8 @@ public class SparkStreamingPlugin extends AbstractStreamPlugin {
 	private Map<Module, JavaStreamingContext> streamingContexts = new HashMap<>();
 
 	@Autowired
-	public SparkStreamingPlugin(MessageBus messageBus, ZooKeeperConnection zkConnection) {
-		super(messageBus, zkConnection);
+	public SparkStreamingPlugin(MessageBus messageBus) {
+		super(messageBus, null);
 	}
 
 	@Override

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
@@ -108,7 +108,7 @@ public class SparkStreamingPlugin extends AbstractStreamPlugin {
 
 	@Autowired
 	public SparkStreamingPlugin(MessageBus messageBus) {
-		super(messageBus, null);
+		super(messageBus);
 	}
 
 	@Override


### PR DESCRIPTION
 - This avoids the creation of the curator pathchildren cache thread for Taplistener when the
SparkStreamingPlugin is initialized