### PR TITLE
[Sprint: 53] XD-3218 Handle deployment status recalucation failures

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentUnitStatus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentUnitStatus.java
@@ -65,7 +65,7 @@ public class DeploymentUnitStatus {
 	/**
 	 * Deployment unit states.
 	 */
-	public static enum State {
+	public enum State {
 
 		/**
 		 * The deployment unit is not deployed.
@@ -100,7 +100,8 @@ public class DeploymentUnitStatus {
 		undeploying,
 
 		/**
-		 * The deployment status is unknown or can't be calculated.
+		 * The deployment status could not be calculated; this is typically
+		 * due to an error loading the deployment unit.
 		 */
 		unknown
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentUnitStatus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentUnitStatus.java
@@ -97,7 +97,12 @@ public class DeploymentUnitStatus {
 		/**
 		 * The deployment unit is in the process of being undeployed.
 		 */
-		undeploying
+		undeploying,
+
+		/**
+		 * The deployment status is unknown or can't be calculated.
+		 */
+		unknown
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ContainerMatchingModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ContainerMatchingModuleRedeployer.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
@@ -123,7 +124,15 @@ public class ContainerMatchingModuleRedeployer extends ModuleRedeployer {
 		// iterate the cache of stream deployments
 		for (ChildData data : streamDeployments.getCurrentData()) {
 			String streamName = ZooKeeperUtils.stripPathConverter.convert(data);
-			final Stream stream = DeploymentLoader.loadStream(client, streamName, streamFactory);
+			Stream stream = null;
+			try {
+				stream = DeploymentLoader.loadStream(client, streamName, streamFactory);
+			}
+			catch (Exception e) {
+				logger.error(String.format("Exception loading the stream %s. The stream deployment status " +
+						"could be unknown. Fix the issue mentioned in the exception and restart the admin. " +
+						"The exception is: %s", streamName, ExceptionUtils.getStackTrace(e)));
+			}
 			// if stream is null this means the stream was destroyed or undeployed
 			if (stream != null) {
 				List<ModuleDeploymentRequestsPath> requestedModules =
@@ -167,7 +176,15 @@ public class ContainerMatchingModuleRedeployer extends ModuleRedeployer {
 			String jobName = ZooKeeperUtils.stripPathConverter.convert(data);
 
 			// if job is null this means the job was destroyed or undeployed
-			Job job = DeploymentLoader.loadJob(client, jobName, jobFactory);
+			Job job = null;
+			try {
+				job = DeploymentLoader.loadJob(client, jobName, jobFactory);
+			}
+			catch (Exception e) {
+				logger.error(String.format("Exception loading the job %s. The job deployment status could be " +
+						"unknown. Fix the issue mentioned in the exception and restart the admin. " +
+						"The exception is: %s", jobName, ExceptionUtils.getStackTrace(e)));
+			}
 			if (job != null) {
 				List<ModuleDeploymentRequestsPath> requestedModules = ModuleDeploymentRequestsPath.getModulesForDeploymentUnit(
 						requestedModulesPaths, jobName);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DepartingContainerModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DepartingContainerModuleRedeployer.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
@@ -121,18 +120,15 @@ public class DepartingContainerModuleRedeployer extends ModuleRedeployer {
 			String moduleType = moduleDeploymentsPath.getModuleType();
 
 			if (ModuleType.job.toString().equals(moduleType)) {
-				Job job = null;
 				try {
-					job = DeploymentLoader.loadJob(client, unitName, jobFactory);
+					final Job job = DeploymentLoader.loadJob(client, unitName, jobFactory);
+					if (job != null) {
+						redeployModule(new ModuleDeployment(job, job.getJobModuleDescriptor(),
+								deploymentProperties), false);
+					}
 				}
 				catch (Exception e) {
-					logger.error(String.format("Exception loading the job %s. The job deployment status could be " +
-							"unknown. Fix the issue mentioned in the exception and restart the admin. " +
-							"The exception is: %s", unitName, ExceptionUtils.getStackTrace(e)));
-				}
-				if (job != null) {
-					redeployModule(new ModuleDeployment(job, job.getJobModuleDescriptor(),
-							deploymentProperties), false);
+					logger.error(String.format("Exception loading job %s", unitName), e);
 				}
 			}
 			else {
@@ -140,18 +136,16 @@ public class DepartingContainerModuleRedeployer extends ModuleRedeployer {
 				if (stream == null) {
 					try {
 						stream = DeploymentLoader.loadStream(client, unitName, streamFactory);
+						streamMap.put(unitName, stream);
+						if (stream != null) {
+							streamModuleDeployments.add(new ModuleDeployment(stream,
+									stream.getModuleDescriptor(moduleDeploymentsPath.getModuleLabel()),
+									deploymentProperties));
+						}
 					}
 					catch (Exception e) {
-						logger.error(String.format("Exception loading the stream %s. The stream deployment status " +
-								"could be unknown. Fix the issue mentioned in the exception and restart the admin. " +
-								"The exception is: %s", unitName, ExceptionUtils.getStackTrace(e)));
+						logger.error(String.format("Exception loading stream %s.", unitName), e);
 					}
-					streamMap.put(unitName, stream);
-				}
-				if (stream != null) {
-					streamModuleDeployments.add(new ModuleDeployment(stream,
-							stream.getModuleDescriptor(moduleDeploymentsPath.getModuleLabel()),
-							deploymentProperties));
 				}
 			}
 		}


### PR DESCRIPTION
  - If the admin fails to load the stream/job (mostly if the module registry isn't in sync)
when recalculating the deployment status, then set the stream/job deployment unit status
to `unknown` and logs error message
  - This way the admin leader election would still happen but the stream status will
notify the user to act on.