### PR TITLE
[Sprint: 50] XD-3142 Disable SI MBeans when JMX is disabled

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
@@ -50,6 +50,7 @@ import org.springframework.xd.dirt.util.ConfigLocations;
 public class ParentConfiguration {
 
 	@Bean
+	@ConditionalOnExpression("${XD_JMX_ENABLED:false}")
 	public MBeanServerFactoryBean mbeanServer() {
 		MBeanServerFactoryBean factoryBean = new MBeanServerFactoryBean();
 		factoryBean.setLocateExistingServerIfPossible(true);

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -5,6 +5,8 @@ spring:
     show_banner: false
   freemarker:
     checkTemplateLocation: false
+  jmx:
+    enabled: ${XD_JMX_ENABLED:false}
 # Redis properties
   redis:
    port: 6379


### PR DESCRIPTION
 - Add `spring.jmx.enabled` property in application.yml and this property is set to `false`
by default. If `XD_JMX_ENABLED` is set then that value would precede.