### PR TITLE
[Sprint: 53] XD-3232: Exclude Transitive Guava Deps

### DIFF
--- a/gradle/build-extensions.gradle
+++ b/gradle/build-extensions.gradle
@@ -184,7 +184,7 @@ project('spring-xd-extension-jdbc') {
         compile "org.springframework:spring-tx"
         compile "org.springframework.batch:spring-batch-infrastructure"
         compile "org.springframework.integration:spring-integration-core"
-        runtime "org.springframework.integration:spring-integration-jdbc"
+        runtime ("org.springframework.integration:spring-integration-jdbc") { exclude group: 'com.google.guava' }
         runtime "com.fasterxml.jackson.core:jackson-databind"
         compile "org.hsqldb:hsqldb"
         runtime "mysql:mysql-connector-java"
@@ -256,7 +256,7 @@ project('spring-xd-extension-sqoop') {
     dependencies {
         compile project(':spring-xd-module-spi')
         compile project(':spring-xd-extension-batch')
-        compile project(':spring-xd-extension-jdbc')
+        compile (project(':spring-xd-extension-jdbc')) { exclude group: 'com.google.guava' }
         compile "org.apache.sqoop:sqoop:${sqoopVersion}:hadoop200"
         provided "org.springframework.batch:spring-batch-core"
         provided "org.springframework.data:spring-data-hadoop-core:${springDataHadoopBase}"
@@ -269,7 +269,7 @@ project('spring-xd-extension-gpload') {
     dependencies {
         compile project(':spring-xd-module-spi')
         compile project(':spring-xd-extension-batch')
-        compile project(':spring-xd-extension-jdbc')
+        compile (project(':spring-xd-extension-jdbc'))  { exclude group: 'com.google.guava' }
         provided "org.springframework.batch:spring-batch-core"
         compile "org.yaml:snakeyaml"
     }

--- a/gradle/build-modules.gradle
+++ b/gradle/build-modules.gradle
@@ -100,7 +100,7 @@ project('modules.source.http') {
 }
 
 project('modules.source.jdbc') {
-    dependencies { runtime project(":spring-xd-extension-jdbc") }
+    dependencies { runtime(project(":spring-xd-extension-jdbc")) { exclude group: 'com.google.guava' } }
 }
 
 project('modules.source.tcp') {
@@ -228,7 +228,7 @@ project('modules.processor.aggregator') {
     dependencies {
         // These are for the message stores
         runtime	("org.springframework.integration:spring-integration-redis") { exclude group: 'org.slf4j' }
-        runtime	("org.springframework.integration:spring-integration-jdbc")
+        runtime	("org.springframework.integration:spring-integration-jdbc") { exclude group: 'com.google.guava' }
     }
 }
 
@@ -284,11 +284,11 @@ project('modules.sink.file') {
 }
 
 project('modules.sink.jdbc') {
-    dependencies { runtime project(":spring-xd-extension-jdbc") }
+    dependencies { runtime(project(":spring-xd-extension-jdbc")) { exclude group: 'com.google.guava' } }
 }
 
 project('modules.sink.gpfdist') {
-    dependencies { runtime project(":spring-xd-extension-gpfdist") }
+    dependencies { runtime(project(":spring-xd-extension-gpfdist")) { exclude group: 'com.google.guava' } }
 }
 
 project('modules.sink.mail') {
@@ -374,7 +374,7 @@ project('modules.job.sparkapp') {
 
 project('modules.job.filejdbc') {
     dependencies {
-        runtime(project(":spring-xd-extension-jdbc"))
+        runtime(project(":spring-xd-extension-jdbc")) { exclude group: 'com.google.guava' }
     }
 }
 
@@ -386,13 +386,13 @@ project('modules.job.hdfsmongodb') {
 
 project('modules.job.hdfsjdbc') {
     dependencies {
-        runtime(project(":spring-xd-extension-jdbc"))
+        runtime(project(":spring-xd-extension-jdbc")) { exclude group: 'com.google.guava' }
     }
 }
 
 project('modules.job.jdbchdfs') {
     dependencies {
-        runtime(project(":spring-xd-extension-jdbc"))
+        runtime(project(":spring-xd-extension-jdbc")) { exclude group: 'com.google.guava' }
         runtime(project(":spring-xd-extension-batch"))
     }
 }


### PR DESCRIPTION
Pulled into modules transitively via s-i-jdbc (used StoredProc adapter only)