### PR TITLE
[Sprint 50 ]XD-2996 Align transport native partitioning with Spring XD partitioning

### DIFF
--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionCapableBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionCapableBusTests.java
@@ -86,7 +86,7 @@ abstract public class PartitionCapableBusTests extends BrokerBusTests {
 		Properties properties = new Properties();
 		properties.put("partitionKeyExpression", "payload");
 		properties.put("partitionSelectorExpression", "hashCode()");
-		properties.put("partitionCount", "3");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "3");
 		properties.put(BusProperties.NEXT_MODULE_CONCURRENCY, "2");
 
 		DirectChannel output = new DirectChannel();
@@ -187,7 +187,7 @@ abstract public class PartitionCapableBusTests extends BrokerBusTests {
 		Properties properties = new Properties();
 		properties.put("partitionKeyExtractorClass", "org.springframework.xd.dirt.integration.bus.PartitionTestSupport");
 		properties.put("partitionSelectorClass", "org.springframework.xd.dirt.integration.bus.PartitionTestSupport");
-		properties.put("partitionCount", "3");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "3");
 		properties.put(BusProperties.NEXT_MODULE_CONCURRENCY, "2");
 
 		DirectChannel output = new DirectChannel();

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
@@ -65,7 +65,7 @@ public class RawModeKafkaMessageBusTests extends KafkaMessageBusTests {
 		Properties properties = new Properties();
 		properties.put("partitionKeyExtractorClass", "org.springframework.xd.dirt.integration.bus.kafka.RawKafkaPartitionTestSupport");
 		properties.put("partitionSelectorClass", "org.springframework.xd.dirt.integration.bus.kafka.RawKafkaPartitionTestSupport");
-		properties.put("partitionCount", "3");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "3");
 		properties.put(BusProperties.NEXT_MODULE_CONCURRENCY, "2");
 
 		DirectChannel output = new DirectChannel();
@@ -119,7 +119,7 @@ public class RawModeKafkaMessageBusTests extends KafkaMessageBusTests {
 		Properties properties = new Properties();
 		properties.put("partitionKeyExpression", "payload[0]");
 		properties.put("partitionSelectorExpression", "hashCode()");
-		properties.put("partitionCount", "3");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "3");
 		properties.put(BusProperties.NEXT_MODULE_CONCURRENCY, "2");
 
 		DirectChannel output = new DirectChannel();

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitMessageBusTests.java
@@ -67,6 +67,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.xd.dirt.integration.bus.Binding;
+import org.springframework.xd.dirt.integration.bus.BusProperties;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.PartitionCapableBusTests;
 import org.springframework.xd.test.rabbit.RabbitTestSupport;
@@ -218,7 +219,7 @@ public class RabbitMessageBusTests extends PartitionCapableBusTests {
 		properties.put("partitionKeyExtractorClass", "foo");
 		properties.put("partitionSelectorExpression", "0");
 		properties.put("partitionSelectorClass", "foo");
-		properties.put("partitionCount", "1");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "1");
 
 		bus.bindProducer("props.0", new DirectChannel(), properties);
 		assertEquals(1, bindings.size());
