### PR TITLE
Including htrace-core-3.1.0-incubating.jar for hadoop 2.7.1 based dis…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1176,7 +1176,6 @@ project('spring-xd-shell') {
 		compile "commons-io:commons-io"
 		configurations.compile.exclude(group: "xerces")
 
-		runtime 'org.apache.htrace:htrace-core:3.1.0-incubating'
 		runtime 'ch.qos.logback:logback-classic'
 
 		testCompile project(":spring-xd-test-fixtures")

--- a/gradle/build-hadoop-distros.gradle
+++ b/gradle/build-hadoop-distros.gradle
@@ -43,6 +43,7 @@ project('spring-xd-hadoop:hadoop27') {
 		from configurations.default
 		include 'spring-data-hadoop-*'
 		include 'hadoop-*'
+		include 'htrace-core-*'
 		include 'avro-*'
 		include 'protobuf-java-*'
 		include 'jetty-util-*'
@@ -149,6 +150,7 @@ project('spring-xd-hadoop:hdp23') {
 		from configurations.default
 		include 'spring-data-hadoop-*'
 		include 'hadoop-*'
+		include 'htrace-core-*'
 		include 'avro-*'
 		include 'protobuf-java-*'
 		include 'jetty-util-*'


### PR DESCRIPTION
…tros

- adding this jar to distro classpath

- removing it from shell base classpath

- fixes NoClassDefFoundError: org/apache/htrace/SamplerBuilder in hdfs sink