### PR TITLE
[Sprint: 51][1.2 GA] XD-3176 Adding Kerberos configuration for WritableResourceModuleRegistry

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/CustomModuleRegistryFactoryBean.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/CustomModuleRegistryFactoryBean.java
@@ -25,6 +25,9 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
 
 /**
  * Will create a {@link SynchronizingModuleRegistry} for hosting custom modules if necessary, depending on the
@@ -33,7 +36,7 @@ import org.springframework.beans.factory.InitializingBean;
  * @since 1.2
  * @author Eric Bottard
  */
-public class CustomModuleRegistryFactoryBean implements FactoryBean<WritableModuleRegistry>, InitializingBean{
+public class CustomModuleRegistryFactoryBean implements FactoryBean<WritableModuleRegistry>, EnvironmentAware, InitializingBean{
 
 	private static final Logger logger = LoggerFactory.getLogger(CustomModuleRegistryFactoryBean.class);
 
@@ -42,6 +45,9 @@ public class CustomModuleRegistryFactoryBean implements FactoryBean<WritableModu
 	private WritableModuleRegistry registry;
 
 	private final String root;
+
+	private ConfigurableEnvironment environment;
+
 
 	public CustomModuleRegistryFactoryBean(String root) {
 		this.root = root;
@@ -63,6 +69,11 @@ public class CustomModuleRegistryFactoryBean implements FactoryBean<WritableModu
 	}
 
 	@Override
+	public void setEnvironment(Environment environment) {
+		this.environment = (ConfigurableEnvironment) environment;
+	}
+
+	@Override
 	public void afterPropertiesSet() throws Exception {
 		Matcher matcher = NO_SYNCHRONIZATION_PATTERN.matcher(root);
 		if (matcher.matches()) {
@@ -76,6 +87,7 @@ public class CustomModuleRegistryFactoryBean implements FactoryBean<WritableModu
 			local.afterPropertiesSet();
 
 			WritableResourceModuleRegistry remote = new WritableResourceModuleRegistry(root);
+			remote.setEnvironment(environment);
 			remote.afterPropertiesSet();
 
 			registry = new SynchronizingModuleRegistry(remote, local);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/WritableResourceModuleRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/WritableResourceModuleRegistry.java
@@ -20,14 +20,20 @@ import java.io.IOException;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Properties;
 
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.core.io.WritableResource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
 import org.springframework.data.hadoop.configuration.ConfigurationFactoryBean;
 import org.springframework.data.hadoop.fs.HdfsResourceLoader;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.xd.dirt.core.RuntimeIOException;
 import org.springframework.xd.module.ModuleDefinition;
 import org.springframework.xd.module.ModuleType;
@@ -43,10 +49,14 @@ public class WritableResourceModuleRegistry extends ResourceModuleRegistry imple
 
 	final protected static byte[] HEX_DIGITS = "0123456789ABCDEF".getBytes();
 
+	final protected static String XD_CONFIG_HOME = "xd.config.home";
+
 	/**
 	 * Whether to attempt to create the directory structure at startup (disable for read-only implementations).
 	 */
 	private boolean createDirectoryStructure = true;
+
+	private ConfigurableEnvironment environment;
 
 
 	public WritableResourceModuleRegistry(String root) {
@@ -104,12 +114,65 @@ public class WritableResourceModuleRegistry extends ResourceModuleRegistry imple
 			throw new RuntimeException("Error trying to save " + uploadedModuleDefinition, e);
 		}
 	}
+
+	public void setEnvironment(Environment environment) {
+		this.environment = (ConfigurableEnvironment) environment;
+	}
+
 	@Override
 	public void afterPropertiesSet() throws Exception {
 		if (root.startsWith("hdfs:")) {
+			boolean securityConfigProvided = false;
+			String authMethod = "";
+			String namenodePrincipal = "";
+			String rmManagerPrincipal = "";
+			String userPrincipal = "";
+			String userKeytab = "";
+			// try servers.yml first
+			if (environment != null && environment.containsProperty("spring.hadoop.security.authMethod")) {
+				securityConfigProvided = true;
+				authMethod = environment.getProperty("spring.hadoop.security.authMethod");
+				namenodePrincipal = environment.getProperty("spring.hadoop.security.namenodePrincipal");
+				rmManagerPrincipal = environment.getProperty("spring.hadoop.security.rmManagerPrincipal");
+				userPrincipal = environment.getProperty("spring.hadoop.security.userPrincipal");
+				userKeytab = environment.getProperty("spring.hadoop.security.userKeytab");
+			}
+			// if needed check hadoop.properties
+			if (!securityConfigProvided && environment != null) {
+				String xdConfigHadoopProps = environment.getProperty(XD_CONFIG_HOME)+ "hadoop.properties";
+				Properties hadoopProps = null;
+				try {
+					hadoopProps = PropertiesLoaderUtils.loadProperties(new UrlResource(xdConfigHadoopProps));
+				} catch (IOException ignore) {}
+				if (hadoopProps != null && (hadoopProps.containsKey("spring.hadoop.security.authMethod") ||
+						hadoopProps.containsKey("hadoop.security.authentication"))) {
+					securityConfigProvided = true;
+					authMethod = hadoopProps.getProperty("spring.hadoop.security.authMethod");
+					if (!StringUtils.hasText(authMethod)) {
+						authMethod = hadoopProps.getProperty("hadoop.security.authentication");
+					}
+					namenodePrincipal = hadoopProps.getProperty("spring.hadoop.security.namenodePrincipal");
+					if (!StringUtils.hasText(namenodePrincipal)) {
+						namenodePrincipal = hadoopProps.getProperty("dfs.namenode.kerberos.principal");
+					}
+					rmManagerPrincipal = hadoopProps.getProperty("spring.hadoop.security.rmManagerPrincipal");
+					if (!StringUtils.hasText(rmManagerPrincipal)) {
+						rmManagerPrincipal = hadoopProps.getProperty("yarn.resourcemanager.principal");
+					}
+					userPrincipal = hadoopProps.getProperty("spring.hadoop.security.userPrincipal");
+					userKeytab = hadoopProps.getProperty("spring.hadoop.security.userKeytab");
+				}
+			}
 			ConfigurationFactoryBean configurationFactoryBean = new ConfigurationFactoryBean();
 			configurationFactoryBean.setRegisterUrlHandler(true);
 			configurationFactoryBean.setFileSystemUri(root);
+			if (securityConfigProvided && "kerberos".equals(authMethod)) {
+				configurationFactoryBean.setSecurityMethod(authMethod);
+				configurationFactoryBean.setNamenodePrincipal(namenodePrincipal);
+				configurationFactoryBean.setRmManagerPrincipal(rmManagerPrincipal);
+				configurationFactoryBean.setUserPrincipal(userPrincipal);
+				configurationFactoryBean.setUserKeytab(userKeytab);
+			}
 			configurationFactoryBean.afterPropertiesSet();
 
 			this.resolver = new HdfsResourceLoader(configurationFactoryBean.getObject());


### PR DESCRIPTION
- this only applies when HDFS is used for custom modules

- pulling security properties from servers.yml first and if not found there then from hadoop.properties