### PR TITLE
[Sprint 51] XD-3164 Expose Kafka bus properties on producers/consumers

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
@@ -45,7 +45,7 @@ class MessageBusConfiguration {
 
 	private static final String RABBIT_ACKMODE_PROPERTY = "xd.messagebus.rabbit.default.ackMode";
 
-	private static final String KAFKA_AUTOCOMMIT_PROPERTY = "xd.messagebus.kafka.default.autoCommitEnabled";
+	private static final String KAFKA_AUTO_OFFSET_COMMIT_PROPERTY = "xd.messagebus.kafka.default.autoOffsetCommitEnabled";
 
 	/**
 	 * This method called by {@link MessageBusReceiver} and {@link MessageBusSender} to setup
@@ -60,7 +60,7 @@ class MessageBusConfiguration {
 		String transport = properties.getProperty("XD_TRANSPORT");
 		// Set Rabbit message bus acknowledgement mode to 'MANUAL'
 		properties.setProperty(RABBIT_ACKMODE_PROPERTY, "MANUAL");
-		properties.setProperty(KAFKA_AUTOCOMMIT_PROPERTY, "false");
+		properties.setProperty(KAFKA_AUTO_OFFSET_COMMIT_PROPERTY, "false");
 		SpringApplicationBuilder application = new SpringApplicationBuilder()
 				.sources(MessageBusConfiguration.class)
 				// ensure the properties are added at the first precedence level

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -171,7 +171,7 @@ xd:
         concurrency:               1
         requiredAcks:              1
         compressionCodec:          none
-        autoCommitEnabled:         true
+        autoCommitOffsetEnabled:   true
         queueSize:                 8192 # must be a power of 2
         maxWait:                   100
         fetchSize:                 1048576

--- a/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
+++ b/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
@@ -29,7 +29,7 @@
 		<property name="defaultConcurrency" value="${xd.messagebus.kafka.default.concurrency}"/>
 		<property name="defaultCompressionCodec" value="${xd.messagebus.kafka.default.compressionCodec}"/>
 		<!-- ConsumerProperties -->
-		<property name="defaultAutoCommitEnabled" value="${xd.messagebus.kafka.default.autoCommitEnabled}"/>
+		<property name="defaultAutoCommitOffsetEnabled" value="${xd.messagebus.kafka.default.autoCommitOffsetEnabled}"/>
 		<property name="defaultFetchSize" value="${xd.messagebus.kafka.default.fetchSize}"/>
 		<property name="defaultMinPartitionCount" value="${xd.messagebus.kafka.default.minPartitionCount}"/>
 		<property name="defaultQueueSize" value="${xd.messagebus.kafka.default.queueSize}"/>


### PR DESCRIPTION
Exposes additional Kafka bus properties so that they can set on stream producers/consumers directly