### PR TITLE
[Sprint: 55] [1.2.x] XD-3078: Module redeploy to reconnected containers

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DepartedContainerModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DepartedContainerModuleRedeployer.java
@@ -52,12 +52,12 @@ import org.springframework.xd.module.RuntimeModuleDeploymentProperties;
  * @author Mark Fisher
  * @author Ilayaperumal Gopinathan
  */
-public class DepartingContainerModuleRedeployer extends ModuleRedeployer {
+public class DepartedContainerModuleRedeployer extends ModuleRedeployer {
 
 	/**
 	 * Logger.
 	 */
-	protected final Logger logger = LoggerFactory.getLogger(DepartingContainerModuleRedeployer.class);
+	protected final Logger logger = LoggerFactory.getLogger(DepartedContainerModuleRedeployer.class);
 
 	/**
 	 * Constructs {@code DepartingContainerModuleRedeployer}
@@ -71,7 +71,7 @@ public class DepartingContainerModuleRedeployer extends ModuleRedeployer {
 	 * @param moduleDeploymentWriter utility that writes deployment requests to zk path
 	 * @param stateCalculator calculator for stream/job state
 	 */
-	public DepartingContainerModuleRedeployer(ZooKeeperConnection zkConnection,
+	public DepartedContainerModuleRedeployer(ZooKeeperConnection zkConnection,
 			ContainerRepository containerRepository,
 			StreamFactory streamFactory, JobFactory jobFactory,
 			PathChildrenCache moduleDeploymentRequests, ContainerMatcher containerMatcher,

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/JobStateTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/JobStateTests.java
@@ -17,7 +17,7 @@
 package org.springframework.xd.distributed.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.springframework.test.util.MatcherAssertionErrors.assertThat;
+import static org.junit.Assert.assertThat;
 
 import java.io.BufferedReader;
 import java.io.File;


### PR DESCRIPTION
Modified ContainerListener as follows:

1. Handling of departed containers has been placed into a `Runnable`. This `Runnable` (`DepartedContainerDeployer`) is scheduled for execution when a container departs.

2. `DepartedContainerDeployer` is also scheduled on a regular basis to ensure that departed containers are processed in cases where an event for the departed container was not raised. This may happen if the admin server is disconnected from ZooKeeper.

See https://docs.google.com/document/d/17L_TmWdrlPP6pyUdLrD_CinyjC3JsULfd7QXJtKHVw4/edit for more background.