### PR TITLE
[Sprint: 50] XD-3141 Avoid ClasspathResource for module config files

### DIFF
--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/ResourceConfiguredModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/ResourceConfiguredModule.java
@@ -58,7 +58,7 @@ public class ResourceConfiguredModule extends SimpleModule {
 				// wouldn't get the overridden module definitions as the classloader is already initialized.
 				try {
 					Assert.isTrue(source.getURL() != null, "Module definition config file URL is invalid");
-					addSource(new UrlResource(source.getURL().toString()));
+					addSource(new UrlResource(source.getURL()));
 				}
 				catch (IOException e) {
 					throw new RuntimeException("Exception loading module definition " + moduleDefinition + ":" + e);

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/ResourceConfiguredModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/ResourceConfiguredModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,7 @@
 
 package org.springframework.xd.module.core;
 
-import java.io.IOException;
-
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
 import org.springframework.xd.module.ModuleDeploymentProperties;
 import org.springframework.xd.module.ModuleDescriptor;
 import org.springframework.xd.module.SimpleModuleDefinition;
@@ -33,7 +29,6 @@ import org.springframework.xd.module.options.ModuleUtils;
  *
  * @author David Turanski
  * @author Eric Bottard
- * @author Ilayaperumal Gopinathan
  */
 public class ResourceConfiguredModule extends SimpleModule {
 
@@ -52,19 +47,7 @@ public class ResourceConfiguredModule extends SimpleModule {
 	protected void configureModuleApplicationContext(SimpleModuleDefinition moduleDefinition) {
 		Resource source = ModuleUtils.resourceBasedConfigurationFile(moduleDefinition);
 		if (source != null) {
-			if (source instanceof ClassPathResource) {
-				// In this case, add the source as UrlResource instead of ClassPathResource. Adding as ClasspathResource
-				// wouldn't get the overridden module definitions as the classloader is already initialized.
-				try {
-					addSource(new UrlResource(source.getURL()));
-				}
-				catch (IOException e) {
-					throw new RuntimeException("Exception loading module definition " + moduleDefinition + ":" + e);
-				}
-			}
-			else {
-				addSource(source);
-			}
+			addSource(source);
 		}
 	}
 

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/ResourceConfiguredModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/ResourceConfiguredModule.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
-import org.springframework.util.Assert;
 import org.springframework.xd.module.ModuleDeploymentProperties;
 import org.springframework.xd.module.ModuleDescriptor;
 import org.springframework.xd.module.SimpleModuleDefinition;
@@ -57,7 +56,6 @@ public class ResourceConfiguredModule extends SimpleModule {
 				// In this case, add the source as UrlResource instead of ClassPathResource. Adding as ClasspathResource
 				// wouldn't get the overridden module definitions as the classloader is already initialized.
 				try {
-					Assert.isTrue(source.getURL() != null, "Module definition config file URL is invalid");
 					addSource(new UrlResource(source.getURL()));
 				}
 				catch (IOException e) {

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleUtils.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleUtils.java
@@ -174,6 +174,9 @@ public class ModuleUtils {
 							.arrayToCommaDelimitedString(resources));
 				}
 				else if (resources.length == 1) {
+					// If the resource is of ClassPathResource add the source as UrlResource.
+					// Adding as ClasspathResource wouldn't get the overridden module definitions as the
+					// classloader is already initialized.
 					Resource resource = (resources[0] instanceof ClassPathResource) ?
 							new UrlResource(resources[0].getURL()) : resources[0];
 					return resource;

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleUtils.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleUtils.java
@@ -18,7 +18,6 @@ package org.springframework.xd.module.options;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
@@ -34,12 +33,12 @@ import org.springframework.core.env.PropertyResolver;
 import org.springframework.core.env.PropertySourcesPropertyResolver;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.xd.module.SimpleModuleDefinition;
-import org.springframework.xd.module.options.ModuleOptions;
 import org.springframework.xd.module.support.ArchiveResourceLoader;
 import org.springframework.xd.module.support.NullClassLoader;
 import org.springframework.xd.module.support.ParentLastURLClassLoader;
@@ -49,6 +48,7 @@ import org.springframework.xd.module.support.ParentLastURLClassLoader;
  *
  * @author Eric Bottard
  * @author David Turanski
+ * @author Ilayaperumal Gopinathan
  */
 public class ModuleUtils {
 
@@ -174,7 +174,9 @@ public class ModuleUtils {
 							.arrayToCommaDelimitedString(resources));
 				}
 				else if (resources.length == 1) {
-					return resources[0];
+					Resource resource = (resources[0] instanceof ClassPathResource) ?
+							new UrlResource(resources[0].getURL()) : resources[0];
+					return resource;
 				}
 			}
 			catch (IOException e) {


### PR DESCRIPTION
 - When the module configuration files (config/*.xml, config/*.properties) are loaded,
they are added as `ClasspathResource`. This doesn't work in case if the module was already
loaded once and the module definition is overridden by `module upload` command. This
requires server restart to re-initialize the classloader.
  - This PR suggests using `UrlResource` for all the `ClasspathResource` sources and thereby
any overridden module definitions are always re-loaded.