@@ -238,7 +239,6 @@ public class RabbitMessageBusTests extends PartitionCapableBusTests {
 		catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), allOf(
 					containsString("RabbitMessageBus does not support producer properties: "),
-					containsString("partitionCount"),
 					containsString("partitionSelectorExpression"),
 					containsString("partitionKeyExtractorClass"),
 					containsString("partitionKeyExpression"),
@@ -252,7 +252,6 @@ public class RabbitMessageBusTests extends PartitionCapableBusTests {
 		catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), allOf(
 					containsString("RabbitMessageBus does not support producer properties: "),
-					containsString("partitionCount"),
 					containsString("partitionSelectorExpression"),
 					containsString("partitionKeyExtractorClass"),
 					containsString("partitionKeyExpression"),
@@ -309,7 +308,7 @@ public class RabbitMessageBusTests extends PartitionCapableBusTests {
 		properties.put("partitionKeyExtractorClass", "foo");
 		properties.put("partitionSelectorExpression", "0");
 		properties.put("partitionSelectorClass", "foo");
-		properties.put("partitionCount", "1");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "1");
 		properties.put("partitionIndex", "0");
 		try {
 			bus.bindRequestor("dummy", null, null, properties);
@@ -318,7 +317,6 @@ public class RabbitMessageBusTests extends PartitionCapableBusTests {
 		catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), allOf(
 					containsString("RabbitMessageBus does not support producer properties: "),
-					containsString("partitionCount"),
 					containsString("partitionSelectorExpression"),
 					containsString("partitionKeyExtractorClass"),
 					containsString("partitionKeyExpression"),
@@ -378,7 +376,7 @@ public class RabbitMessageBusTests extends PartitionCapableBusTests {
 		properties.put("partitionKeyExtractorClass", "foo");
 		properties.put("partitionSelectorExpression", "0");
 		properties.put("partitionSelectorClass", "foo");
-		properties.put("partitionCount", "1");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "1");
 		properties.put("partitionIndex", "0");
 		try {
 			bus.bindReplier("dummy", null, null, properties);
@@ -387,7 +385,6 @@ public class RabbitMessageBusTests extends PartitionCapableBusTests {
 		catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), allOf(
 					containsString("RabbitMessageBus does not support consumer properties: "),
-					containsString("partitionCount"),
 					containsString("partitionSelectorExpression"),
 					containsString("partitionKeyExtractorClass"),
 					containsString("partitionKeyExpression"),

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
@@ -48,6 +48,7 @@ import org.springframework.integration.redis.inbound.RedisQueueMessageDrivenEndp
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.xd.dirt.integration.bus.Binding;
+import org.springframework.xd.dirt.integration.bus.BusProperties;
 import org.springframework.xd.dirt.integration.bus.EmbeddedHeadersMessageConverter;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.PartitionCapableBusTests;
@@ -163,7 +164,7 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 		properties.put("partitionKeyExtractorClass", "foo");
 		properties.put("partitionSelectorExpression", "0");
 		properties.put("partitionSelectorClass", "foo");
-		properties.put("partitionCount", "1");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "1");
 
 		bus.bindProducer("props.0", new DirectChannel(), properties);
 		assertEquals(1, bindings.size());
@@ -179,7 +180,6 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 		catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), allOf(
 					containsString("RedisMessageBus does not support producer properties: "),
-					containsString("partitionCount"),
 					containsString("partitionSelectorExpression"),
 					containsString("partitionKeyExtractorClass"),
 					containsString("partitionKeyExpression"),
@@ -193,7 +193,6 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 		catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), allOf(
 					containsString("RedisMessageBus does not support producer properties: "),
-					containsString("partitionCount"),
 					containsString("partitionSelectorExpression"),
 					containsString("partitionKeyExtractorClass"),
 					containsString("partitionKeyExpression"),
@@ -233,7 +232,6 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 		properties.put("partitionKeyExtractorClass", "foo");
 		properties.put("partitionSelectorExpression", "0");
 		properties.put("partitionSelectorClass", "foo");
-		properties.put("partitionCount", "1");
 		properties.put("partitionIndex", "0");
 		try {
 			bus.bindRequestor("dummy", new DirectChannel(), new DirectChannel(), properties);
@@ -242,7 +240,6 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 		catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), allOf(
 					containsString("RedisMessageBus does not support producer properties: "),
-					containsString("partitionCount"),
 					containsString("partitionSelectorExpression"),
 					containsString("partitionKeyExtractorClass"),
 					containsString("partitionKeyExpression"),
@@ -283,7 +280,7 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 		properties.put("partitionKeyExtractorClass", "foo");
 		properties.put("partitionSelectorExpression", "0");
 		properties.put("partitionSelectorClass", "foo");
-		properties.put("partitionCount", "1");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "1");
 		properties.put("partitionIndex", "0");
 		try {
 			bus.bindReplier("dummy", new DirectChannel(), new DirectChannel(), properties);
@@ -292,7 +289,6 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 		catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), allOf(
 					containsString("RedisMessageBus does not support consumer properties: "),
-					containsString("partitionCount"),
 					containsString("partitionSelectorExpression"),
 					containsString("partitionKeyExtractorClass"),
 					containsString("partitionKeyExpression"),

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -626,7 +626,8 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		else {
 			queue.setExpressionRoutingKey(EXPRESSION_PARSER.parseExpression(buildPartitionRoutingExpression
 					(queueName)));
-			for (int i = 0; i < properties.getPartitionCount(); i++) {
+			// if the stream is partitioned, create one queue for each target partition
+			for (int i = 0; i < properties.getNextModuleCount(); i++) {
 				this.rabbitAdmin.declareQueue(new Queue(queueName + "-" + i));
 			}
 		}
@@ -872,7 +873,7 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		private SendingHandler(MessageHandler delegate, String replyTo, RabbitPropertiesAccessor properties) {
 			this.delegate = delegate;
 			this.replyTo = replyTo;
-			this.partitioningMetadata = new PartitioningMetadata(properties);
+			this.partitioningMetadata = new PartitioningMetadata(properties, properties.getNextModuleCount());
 			this.setBeanFactory(RabbitMessageBus.this.getBeanFactory());
 		}
 

--- a/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -413,7 +413,7 @@ public class RedisMessageBus extends MessageBusSupport implements DisposableBean
 		private SendingHandler(MessageHandler delegate, String replyTo, RedisPropertiesAccessor properties) {
 			this.delegate = delegate;
 			this.replyTo = replyTo;
-			this.partitioningMetadata = new PartitioningMetadata(properties);
+			this.partitioningMetadata = new PartitioningMetadata(properties, properties.getNextModuleCount());
 			this.setBeanFactory(RedisMessageBus.this.getBeanFactory());
 		}
 

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/AbstractBusPropertiesAccessor.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/AbstractBusPropertiesAccessor.java
@@ -273,11 +273,11 @@ public abstract class AbstractBusPropertiesAccessor implements BusProperties {
 	}
 
 	/**
-	 * The number of partitions for this module.
-	 * @return The count.
+	 * The next module count for non-sink modules
+	 * @return the next module count
 	 */
-	public int getPartitionCount() {
-		return getProperty(PARTITION_COUNT, 1);
+	public int getNextModuleCount() {
+		return getProperty(NEXT_MODULE_COUNT, 1);
 	}
 
 	/**

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
@@ -67,11 +67,6 @@ public interface BusProperties {
 	public static final String COUNT = "count";
 
 	/**
-	 * The partition count.
-	 */
-	public static final String PARTITION_COUNT = "partitionCount";
-
-	/**
 	 * The consumer's partition index.
 	 */
 	public static final String PARTITION_INDEX = "partitionIndex";

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -138,7 +138,6 @@ public abstract class MessageBusSupport
 
 	protected static final Set<Object> PRODUCER_PARTITIONING_PROPERTIES = new HashSet<Object>(
 			Arrays.asList(new String[] {
-				BusProperties.PARTITION_COUNT,
 				BusProperties.PARTITION_KEY_EXPRESSION,
 				BusProperties.PARTITION_KEY_EXTRACTOR_CLASS,
 				BusProperties.PARTITION_SELECTOR_CLASS,
@@ -962,12 +961,12 @@ public abstract class MessageBusSupport
 
 		private final int partitionCount;
 
-		public PartitioningMetadata(AbstractBusPropertiesAccessor properties) {
+		public PartitioningMetadata(AbstractBusPropertiesAccessor properties, int partitionCount) {
+			this.partitionCount = partitionCount;
 			this.partitionKeyExtractorClass = properties.getPartitionKeyExtractorClass();
 			this.partitionKeyExpression = properties.getPartitionKeyExpression();
 			this.partitionSelectorClass = properties.getPartitionSelectorClass();
 			this.partitionSelectorExpression = properties.getPartitionSelectorExpression();
-			this.partitionCount = properties.getPartitionCount();
 		}
 
 		public boolean isPartitionedModule() {


### PR DESCRIPTION
- Eliminate the `partitionCount` property, which is currently just a copy of `count`, as well as its calculation;
- Propagate `nextModuleCount` and `nextModuleConcurrency` to all non-last modules;
- Make the target partition count an argument for the construction of `PartitioningMetadata`, and defer to the transport-specific implementation to decide on the value to be used: Redis and Rabbit will simply use `nextModuleCount`, and Kafka will use the partition count of the target topic;
- the number of the partitions used by the Kafka bus is the larger of `minPartitionCount` and `nextModuleConcurrency` * `nextModuleCount`, unless a topic exists and already has more partitions than either of the two values, case in which the number of existing partitions will be used;
- eliminate the additional calculation in the Kafka bus, which was required because the number of Spring XD partitions could have been, in principle, different from the number of underlying Kafka partitions;
- unit tests adjustments;