### PR TITLE
XD-3219 Fix configuration in secure shell tests

### DIFF
--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTests.java
@@ -46,7 +46,7 @@ import org.springframework.xd.test.RandomConfigurationSupport;
  *
  * @author Marius Bogoevici
  */
-public class SecuredShellAccessTests extends RandomConfigurationSupport {
+public class SecuredShellAccessTests {
 
 	private static SingleNodeApplication singleNodeApplication;
 
@@ -56,10 +56,11 @@ public class SecuredShellAccessTests extends RandomConfigurationSupport {
 
 	@BeforeClass
 	public static void setUp() throws Exception {
+		RandomConfigurationSupport randomConfigurationSupport = new RandomConfigurationSupport();
 		originalConfigLocation = System.getProperty("spring.config.location");
 		System.setProperty("spring.config.location", "classpath:org/springframework/xd/shell/security/securedServer.yml");
 		singleNodeApplication = new SingleNodeApplication().run();
-		adminPort = singleNodeApplication.adminContext().getEnvironment().resolvePlaceholders("${server.port}");
+		adminPort = randomConfigurationSupport.getAdminServerPort();
 	}
 
 	@Test

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessWithSslTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessWithSslTests.java
@@ -47,7 +47,7 @@ import org.springframework.xd.test.RandomConfigurationSupport;
  *
  * @author Marius Bogoevici
  */
-public class SecuredShellAccessWithSslTests extends RandomConfigurationSupport {
+public class SecuredShellAccessWithSslTests {
 
 	private static SingleNodeApplication singleNodeApplication;
 
@@ -57,10 +57,11 @@ public class SecuredShellAccessWithSslTests extends RandomConfigurationSupport {
 
 	@BeforeClass
 	public static void setUp() throws Exception {
+		RandomConfigurationSupport randomConfigurationSupport = new RandomConfigurationSupport();
 		originalConfigLocation = System.getProperty("spring.config.location");
 		System.setProperty("spring.config.location", "classpath:org/springframework/xd/shell/security/securedServerWithSsl.yml");
 		singleNodeApplication = new SingleNodeApplication().run();
-		adminPort = singleNodeApplication.adminContext().getEnvironment().resolvePlaceholders("${server.port}");
+		adminPort = randomConfigurationSupport.getAdminServerPort();
 	}
 
 	@Test


### PR DESCRIPTION
 - Since the SecuredShellTests initialize singlenode app in a static way,
the random configuration needs to be setup statically as well.