### PR TITLE
[Sprint: 53] XD-3258 Adding jars needed for writing Avro format and Snappy compres…

### DIFF
--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
@@ -92,6 +92,7 @@ public class SqoopRunner {
 
 		String xdModuleLibjars = System.getenv("XD_MODULE_LIBJARS");
 		if (StringUtils.hasText(xdModuleLibjars)) {
+			logger.info("Adding --libjars to Sqoop job submission");
 			String[] extraJars = StringUtils.commaDelimitedListToStringArray(xdModuleLibjars);
 			List<URL> classPathUrls = new ArrayList<URL>();
 			try {
@@ -105,6 +106,23 @@ public class SqoopRunner {
 						logger.info("Adding jar: " + url);
 						libJars.add(new UrlResource(url));
 					}
+				}
+			}
+			ConfigurationUtils.addLibs(configuration, libJars.toArray(new Resource[libJars.size()]));
+		}
+
+		if (sqoopArguments.contains("--as-avrodatafile")) {
+			logger.info("Adding Avro libraries to Sqoop job submission");
+			List<URL> classPathUrls = new ArrayList<URL>();
+			try {
+				classPathUrls.addAll(Arrays.asList(((URLClassLoader) SqoopRunner.class.getClassLoader()).getURLs()));
+			} catch (Exception ignore) {
+			}
+			List<Resource> libJars = new ArrayList<>();
+			for (URL url : classPathUrls) {
+				if (url.getPath().contains("avro-mapred-1.7") || url.getPath().contains("avro-1.7")) {
+					logger.info("Adding jar: " + url);
+					libJars.add(new UrlResource(url));
 				}
 			}
 			ConfigurationUtils.addLibs(configuration, libJars.toArray(new Resource[libJars.size()]));

--- a/gradle/build-modules.gradle
+++ b/gradle/build-modules.gradle
@@ -410,8 +410,31 @@ project('modules.job.timestampfile') {
 }
 
 project('modules.job.sqoop') {
+    configurations.runtime {
+        resolutionStrategy {
+            eachDependency { DependencyResolveDetails details ->
+                //Force requested version of Snappy so we can copy it to the lib directory
+                if (details.requested.group == 'org.xerial.snappy' && details.requested.name == 'snappy-java') {
+                    details.useVersion requested.version
+                }
+            }
+        }
+    }
     dependencies {
         runtime(project(":spring-xd-extension-sqoop"))
+        runtime('org.xerial.snappy:snappy-java:1.0.5')
+        runtime('org.apache.avro:avro-mapred:1.7.6:hadoop2') {
+            exclude group: 'org.apache.avro', module: 'avro-ipc'
+            exclude group: 'com.google.guava', module: 'guava'
+        }
+    }
+    copyLibs.dependsOn {
+        copyExtraLibs
+    }
+    task copyExtraLibs(type: Copy) {
+        from configurations.runtime
+        into project.file('lib/')
+        include 'snappy-java-*'
     }
 }
 

--- a/src/docs/asciidoc/Jobs.asciidoc
+++ b/src/docs/asciidoc/Jobs.asciidoc
@@ -549,7 +549,9 @@ job create sqoopHiveArgs1 --definition "sqoop --command=import --args='--table M
 
 For more detailed coverage of using quotes and escaping please see xref:DSL-Reference#dsl-quotes-escaping[Single quotes, Double quotes, Escaping].
 
-NOTE: Some JDBC drivers require additional jars to work properly. If this is the case, then you can use the `--libjars` option to provide a comma separated list of jars to be added to the job execution. You should only specify the name of the jar and not the full path. The jars will be looked up from the classpath and included in the job submitted to the Hadoop cluster.
+NOTE: Some JDBC drivers and some compression codecs require additional jars to work properly. If this is the case, then you can use the `--libjars` option to provide a comma separated list of jars to be added to the job execution. You should only specify the name of the jar and not the full path. The jars will be looked up from the classpath and included in the job submitted to the Hadoop cluster.
+
+NOTE: When using Sqoop's `--as-avrodatafile` argument we will automatically include the Avro jars in the Sqoop job submission. No need to specify them as part of the `--libjars` option.
 
 NOTE: Advanced Hadoop configuration options can be provided in one of several configuration files. The `hadoop-site.xml` file is only used by the Sqoop job while the other configuration files are used by all Hadoop related jobs and streams:
 


### PR DESCRIPTION
…sion

-- when using the --as-avrodatafile Sqoop argument we add needed Avro jars to the job submission automatically

-- adding avro-mapred-1.7.6-hadoop2.jar to lib directory of the sqoop job since we need that for --as-avrodatafile

-- adding snappy-java-1.0.5 to lib directory of the sqoop job since 1.1.0.1 version in xd/lib didn't work with Sqoop 1.4.5

NOTE: we should backport this to 1.2.x as well