### PR TITLE
[Sprint: 53] XD-3222 Adding a '--libjars' option to Sqoop job

### DIFF
--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopEnvironmentProvider.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopEnvironmentProvider.java
@@ -31,8 +31,11 @@ public class SqoopEnvironmentProvider implements EnvironmentProvider {
 
 	ConfigurableEnvironment environment;
 
-	public SqoopEnvironmentProvider(ConfigurableEnvironment environment) {
+	String libjars;
+
+	public SqoopEnvironmentProvider(ConfigurableEnvironment environment, String libjars) {
 		this.environment = environment;
+		this.libjars = libjars;
 	}
 
 	@Override
@@ -42,6 +45,9 @@ public class SqoopEnvironmentProvider implements EnvironmentProvider {
 			env.put("JAVA_HOME", javaHome);
 		}
 		env.put("SQOOP_CONF_DIR", environment.getProperty(XD_CONFIG_HOME));
+		if (StringUtils.hasText(libjars)) {
+			env.put("XD_MODULE_LIBJARS", libjars);
+		}
 	}
 
 }

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopOptionsMetadata.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopOptionsMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ public class SqoopOptionsMetadata {
 
 	private String args = "";
 
+	private String libjars = "";
+
 	@NotBlank
 	public String getCommand() {
 		return command;
@@ -53,5 +55,14 @@ public class SqoopOptionsMetadata {
 	@ModuleOption("the arguments for the Sqoop command")
 	public void setArgs(String args) {
 		this.args = args;
+	}
+
+	public String getLibjars() {
+		return libjars;
+	}
+
+	@ModuleOption("extra jars from the classpath to add to the job")
+	public void setLibjars(String libjars) {
+		this.libjars = libjars;
 	}
 }

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
@@ -51,6 +51,8 @@ public class SqoopTasklet extends AbstractProcessBuilderTasklet implements Initi
 
 	private Properties hadoopProperties;
 
+	private String libjars;
+
 
 	public String[] getArguments() {
 		return arguments;
@@ -66,6 +68,10 @@ public class SqoopTasklet extends AbstractProcessBuilderTasklet implements Initi
 
 	public void setHadoopProperties(Properties hadoopProperties) {
 		this.hadoopProperties = hadoopProperties;
+	}
+
+	public void setLibjars(String libjars) {
+		this.libjars = libjars;
 	}
 
 	@Override
@@ -132,7 +138,7 @@ public class SqoopTasklet extends AbstractProcessBuilderTasklet implements Initi
 		if (arguments == null || arguments.length < 1) {
 			throw new IllegalArgumentException("Missing arguments and/or configuration options for Sqoop");
 		}
-		addEnvironmentProvider(new SqoopEnvironmentProvider(environment));
+		addEnvironmentProvider(new SqoopEnvironmentProvider(environment, libjars));
 		addEnvironmentProvider(new ClasspathEnvironmentProvider(environment, this.getClass()));
 	}
 }

--- a/modules/job/sqoop/config/sqoop.xml
+++ b/modules/job/sqoop/config/sqoop.xml
@@ -43,6 +43,7 @@
 			</list>
 		</property>
 		<property name="hadoopProperties" ref="hadoopProperties"/>
+		<property name="libjars" value="${libjars}"/>
 	</bean>
 
 	<util:properties id="hadoopProperties" location="${xd.config.home}/hadoop.properties"/>

--- a/src/docs/asciidoc/Jobs.asciidoc
+++ b/src/docs/asciidoc/Jobs.asciidoc
@@ -549,6 +549,8 @@ job create sqoopHiveArgs1 --definition "sqoop --command=import --args='--table M
 
 For more detailed coverage of using quotes and escaping please see xref:DSL-Reference#dsl-quotes-escaping[Single quotes, Double quotes, Escaping].
 
+NOTE: Some JDBC drivers require additional jars to work properly. If this is the case, then you can use the `--libjars` option to provide a comma separated list of jars to be added to the job execution. You should only specify the name of the jar and not the full path. The jars will be looked up from the classpath and included in the job submitted to the Hadoop cluster.
+
 NOTE: Advanced Hadoop configuration options can be provided in one of several configuration files. The `hadoop-site.xml` file is only used by the Sqoop job while the other configuration files are used by all Hadoop related jobs and streams:
 
 - `$XD_HOME/config/hadoop.properties` -- just add the property you would like to set:
@@ -644,6 +646,7 @@ $$args$$:: $$the arguments for the Sqoop command$$ *($$String$$, default: ``)*
 $$command$$:: $$the Sqoop command to run$$ *($$String$$, default: ``)*
 $$driverClassName$$:: $$the JDBC driver to use$$ *($$String$$, no default)*
 $$fsUri$$:: $$the URI to use to access the Hadoop FileSystem$$ *($$String$$, default: `${spring.hadoop.fsUri}`)*
+$$libjars$$:: $$extra jars from the classpath to add to the job$$ *($$String$$, default: ``)*
 $$password$$:: $$the JDBC password$$ *($$Password$$, no default)*
 $$resourceManagerHost$$:: $$the Host for Hadoop's ResourceManager$$ *($$String$$, default: `${spring.hadoop.resourceManagerHost}`)*
 $$resourceManagerPort$$:: $$the Port for Hadoop's ResourceManager$$ *($$String$$, default: `${spring.hadoop.resourceManagerPort}`)*


### PR DESCRIPTION
* this allows us to specify additional jars from the classpath to be added to the job execution

* this is useful for JDBC drivers that come with multiple jars (like Teradata)
  - just add --libjars=tdgssconfig.jar to the job definition and it will be added
  - the terajdbc4.jar is already added automatically since it contains the driver class