### PR TITLE
[Sprint: 51][1.2 GA] XD-3115 Support Reactor Processors that have an inheritance hierarchy

### DIFF
--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractMessageHandlerTests.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractMessageHandlerTests.java
@@ -36,15 +36,27 @@ public abstract class AbstractMessageHandlerTests {
 	@Autowired
 	@Qualifier("outputChannel1")
 	PollableChannel outputChannel1;
+
 	@Autowired
 	@Qualifier("outputChannel2")
 	PollableChannel outputChannel2;
+
+	@Autowired
+	@Qualifier("outputChannel3")
+	PollableChannel outputChannel3;
+
 	@Autowired
 	@Qualifier("toMessageHandlerChannel")
 	MessageChannel toMessageHandlerChannel;
+
 	@Autowired
 	@Qualifier("toStringHandlerChannel")
 	MessageChannel toStringHandlerChannel;
+
+	@Autowired
+	@Qualifier("toRawTypeHandlerChannel")
+	MessageChannel toRawTypeHandlerChannel;
+
 
 	@Test
 	public void pojoBasedProcessor() throws IOException {
@@ -65,10 +77,26 @@ public abstract class AbstractMessageHandlerTests {
 		}
 	}
 
+	@Test
+	public void rawTypeBasedProcessor() throws IOException {
+		sendRawMessages();
+		for (int i = 0; i < numMessages; i++) {
+			Message<?> outputMessage = outputChannel3.receive(500);
+			assertEquals("ping-objectpong", outputMessage.getPayload());
+		}
+	}
+
 	private void sendPojoMessages() {
 		Message<?> message = new GenericMessage<String>("ping");
 		for (int i = 0; i < numMessages; i++) {
 			toMessageHandlerChannel.send(message);
+		}
+	}
+
+	private void sendRawMessages() {
+		Message<?> message = new GenericMessage<String>("ping");
+		for (int i = 0; i < numMessages; i++) {
+			toRawTypeHandlerChannel.send(message);
 		}
 	}
 

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractPongStringProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractPongStringProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,8 @@
  */
 package org.springframework.xd.reactor;
 
-import reactor.fn.Function;
-import reactor.rx.Stream;
-
 /**
- * A simple stream processor that transforms Strings by adding "-pong" to the string.
- *
  * @author Mark Pollack
  */
-public class PongStringProcessor extends AbstractPongStringProcessor {
-
-    @Override
-    public Stream<String> process(Stream<String> inputStream) {
-        return inputStream.map(new Function<String, String>() {
-            @Override
-            public String apply(String message) {
-                return message + "-stringpong";
-            }
-        });
-    }
+public abstract class AbstractPongStringProcessor  implements Processor<String, String> {
 }

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractRawTypeProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractRawTypeProcessor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright ${today.year} the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.reactor;
+
+/**
+ * @author Marius Bogoevici
+ */
+public abstract class AbstractRawTypeProcessor implements Processor {
+}

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AdditionalInterface.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AdditionalInterface.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright ${today.year} the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.reactor;
+
+/**
+ * A test interface to be added on a processor, verifying that the code that extracts the input type
+ * identifies the {@link Processor} interface correctly
+ *
+ * @author Marius Bogoevici
+ */
+public interface AdditionalInterface<I,O> {
+
+	O handle(I input);
+}

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongRawTypeProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongRawTypeProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright ${today.year} the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,25 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.xd.reactor;
 
 import reactor.fn.Function;
 import reactor.rx.Stream;
 
 /**
- * A simple stream processor that transforms Strings by adding "-pong" to the string.
- *
- * @author Mark Pollack
+ * @author Marius Bogoevici
  */
-public class PongStringProcessor extends AbstractPongStringProcessor {
+public class PongRawTypeProcessor extends AbstractRawTypeProcessor implements AdditionalInterface<Integer,Integer> {
 
-    @Override
-    public Stream<String> process(Stream<String> inputStream) {
-        return inputStream.map(new Function<String, String>() {
-            @Override
-            public String apply(String message) {
-                return message + "-stringpong";
-            }
-        });
-    }
+	@Override
+	public Stream process(Stream inputStream) {
+		return inputStream.map(new Function<Object, Object>() {
+			@Override
+			public Object apply(Object message) {
+				return message.toString() + "-objectpong";
+			}
+		});
+	}
+
+	@Override
+	public Integer handle(Integer input) {
+		return input;
+	}
 }
+

--- a/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/BroadcasterMessageHandlerTests-context.xml
+++ b/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/BroadcasterMessageHandlerTests-context.xml
@@ -16,5 +16,10 @@
         <constructor-arg ref="stringProcessor"/>
     </bean>
 
+    <bean name="reactorRawTypeHandler" class="org.springframework.xd.reactor.BroadcasterMessageHandler">
+        <constructor-arg ref="rawTypeProcessor"/>
+    </bean>
+
+
 
 </beans>

--- a/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/MultipleBroadcasterMessageHandlerTests-context.xml
+++ b/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/MultipleBroadcasterMessageHandlerTests-context.xml
@@ -19,4 +19,11 @@
     </bean>
 
 
+    <bean name="reactorRawTypeHandler" class="org.springframework.xd.reactor.MultipleBroadcasterMessageHandler">
+        <constructor-arg ref="rawTypeProcessor"/>
+        <constructor-arg value="T(java.lang.Thread).currentThread().getId()"/>
+    </bean>
+
+
+
 </beans>

--- a/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/reactor.xml
+++ b/spring-xd-reactor/src/test/resources/org/springframework/xd/reactor/reactor.xml
@@ -14,10 +14,15 @@
         <int:queue capacity="20"/>
     </int:channel>
 
+    <int:channel id="outputChannel3">
+        <int:queue capacity="20"/>
+    </int:channel>
 
     <int:channel id="toMessageHandlerChannel"/>
 
     <int:channel id="toStringHandlerChannel"/>
+
+    <int:channel id="toRawTypeHandlerChannel"/>
 
     <bean id="messageProcessor" class="org.springframework.xd.reactor.PongMessageProcessor"/>
 
@@ -30,5 +35,9 @@
     <int:service-activator input-channel="toStringHandlerChannel" ref="reactorStringHandler"
                            output-channel="outputChannel2"/>
 
+    <bean id="rawTypeProcessor" class="org.springframework.xd.reactor.PongRawTypeProcessor"/>
+
+    <int:service-activator input-channel="toRawTypeHandlerChannel" ref="reactorRawTypeHandler"
+                           output-channel="outputChannel3"/>
 
 </beans>


### PR DESCRIPTION
- Navigate the class hierarchy for finding the parameterized Processor interface
- Ensure that the Processor interface is identified correctly for extracting type arguments
- Correct behaviour if a raw type processor is used
- Ensure that Message instances are passed directly if and only if the Processor defines a Message type argument