### PR TITLE
XD-3217 The shell cannot connect to admin node when secured

### DIFF
--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTestSuite.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTestSuite.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.shell.security;
+
+import org.junit.runner.RunWith;
+
+import org.springframework.xd.test.PackageSuiteRunner;
+
+/**
+ * Runs all the secured shell tests. They need to be run independently as each starts a different Spring XD configuration
+ *
+ * @author Marius Bogoevici
+ */
+@RunWith(PackageSuiteRunner.class)
+public class SecuredShellAccessTestSuite {
+
+}

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import org.springframework.xd.test.RandomConfigurationSupport;
  *
  * @author Marius Bogoevici
  */
-public class SecuredShellAccessTest extends RandomConfigurationSupport {
+public class SecuredShellAccessTests extends RandomConfigurationSupport {
 
 	private static SingleNodeApplication singleNodeApplication;
 
@@ -170,9 +170,7 @@ public class SecuredShellAccessTest extends RandomConfigurationSupport {
 		JLineShellComponent shell = bootstrap.getJLineShellComponent();
 		CommandResult commandResult = shell.executeCommand("admin config server --uri http://localhost:" + adminPort + " --password whosThere");
 		assertThat(commandResult.isSuccess(), is(true));
-		Configuration configuration = bootstrap.getApplicationContext().getBean(Configuration.class);
-		assertThat(configuration.getTarget().getTargetException(), instanceOf(IllegalArgumentException.class));
-		assertThat(configuration.getTarget().getTargetException().getMessage(), equalTo("A password may be specified only together with a user name"));
+		assertThat(commandResult.getResult(), equalTo((Object)"A password may be specified only together with a username"));
 		commandResult = shell.executeCommand("module list");
 		assertThat(commandResult.isSuccess(), is(false));
 	}

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessWithSslTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessWithSslTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ import org.springframework.xd.test.RandomConfigurationSupport;
  *
  * @author Marius Bogoevici
  */
-public class SecuredShellAccessWithSslTest extends RandomConfigurationSupport {
+public class SecuredShellAccessWithSslTests extends RandomConfigurationSupport {
 
 	private static SingleNodeApplication singleNodeApplication;
 

--- a/spring-xd-shell/src/test/resources/org/springframework/xd/shell/security/securedServer.yml
+++ b/spring-xd-shell/src/test/resources/org/springframework/xd/shell/security/securedServer.yml
@@ -8,4 +8,5 @@ security:
   user:
     name: admin
     password: whosThere
+    role: ADMIN, VIEW, CREATE
 ---

--- a/spring-xd-shell/src/test/resources/org/springframework/xd/shell/security/securedServerWithSsl.yml
+++ b/spring-xd-shell/src/test/resources/org/springframework/xd/shell/security/securedServerWithSsl.yml
@@ -13,4 +13,5 @@ security:
   user:
     name: admin
     password: whosThere
+    role: ADMIN, VIEW, CREATE
 ---

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/config/SecurityConfiguration.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/config/SecurityConfiguration.java
@@ -99,6 +99,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 		ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry security =
 				http.csrf().disable()
 						.authorizeRequests()
+						.antMatchers("/").authenticated()
 						.antMatchers("/admin-ui/**").permitAll()
 						.antMatchers("/authenticate").permitAll()
 						.antMatchers("/security/info").permitAll()


### PR DESCRIPTION
* Allow access to '/' when user is authenticated (without being authenticated explicitly, the shell fails to connect) - redirection in the admin-ui obviates this;
* Create test suite for existing shell security tests, to avoid them being ignored
* Fix secured shell tests for out-of-date settings