### PR TITLE
[Sprint: 50] XD-3150 Fix filepollhdfs problem with multiple files

### DIFF
--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/HdfsTextItemWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/HdfsTextItemWriter.java
@@ -33,7 +33,7 @@ import org.springframework.data.hadoop.store.StoreException;
 import org.springframework.util.Assert;
 
 /**
- * 
+ *
  * @author Mark Pollack
  */
 public class HdfsTextItemWriter<T> extends AbstractHdfsItemWriter<T> implements InitializingBean {
@@ -106,7 +106,7 @@ public class HdfsTextItemWriter<T> extends AbstractHdfsItemWriter<T> implements 
 
 	/**
 	 * Converts the list of items to a byte array.
-	 * 
+	 *
 	 * @param items
 	 * @return the byte array
 	 */
@@ -152,13 +152,15 @@ public class HdfsTextItemWriter<T> extends AbstractHdfsItemWriter<T> implements 
 			} catch (IOException e) {
 				IOUtils.closeStream(fsDataOutputStream);
 				throw new StoreException("Error while closing stream", e);
+			} finally {
+				fsDataOutputStream = null;
 			}
 		}
 	}
 
 	/**
 	 * Public setter for the {@link LineAggregator}. This will be used to translate the item into a line for output.
-	 * 
+	 *
 	 * @param lineAggregator the {@link LineAggregator} to set
 	 */
 	public void setLineAggregator(LineAggregator<T> lineAggregator) {

--- a/src/docs/asciidoc/Jobs.asciidoc
+++ b/src/docs/asciidoc/Jobs.asciidoc
@@ -44,7 +44,7 @@ xd:> job create myjob --definition "filepollhdfs --names=forename,surname,addres
 You would then use a stream with a file source to scan a directory for files and drive the job. A separate job will be started for each file found:
 
 ----
-xd:> stream create csvStream --definition "file --ref=true --dir=/mycsvdir --pattern=*.csv > queue:job:myjob" --deploy
+xd:> stream create csvStream --definition "file --mode=ref --dir=/mycsvdir --pattern=*.csv > queue:job:myjob" --deploy
 
 ----
 


### PR DESCRIPTION
- Fixing regression where second file threw error
  because writer tried to flush a closed stream.
- Fix docs to use correct option for file sink
  in filepollhdfs job section
  "file --ref=true" vs. "file --mode=ref"