### PR TITLE
[Sprint: 58] XD-3568 Add exludes for Boot Solr auto configuration

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
 import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.ServerPropertiesAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -44,7 +45,8 @@ import org.springframework.xd.dirt.util.ConfigLocations;
  */
 @EnableAutoConfiguration(exclude = {ServerPropertiesAutoConfiguration.class, BatchAutoConfiguration.class,
 		ThymeleafAutoConfiguration.class, JmxAutoConfiguration.class, HealthIndicatorAutoConfiguration.class,
-		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class })
+		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class,
+		SolrAutoConfiguration.class })
 @ImportResource("classpath:" + ConfigLocations.XD_CONFIG_ROOT + "global/parent-context.xml")
 @EnableBatchProcessing
 public class ParentConfiguration {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminServerApplication.java
@@ -34,6 +34,7 @@ import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAuto
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerException;
 import org.springframework.context.ApplicationContext;
@@ -65,7 +66,7 @@ import org.springframework.xd.dirt.web.WebConfiguration;
 @Configuration
 @EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, JmxAutoConfiguration.class,
 		AuditAutoConfiguration.class, GroovyTemplateAutoConfiguration.class, MongoAutoConfiguration.class,
-		MongoDataAutoConfiguration.class })
+		MongoDataAutoConfiguration.class, SolrAutoConfiguration.class})
 @ImportResource("classpath:" + ConfigLocations.XD_INTERNAL_CONFIG_ROOT + "admin-server.xml")
 @ComponentScan("org.springframework.xd.dirt.server.security")
 @Import({RestConfiguration.class, WebConfiguration.class, DeploymentConfiguration.class})

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.xd.dirt.cluster.AdminAttributes;
@@ -51,7 +52,8 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
  */
 @Configuration
 @EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, JmxAutoConfiguration.class,
-		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class })
+		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class,
+		SolrAutoConfiguration.class })
 public class DeploymentConfiguration {
 
 	@Autowired

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
@@ -51,7 +52,8 @@ import org.springframework.xd.module.options.ModuleOptionsMetadataResolver;
  */
 @Configuration
 @EnableAutoConfiguration(exclude = {BatchAutoConfiguration.class, JmxAutoConfiguration.class,
-		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class })
+		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class,
+		SolrAutoConfiguration.class })
 public class ContainerConfiguration {
 
 	/*

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerServerApplication.java
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -63,7 +64,8 @@ import org.springframework.xd.dirt.util.XdProfiles;
  */
 @Configuration
 @EnableAutoConfiguration(exclude = { BatchAutoConfiguration.class, JmxAutoConfiguration.class,
-	AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class })
+		AuditAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class,
+		SolrAutoConfiguration.class })
 public class ContainerServerApplication implements EnvironmentAware {
 
 	private static final Logger logger = LoggerFactory.getLogger(ContainerServerApplication.class);

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/WebConfiguration.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/WebConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.solr.SolrAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,7 +28,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Gunnar Hillert
  */
 @EnableAutoConfiguration(exclude = {GroovyTemplateAutoConfiguration.class,
-		MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
+		MongoAutoConfiguration.class, MongoDataAutoConfiguration.class, SolrAutoConfiguration.class})
 @Configuration
 @ComponentScan
 public class WebConfiguration {


### PR DESCRIPTION
- needed when Solr 5.x is on classpath - see https://github.com/spring-projects/spring-boot/issues/2795

- add SolrAutoConfiguration.class to exclude for @EnableAutoConfiguration