### PR TITLE
[Sprint: 51] XD-3172 Add file source option `withMarkers`

### DIFF
--- a/modules/common/file-source-common-context.xml
+++ b/modules/common/file-source-common-context.xml
@@ -40,7 +40,10 @@
 				<header name="file_name"   expression="payload.name"/>
 			</header-enricher>
 			<splitter id="iteratingFileSplitter">
-				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter"/>
+				<beans:bean class="org.springframework.integration.file.splitter.FileSplitter">
+					<beans:constructor-arg index="0" value="true"/>
+					<beans:constructor-arg index="1" value="${withMarkers:false}"/>
+				</beans:bean>
 			</splitter>
 		</chain>
 	</beans:beans>

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
@@ -18,6 +18,7 @@
 
 package org.springframework.xd.dirt.modules.metadata;
 
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.xd.module.options.spi.ModuleOption;
@@ -34,6 +35,8 @@ public class FileAsRefMixin implements ProfileNamesProvider {
 
 	private FileReadingMode fileReadingmode = FileReadingMode.contents;
 
+	private Boolean withMarkers = null;
+
 	@NotNull
 	public FileReadingMode getMode() {
 		return fileReadingmode;
@@ -44,8 +47,29 @@ public class FileAsRefMixin implements ProfileNamesProvider {
 		this.fileReadingmode = mode;
 	}
 
+	public Boolean getWithMarkers() {
+		return withMarkers;
+	}
+
+	@ModuleOption(defaultValue = "false",
+			value = "if true emits start of file/end of file marker messages before/after the data. Only valid with FileReadingMode 'lines'")
+	public void setWithMarkers(Boolean withMarkers) {
+		this.withMarkers = withMarkers;
+	}
+
+	@AssertTrue(message = "withMarkers can only be supplied when FileReadingMode is 'lines'")
+	public boolean isWithMarkersValid() {
+		if (this.withMarkers != null && !FileReadingMode.lines.equals(this.fileReadingmode)) {
+			return false;
+		}
+		else {
+			return true;
+		}
+	}
+
 	@Override
 	public String[] profilesToActivate() {
 		return new String[] { this.fileReadingmode.getProfile() };
 	}
+
 }

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -47,6 +47,10 @@ customized using the `--mode` option:
 - *lines* Will split files line-by-line and emit a new message for each line
 - *contents* The default. Provides the contents of a file as a byte array
 
+When using `--mode=lines`, you can also provide the additional option `--withMarkers=true`.
+If set to `true`, the underlying `FileSplitter` will emit additional _start-of-file_ and _end-of-file_ marker messages before and after the actual data.
+The payload of these 2 additional marker messages is of type `FileSplitter.FileMarker`. The option `withMarkers` defaults to `false` if not explicitly set.
+
 To log the contents of a file create a stream definition using the XD shell
 
     xd:> stream create --name filetest --definition "file | log" --deploy
@@ -76,6 +80,7 @@ $$mode$$:: $$specifies how the file is being read. By default the content of a f
 $$pattern$$:: $$a filter expression (Ant style) to accept only files that match the pattern$$ *($$String$$, default: `*`)*
 $$preventDuplicates$$:: $$whether to prevent the same file from being processed twice$$ *($$boolean$$, default: `true`)*
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
+$$withMarkers$$:: $$if true emits start of file/end of file marker messages before/after the data. Only valid with FileReadingMode 'lines'$$ *($$Boolean$$, no default)*
 //$source.file
 
 The `ref` option is useful in some cases in which the file contents are large and it would be more efficient to send the file path.
@@ -91,6 +96,10 @@ customized using the `--mode` option:
 - *ref* Provides a `java.io.File` reference
 - *lines* Will split files line-by-line and emit a new message for each line
 - *contents* The default. Provides the contents of a file as a byte array
+
+When using `--mode=lines`, you can also provide the additional option `--withMarkers=true`.
+If set to `true`, the underlying `FileSplitter` will emit additional _start-of-file_ and _end-of-file_ marker messages before and after the actual data.
+The payload of these 2 additional marker messages is of type `FileSplitter.FileMarker`. The option `withMarkers` defaults to `false` if not explicitly set.
 
 ==== Options
 
@@ -117,6 +126,7 @@ $$remoteFileSeparator$$:: $$file separator to use on the remote side$$ *($$Strin
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
 $$tmpFileSuffix$$:: $$extension to use when downloading files$$ *($$String$$, default: `.tmp`)*
 $$username$$:: $$the username for the FTP connection$$ *($$String$$, no default)*
+$$withMarkers$$:: $$if true emits start of file/end of file marker messages before/after the data. Only valid with FileReadingMode 'lines'$$ *($$Boolean$$, no default)*
 //$source.ftp
 
 [[gemfire-continuous-query]]
@@ -699,6 +709,10 @@ customized using the `--mode` option:
 - *lines* Will split files line-by-line and emit a new message for each line
 - *contents* The default. Provides the contents of a file as a byte array
 
+When using `--mode=lines`, you can also provide the additional option `--withMarkers=true`.
+If set to `true`, the underlying `FileSplitter` will emit additional _start-of-file_ and _end-of-file_ marker messages before and after the actual data.
+The payload of these 2 additional marker messages is of type `FileSplitter.FileMarker`. The option `withMarkers` defaults to `false` if not explicitly set.
+
 ==== Options
 
 //^source.sftp
@@ -724,6 +738,7 @@ $$remoteDir$$:: $$the remote directory to transfer the files from$$ *($$String$$
 $$timeUnit$$:: $$the time unit for the fixed and initial delays$$ *($$String$$, default: `SECONDS`)*
 $$tmpFileSuffix$$:: $$extension to use when downloading files$$ *($$String$$, default: `.tmp`)*
 $$user$$:: $$the username to use$$ *($$String$$, no default)*
+$$withMarkers$$:: $$if true emits start of file/end of file marker messages before/after the data. Only valid with FileReadingMode 'lines'$$ *($$Boolean$$, no default)*
 //$source.sftp
 
 [[stdout]]


### PR DESCRIPTION
Enables the SOF/EOF markers when splitting a file into lines

* Upgrade Spring Integration dependency from `4.1.4.RELEASE` to `4.1.5.RELEASE`
* Add test
* Add documentation

Jira: https://jira.spring.io/browse/XD-3172