### PR TITLE
Add a Job DSL Parser

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ArgumentNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ArgumentNode.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+/**
+ * Represents an argument like "--name=value".
+ *
+ * @author Andy Clement
+ */
+public class ArgumentNode extends AstNode {
+
+	private final String name;
+
+	private final String value;
+
+	public ArgumentNode(String name, String value, int startpos, int endpos) {
+		super(startpos, endpos);
+		this.name = name;
+		this.value = value;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public String stringify(boolean includePositionalInfo) {
+		StringBuilder s = new StringBuilder();
+		s.append("--").append(name).append("=").append(value);
+		return s.toString();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder s = new StringBuilder();
+		s.append("--").append(name).append("=").append(value);
+		return s.toString();
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/AstNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/AstNode.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+/**
+ * AST base class for AST nodes in a parsed Job specification.
+ *
+ * @author Andy Clement
+ */
+public abstract class AstNode {
+
+	protected int startpos;
+
+	protected int endpos;
+
+	public AstNode(int startPos, int endPos) {
+		this.startpos = startPos;
+		this.endpos = endPos;
+	}
+
+	public int getStartPos() {
+		return startpos;
+	}
+
+	public int getEndPos() {
+		return endpos;
+	}
+
+	/**
+	 * @return a string representation of the AST. Useful for debugging/testing.
+	 */
+	public abstract String stringify(boolean includePositionInfo);
+
+	public String stringify() {
+		return stringify(false);
+	}
+
+	// TODO pretty print the AST to a (possibly multiline) string
+	public String format(int currentIndent) {
+		return "";
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/CheckpointedJobDefinitionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/CheckpointedJobDefinitionException.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.List;
+
+/**
+ * An extension of JobSpecificationException that remembers the point up to which parsing went OK (signaled by a '*' in
+ * the dumped message).
+ *
+ * @author Eric Bottard
+ */
+@SuppressWarnings("serial")
+public class CheckpointedJobDefinitionException extends JobSpecificationException {
+
+	private int checkpointPointer = -1;
+
+	private List<Token> tokens;
+
+	private int tokenPointer;
+
+	/**
+	 * Construct a new exception
+	 * @param expressionString the raw, untokenized text that was being parsed
+	 * @param textPosition the text offset where the error occurs
+	 * @param checkpointPointer the token-index of the last known good token
+	 * @param tokenPointer the token-index of token where the error occured
+	 * @param tokens the list of tokens that make up expressionString
+	 * @param message the error message
+	 * @param inserts variables that may be inserted in the error message
+	 */
+	public CheckpointedJobDefinitionException(String expressionString, int textPosition, int tokenPointer,
+			int checkpointPointer, List<Token> tokens, JobDSLMessage message, Object... inserts) {
+		super(expressionString, textPosition, message, inserts);
+		this.tokenPointer = tokenPointer;
+		this.checkpointPointer = checkpointPointer;
+		this.tokens = tokens;
+	}
+
+
+	/**
+	 * @return a formatted message with inserts applied.
+	 */
+	@Override
+	public String getMessage() {
+		StringBuilder s = new StringBuilder();
+		if (message != null) {
+			s.append(message.formatMessage(position, inserts));
+		}
+		else {
+			s.append(super.getMessage());
+		}
+		if (expressionString != null && expressionString.length() > 0) {
+			s.append("\n").append(expressionString).append("\n");
+		}
+		int offset = position;
+		if (checkpointPointer > 0 && offset >= 0) {
+			int checkpointPosition = getCheckpointPosition();
+			offset -= checkpointPosition;
+			for (int i = 0; i < checkpointPosition; i++) {
+				s.append(' ');
+			}
+			s.append("*");
+			offset--; // account for the '*'
+		}
+		if (offset >= 0) {
+			for (int i = 0; i < offset; i++) {
+				s.append(' ');
+			}
+			s.append("^\n");
+		}
+		return s.toString();
+	}
+
+
+	public int getCheckpointPosition() {
+		return checkpointPointer == 0 ? 0 : tokens.get(checkpointPointer - 1).endpos;
+	}
+
+	/**
+	 * Return the parsed expression until the last known, well formed position. Attempting to re-parse that expression
+	 * is guaranteed to not fail.
+	 */
+	public String getExpressionStringUntilCheckpoint() {
+		return expressionString.substring(0, getCheckpointPosition());
+	}
+
+	public int getCheckpointPointer() {
+		return checkpointPointer;
+	}
+
+
+	public List<Token> getTokens() {
+		return tokens;
+	}
+
+
+	public int getTokenPointer() {
+		return tokenPointer;
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Flow.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Flow.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The AST node representing a flow. A flow is a series of jobs to execute sequentially. Those jobs
+ * can themselves be individual jobs or splits. In DSL form a flow is expressed like this:
+ * <pre><tt>aa || bb</tt></pre>.
+ *
+ * @author Andy Clement
+ */
+public class Flow extends JobSeries {
+
+	private List<JobNode> series;
+
+	public Flow(List<JobNode> jobDefOrRefsWithConditions) {
+		super(jobDefOrRefsWithConditions.get(0).getStartPos(),
+				jobDefOrRefsWithConditions.get(jobDefOrRefsWithConditions.size() - 1).getEndPos());
+		this.series = Collections.unmodifiableList(jobDefOrRefsWithConditions);
+	}
+
+	@Override
+	public String stringify(boolean includePositionInfo) {
+		StringBuilder s = new StringBuilder();
+		for (int i = 0; i < series.size(); i++) {
+			if (i > 0) {
+				s.append(" ").append(TokenKind.DOUBLE_PIPE.getTokenString()).append(" ");
+			}
+			s.append(series.get(i).stringify(includePositionInfo));
+		}
+		return s.toString();
+	}
+
+	@Override
+	public int getSeriesLength() {
+		return series.size();
+	}
+
+	@Override
+	public List<JobNode> getSeries() {
+		return series;
+	}
+
+	@Override
+	public JobNode getSeriesElement(int index) {
+		return series.get(index);
+	}
+
+	@Override
+	boolean isFlow() {
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "[Flow:" + stringify(true) + "]";
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
@@ -17,8 +17,11 @@
 package org.springframework.xd.dirt.job.dsl;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -27,11 +30,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  * @author Andy Clement
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Graph {
 
-	public final List<Node> nodes;
+	public List<Node> nodes;
 
-	public final List<Link> links;
+	public List<Link> links;
+
+	Graph() {
+		this.nodes = new ArrayList<>();
+		this.links = new ArrayList<>();
+	}
 
 	Graph(List<Node> nodes, List<Link> links) {
 		this.nodes = nodes;
@@ -46,18 +55,244 @@ public class Graph {
 		return this.links;
 	}
 
+	@Override
+	public String toString() {
+		return "Graph:  nodes=#" + nodes.size() + "  links=#" + links.size() + "\n" + nodes + "\n" + links;
+	}
+
 	public String toJSON() {
 		Graph g = new Graph(nodes, links);
 		ObjectMapper mapper = new ObjectMapper();
-		//		mapper.setVisibilityChecker(
-		//				mapper.getSerializationConfig().getDefaultVisibilityChecker().withFieldVisibility(Visibility.ANY));
 		mapper.setSerializationInclusion(Include.NON_NULL);
 		try {
 			return mapper.writeValueAsString(g);
 		}
 		catch (IOException e) {
-			e.printStackTrace();
+			throw new IllegalStateException("Unexpected problem creating JSON from Graph", e);
+		}
+	}
+
+	/**
+	 * Produce the DSL representation of the graph.
+	 * To make this process easier we can assume there is a START and an END node.
+	 *
+	 * @return DSL string version of the graph
+	 */
+	public String toDSLText() {
+		StringBuilder graphText = new StringBuilder();
+		List<Node> unvisitedNodes = new ArrayList<>();
+		unvisitedNodes.addAll(nodes);
+		Node start = findNodeByName("START");
+		Node end = findNodeByName("END");
+		if (start == null || end == null) {
+			throw new IllegalStateException("Graph is malformed - problems finding START and END nodes");
+		}
+		List<Link> toFollow = findLinksFrom(start, false);
+		followLinks(graphText, toFollow, null);
+		return graphText.toString();
+	}
+
+	/**
+	 * Chase down links, populating the graphText as it proceeds.
+	 *
+	 * @param graphText where to place the DSL text as we process the graph
+	 * @param toFollow the links to follow
+	 * @param nodeToTerminateFollow the node that should trigger termination of following
+	 */
+	private void followLinks(StringBuilder graphText, List<Link> toFollow, Node nodeToTerminateFollow) {
+		while (toFollow.size() != 0) {
+			if (toFollow.size() > 1) { // SPLIT
+				if (graphText.length() != 0) {
+					// If there is something already in the text, a || is needed to
+					// join it to the preceeding element
+					graphText.append(" || ");
+				}
+				graphText.append("<");
+				Node endOfSplit = findEndOfSplit(toFollow);
+				for (int i = 0; i < toFollow.size(); i++) {
+					if (i > 0) {
+						graphText.append(" & ");
+					}
+					Link l = toFollow.get(i);
+					followLink(graphText, l, endOfSplit);
+				}
+				graphText.append(">");
+				if (endOfSplit == null || endOfSplit.isEnd()) {
+					// nothing left to do
+					break;
+				}
+				if (endOfSplit == nodeToTerminateFollow) {
+					// Time to finish if termination node hit
+					break;
+				}
+				if (!endOfSplit.isSync()) {
+					// If not a sync node, include it in the output text
+					graphText.append(" || ");
+					printNode(graphText, endOfSplit);
+				}
+				toFollow = findLinksFromWithoutTransitions(endOfSplit, false);
+			}
+			else if (toFollow.size() == 1) { // FLOW
+				if (findNodeById(toFollow.get(0).to) != nodeToTerminateFollow) {
+					if (graphText.length() != 0) {
+						// First one doesn't need a || on the front
+						graphText.append(" || ");
+					}
+					followLink(graphText, toFollow.get(0), nodeToTerminateFollow);
+				}
+				break;
+			}
+		}
+	}
+
+	private Node findEndOfSplit(List<Link> toFollow) {
+		if (toFollow.size() == 0) {
+			return null;
+		}
+		if (toFollow.size() == 1) {
+			// return the first node...
+			return findNodeById(toFollow.get(0).to);
+		}
+		// Follow the first link. For each node found see if it
+		// exists down the chain of all the other links (i.e. is a common target)
+		Link link = toFollow.get(0);
+		Node nextCandidate = findNodeById(link.to);
+		while (nextCandidate != null) {
+			boolean allLinksLeadToTheCandidate = true;
+			for (int l = 1; l < toFollow.size(); l++) {
+				if (!foundInChain(toFollow.get(l), nextCandidate)) {
+					allLinksLeadToTheCandidate = false;
+					break;
+				}
+			}
+			if (allLinksLeadToTheCandidate) {
+				return nextCandidate;
+			}
+			List<Link> links = findLinksFromWithoutTransitions(nextCandidate, true);
+			if (links.size() == 0) {
+				nextCandidate = null;
+			}
+			else if (links.size() == 1) {
+				nextCandidate = findNodeById(links.get(0).to);
+			}
+			else {
+				while (countLinksWithoutTransitions(links) > 1) {
+					nextCandidate = findEndOfSplit(links);
+					links = findLinksFromWithoutTransitions(nextCandidate, true);
+				}
+			}
+		}
+		// This indicates a broken graph
+		return null;
+	}
+
+	/**
+	 * Walk a specified link to see if it ever hits the candidate node.
+	 *
+	 * @param link points to the head of a chain of nodes
+	 * @param candidate the node possibly found on the chain of nodes
+	 * @return true if the candidate is found down the specified chain
+	 */
+	private boolean foundInChain(Link link, Node candidate) {
+		String targetId = link.to;
+		Node targetNode = findNodeById(targetId);
+		if (targetNode == candidate) {
+			return true;
+		}
+		List<Link> outboundLinks = findLinksFromWithoutTransitions(targetNode, true);
+		while (outboundLinks.size() > 0) {
+			while (countLinksWithoutTransitions(outboundLinks) > 1) {
+				Node splitEnd = findEndOfSplit(outboundLinks);
+				// eee is found as the split end for ccc&ddd  - however, it is ALSO the end of the outer split
+				if (splitEnd == candidate) {
+					return true;
+				}
+				outboundLinks = findLinksFromWithoutTransitions(splitEnd, true);
+			}
+			// Now we are at a single link (or no links) in outbound links
+			if (outboundLinks.size() > 0) {
+				// single link
+				targetNode = findNodeById(outboundLinks.get(0).to);
+				if (targetNode == candidate) {
+					return true;
+				}
+				outboundLinks = findLinksFromWithoutTransitions(targetNode, true);
+			}
+		}
+		return false;
+	}
+
+	private int countLinksWithoutTransitions(List<Link> links) {
+		int count = 0;
+		for (Link link : links) {
+			if (!link.hasTransitionSet()) {
+				count++;
+			}
+		}
+		return count;
+	}
+
+	private void printNode(StringBuilder graphText, Node node) {
+		graphText.append(node.name).append("");
+	}
+
+	private void followLink(StringBuilder graphText, Link link, Node nodeToFinishFollowingAt) {
+		Node target = findNodeById(link.to);
+		printNode(graphText, target);
+		List<Link> toFollow = findLinksFrom(target, false);
+		for (Iterator<Link> iterator = toFollow.iterator(); iterator.hasNext();) {
+			Link l = iterator.next();
+			if (l.hasTransitionSet()) {
+				// capture the target of this link as a simple transition
+				String transitionName = l.getTransitionName();
+				Node transitionTarget = findNodeById(l.to);
+				graphText.append(" | ").append(transitionName).append(" = ").append(transitionTarget.name);
+				iterator.remove();
+			}
+		}
+		followLinks(graphText, toFollow, nodeToFinishFollowingAt);
+	}
+
+	private Node findNodeById(String id) {
+		for (Node n : nodes) {
+			if (n.id.equals(id)) {
+				return n;
+			}
 		}
 		return null;
+	}
+
+	private Node findNodeByName(String name) {
+		for (Node n : nodes) {
+			if (n.name.equals(name)) {
+				return n;
+			}
+		}
+		return null;
+	}
+
+	private List<Link> findLinksFromWithoutTransitions(Node n, boolean includeThoseLeadingToEnd) {
+		List<Link> result = new ArrayList<>();
+		for (Link link : links) {
+			if (link.from.equals(n.id)) {
+				if (!link.hasTransitionSet()
+						&& (includeThoseLeadingToEnd || !findNodeById(link.to).name.equals("END"))) {
+					result.add(link);
+				}
+			}
+		}
+		return result;
+	}
+
+	private List<Link> findLinksFrom(Node n, boolean includeThoseLeadingToEnd) {
+		List<Link> result = new ArrayList<>();
+		for (Link link : links) {
+			if (link.from.equals(n.id)) {
+				if (includeThoseLeadingToEnd || !findNodeById(link.to).name.equals("END")) {
+					result.add(link);
+				}
+			}
+		}
+		return result;
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Represents a Graph that Flo will display. A graph consists of simple nodes and links.
+ *
+ * @author Andy Clement
+ */
+public class Graph {
+
+	public final List<Node> nodes;
+
+	public final List<Link> links;
+
+	Graph(List<Node> nodes, List<Link> links) {
+		this.nodes = nodes;
+		this.links = links;
+	}
+
+	public List<Node> getNodes() {
+		return this.nodes;
+	}
+
+	public List<Link> getLinks() {
+		return this.links;
+	}
+
+	public String toJSON() {
+		Graph g = new Graph(nodes, links);
+		ObjectMapper mapper = new ObjectMapper();
+		//		mapper.setVisibilityChecker(
+		//				mapper.getSerializationConfig().getDefaultVisibilityChecker().withFieldVisibility(Visibility.ANY));
+		mapper.setSerializationInclusion(Include.NON_NULL);
+		try {
+			return mapper.writeValueAsString(g);
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -233,7 +234,24 @@ public class Graph {
 	}
 
 	private void printNode(StringBuilder graphText, Node node) {
-		graphText.append(node.name).append("");
+		// What to generate depends on whether it is a job definition or reference
+		if (node.metadata != null && node.metadata.containsKey(Node.METADATAKEY_JOBMODULENAME)) {
+			graphText.append(node.metadata.get(Node.METADATAKEY_JOBMODULENAME)).append(" ");
+			graphText.append(node.name).append(" ");
+			if (node.properties != null) {
+				int count = 0;
+				for (Map.Entry<String, String> entry : node.properties.entrySet()) {
+					if (count > 0) {
+						graphText.append(" ");
+					}
+					graphText.append("--").append(entry.getKey()).append("=").append(entry.getValue());
+					count++;
+				}
+			}
+		}
+		else {
+			graphText.append(node.name).append("");
+		}
 	}
 
 	private void followLink(StringBuilder graphText, Link link, Node nodeToFinishFollowingAt) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDSLMessage.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDSLMessage.java
@@ -45,7 +45,7 @@ public enum JobDSLMessage {
 	MISSING_CHARACTER(ERROR, 205, "missing expected character ''{0}''"), //
 	NOT_EXPECTED_TOKEN(ERROR, 206, "Unexpected token.  Expected ''{0}'' but was ''{1}''"), //
 	OOD(ERROR, 207, "Unexpectedly ran out of input"), //
-	UNEXPECTED_DATA(ERROR, 208, "unexpected data in stream definition ''{0}''"), //
+	UNEXPECTED_DATA(ERROR, 208, "unexpected data in job definition ''{0}''"), //
 	EXPECTED_WHITESPACE_AFTER_NAME_BEFORE_ARGUMENT(ERROR,
 			209,
 			"expected whitespace after job name and before argument"), //
@@ -56,7 +56,23 @@ public enum JobDSLMessage {
 					EXPECTED_TRANSITION_NAME(ERROR, 212, "Expected the name of a job exit state but found ''{0}''"), //
 					EXPECTED_EQUALS_AFTER_TRANSITION_NAME(ERROR,
 							213,
-							"Expected an equals after a job exit state but found ''{0}''");
+							"Expected an equals after a job exit state but found ''{0}''"), //
+							NON_TERMINATING_QUOTED_STRING(
+									ERROR, 214, "Cannot find terminating '' for string"), //
+									NON_TERMINATING_DOUBLE_QUOTED_STRING(ERROR,
+											215,
+											"Cannot find terminating \" for string"), //
+											UNEXPECTED_ESCAPE_CHAR(ERROR, 216, "unexpected escape character."), //
+											MISSING_EQUALS_AFTER_TRANSITION_NAME(ERROR,
+													217,
+													"Expected an equals after the transition ''{0}''"), //
+													ONLY_ONE_AMPERSAND_REQUIRED(ERROR,
+															218,
+															"Only a single '&' is required between jobs in a split"), //
+															EXPECTED_JOB_REF_OR_DEF(ERROR,
+																	219,
+																	"Expected job reference or definition");
+	;
 
 
 	private Kind kind;

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDSLMessage.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDSLMessage.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import static org.springframework.xd.dirt.job.dsl.JobDSLMessage.Kind.ERROR;
+
+import java.text.MessageFormat;
+
+/**
+ * Contains all the messages that can be produced during Spring XD Job DSL parsing. Each message has a kind (info, warn,
+ * error) and a code number. Tests can be written to expect particular code numbers rather than particular text,
+ * enabling the message text to more easily be modified and the tests to run successfully in different locales.
+ * <p>
+ * When a message is formatted, it will have this kind of form
+ *
+ * <pre class="code">
+ * XD105E: (pos 34): Expected an argument value but was ' '
+ * </pre>
+ *
+ * </code> The prefix captures the code and the error kind, whilst the position is included if it is known.
+ *
+ * @author Andy Clement
+ */
+public enum JobDSLMessage {
+
+	UNEXPECTED_DATA_AFTER_JOBSPEC(ERROR, 200, "Found unexpected data after job specification: ''{0}''"), //
+	NO_WHITESPACE_BEFORE_ARG_NAME(ERROR, 201, "No whitespace allowed between '--' and option name"), //
+	NO_WHITESPACE_BEFORE_ARG_EQUALS(ERROR, 202, "No whitespace allowed after argument name and before '='"), //
+	NO_WHITESPACE_BEFORE_ARG_VALUE(ERROR, 203, "No whitespace allowed after '=' and before option value"), //
+	EXPECTED_ARGUMENT_VALUE(ERROR, 204, "Expected an argument value but was ''{0}''"), //
+	MISSING_CHARACTER(ERROR, 205, "missing expected character ''{0}''"), //
+	NOT_EXPECTED_TOKEN(ERROR, 206, "Unexpected token.  Expected ''{0}'' but was ''{1}''"), //
+	OOD(ERROR, 207, "Unexpectedly ran out of input"), //
+	UNEXPECTED_DATA(ERROR, 208, "unexpected data in stream definition ''{0}''"), //
+	EXPECTED_WHITESPACE_AFTER_NAME_BEFORE_ARGUMENT(ERROR,
+			209,
+			"expected whitespace after job name and before argument"), //
+			NO_WHITESPACE_IN_DOTTED_NAME(ERROR, 210, "No whitespace is allowed between dot and components of a name"), //
+			MISSING_JOB_NAME_IN_INLINEJOBDEF(ERROR,
+					211,
+					"The job module must be followed by the job name before any job arguments"), //
+					EXPECTED_TRANSITION_NAME(ERROR, 212, "Expected the name of a job exit state but found ''{0}''"), //
+					EXPECTED_EQUALS_AFTER_TRANSITION_NAME(ERROR,
+							213,
+							"Expected an equals after a job exit state but found ''{0}''");
+
+
+	private Kind kind;
+
+	private int code;
+
+	private String message;
+
+	private JobDSLMessage(Kind kind, int code, String message) {
+		this.kind = kind;
+		this.code = code;
+		this.message = message;
+	}
+
+	/**
+	 * Produce a complete message including the prefix, the position (if known) and with the inserts applied to the
+	 * message.
+	 *
+	 * @param pos the position, if less than zero it is ignored and not included in the message
+	 * @param inserts the inserts to put into the formatted message
+	 * @return a formatted message
+	 */
+	public String formatMessage(int pos, Object... inserts) {
+		StringBuilder formattedMessage = new StringBuilder();
+		formattedMessage.append("XD").append(code);
+		// switch (kind) {
+		// case WARNING:
+		// formattedMessage.append("W");
+		// break;
+		// case INFO:
+		// formattedMessage.append("I");
+		// break;
+		// case ERROR:
+		formattedMessage.append("E");
+		// break;
+		// }
+		formattedMessage.append(":");
+		if (pos != -1) {
+			formattedMessage.append("(pos ").append(pos).append("): ");
+		}
+		formattedMessage.append(MessageFormat.format(message, inserts));
+		return formattedMessage.toString();
+	}
+
+	public Kind getKind() {
+		return kind;
+	}
+
+	public static enum Kind {
+		INFO, WARNING, ERROR
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDefinition.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+/**
+ * Represents an inlined job definition in a job specification. For example in the specification
+ * "<tt>aa || bb || cc dd --a=b --c=d || ff</tt>" a Job definition would be created to represent
+ * <tt>cc</tt>. It would be a definition where the jobModuleId is <tt>cc</tt>, the jobNameId is <tt>dd</tt>
+ * and the arguments are <tt>a=b</tt> and <tt>c=d</tt>.
+ *
+ * @author Andy Clement
+ */
+public class JobDefinition extends JobDescriptor {
+
+	private Token jobModuleId;
+
+	private Token jobNameId;
+
+	private ArgumentNode[] args;
+
+	public JobDefinition(Token jobModuleId, Token jobNameId, ArgumentNode[] args) {
+		super(jobModuleId.startpos, jobNameId.endpos);
+		this.jobModuleId = jobModuleId;
+		this.jobNameId = jobNameId;
+		this.args = args;
+	}
+
+	@Override
+	public String stringify(boolean includePositionInfo) {
+		StringBuilder s = new StringBuilder();
+		s.append(jobModuleId.stringValue()).append(" ").append(jobNameId.stringValue());
+		if (args != null) {
+			for (ArgumentNode arg : args) {
+				s.append(" ");
+				s.append(arg.stringify(includePositionInfo));
+			}
+		}
+		if (hasTransitions()) {
+			for (Transition t : transitions) {
+				s.append(" ");
+				s.append(t.stringify(includePositionInfo));
+			}
+		}
+		return s.toString();
+	}
+
+	@Override
+	public final boolean isDefinition() {
+		return true;
+	}
+
+	public String getJobModuleName() {
+		return jobModuleId.stringValue();
+	}
+
+	public String getJobName() {
+		return jobNameId.stringValue();
+	}
+
+	public ArgumentNode[] getArguments() {
+		return args;
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDescriptor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDescriptor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.List;
+
+/**
+ * Common AST base class for nodes representing job definitions or job references.
+ *
+ * @author Andy Clement
+ */
+public abstract class JobDescriptor extends JobNode {
+
+	/**
+	 * Both inline job definitions and job references can be suffixed with transitions. For example "<tt>| completed=foo</tt>" which
+	 * indicates if the job finishes in the <tt>completed</tt> state then execution should continue with the <tt>foo</tt> job.
+	 */
+	List<Transition> transitions;
+
+	public JobDescriptor(int startpos, int endpos) {
+		super(startpos, endpos);
+	}
+
+	void setTransitions(List<Transition> transitions) {
+		this.transitions = transitions;
+	}
+
+	@Override
+	public String toString() {
+		return "JobDescriptor: " + stringify(true);
+	}
+
+	@Override
+	public final boolean isJobDescriptor() {
+		return true;
+	}
+
+	public boolean isReference() {
+		return false;
+	}
+
+	public boolean isDefinition() {
+		return false;
+	}
+
+	public List<Transition> getTransitions() {
+		return transitions;
+	}
+
+	public boolean hasTransitions() {
+		return transitions != null;
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobNode.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.List;
+
+/**
+ * AST node base type for all elements in an AST parsed from a job specification.
+ *
+ * @author Andy Clement
+ */
+public abstract class JobNode extends AstNode {
+
+	public JobNode(int startPos, int endPos) {
+		super(startPos, endPos);
+	}
+
+	/**
+	 * @return true if this node represents a flow (a number of jobs to run in sequence)
+	 */
+	boolean isFlow() {
+		return false;
+	}
+
+	/**
+	 * @return true if this node represents a split (a number of jobs to run in parallel)
+	 */
+	boolean isSplit() {
+		return false;
+	}
+
+	/**
+	 * @return true if this node represents a inlined job definition or simple job reference, otherwise false
+	 */
+	public boolean isJobDescriptor() {
+		return false;
+	}
+
+	/**
+	 * For nodes representing a flow or split, return how many are in the series of things
+	 * to run (so the number to run in sequence or the number to run in parallel).
+	 *
+	 * @return the length of the series for flow or split nodes, otherwise -1
+	 */
+	public int getSeriesLength() {
+		return -1;
+	}
+
+	/**
+	 * For nodes representing a flow or a split, return a specific element in the
+	 * series of things that will run either sequentially or in parallel.
+	 *
+	 * @param index the element of interest
+	 * @return the indicated series or null if this is not a flow/split node
+	 */
+	public JobNode getSeriesElement(int index) {
+		return null;
+	}
+
+	/**
+	 * For nodes representing a flow or a split, return the series of
+	 * elements to run in sequence/parallel.
+	 *
+	 * @return the series of elements for this flow/split, or null if not a flow/split node
+	 */
+	public List<JobNode> getSeries() {
+		return null;
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobParser.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parse a Batch DSL Job specification.
+ *
+ * @author Andy Clement
+ */
+public class JobParser {
+
+	private Tokens tokens;
+
+	public JobParser() {
+	}
+
+	/**
+	 * Parse a job flow definition into an abstract syntax tree (AST).
+	 *
+	 * @param the textual job specification
+	 * @return the AST for the parsed stream
+	 * @throws JobSpecificationException
+	 */
+	public JobSpecification parse(String jobSpecification) {
+		tokens = new Tokens(jobSpecification);
+		JobNode jobNode = parseJobNode();
+		JobSpecification js = new JobSpecification(jobSpecification, jobNode);
+		if (tokens.hasNext()) {
+			throw new JobSpecificationException(tokens.getExpression(), tokens.peek().startpos,
+					JobDSLMessage.UNEXPECTED_DATA_AFTER_JOBSPEC,
+					toString(tokens.next()));
+		}
+		return js;
+	}
+
+	private JobNode parseJobNode() {
+		// Handle (...)
+		if (tokens.maybeEat(TokenKind.OPEN_PAREN)) {
+			JobNode jn = parseJobNode();
+			tokens.eat(TokenKind.CLOSE_PAREN);
+			return jn;
+		}
+		// Handle a split < ... >
+		if (tokens.peek(TokenKind.SPLIT_OPEN)) {
+			JobNode jn = parseSplit();
+			// is the split part of a flow? "<..> || b"
+			return maybeParseFlow(jn);
+		}
+		JobDescriptor jd = parseJobDescriptor();
+		// Handle a potential flow "a || b"
+		return maybeParseFlow(jd);
+	}
+
+	private JobNode maybeParseFlow(JobNode firstJobNodeInFlow) {
+		if (tokens.peek(TokenKind.DOUBLE_PIPE)) {
+			List<JobNode> jobNodes = new ArrayList<>();
+			jobNodes.add(firstJobNodeInFlow);
+			while (tokens.maybeEat(TokenKind.DOUBLE_PIPE)) {
+				JobNode nextNode = parseJobNode();
+				// If nextNode is a Flow node, merge it with this one
+				if (nextNode instanceof Flow) {
+					jobNodes.addAll(nextNode.getSeries());
+				}
+				else {
+					jobNodes.add(nextNode);
+				}
+			}
+			return new Flow(jobNodes);
+		}
+		else {
+			return firstJobNodeInFlow;
+		}
+	}
+
+	// '<' jobs ['&' jobs]+ '>'
+	private JobNode parseSplit() {
+		List<JobNode> flows = new ArrayList<>();
+		tokens.eat(TokenKind.SPLIT_OPEN);
+		// '<' jobSequence  [ '&' jobSequence]* '>'
+		flows.add(parseJobNode());
+		while (tokens.maybeEat(TokenKind.AMPERSAND)) {
+			flows.add(parseJobNode());
+		}
+		tokens.eat(TokenKind.SPLIT_CLOSE);
+		return new Split(flows);
+	}
+
+	// JobDescriptor can be a simple JobReference (reference to a pre-existing definition) or
+	// an inlined JobDefinition.
+	//
+	// JobReference := identifier:jobname [stateTransitions]*
+	// JobDefinition := identifier:jobmodulename identifier:jobname ['--'optionname'='optionvalue]* [stateTransitions]*
+	private JobDescriptor parseJobDescriptor() {
+		JobDescriptor jd = null;
+		// Double identifiers indicates job definition
+		if (tokens.peek(0, TokenKind.IDENTIFIER)) {
+			if (tokens.peek(1, TokenKind.IDENTIFIER)) {
+				jd = parseJobDefinition();
+			}
+			else if (tokens.peek(1, TokenKind.DOUBLE_MINUS)) {
+				// Error: something like 'foo --bar=xxx' - an inline job definition needs
+				// the job name to follow the job module
+				tokens.raiseException(tokens.peek(1).startpos, JobDSLMessage.MISSING_JOB_NAME_IN_INLINEJOBDEF);
+			}
+			else {
+				jd = new JobReference(tokens.eat(TokenKind.IDENTIFIER));
+			}
+		}
+		if (tokens.peek(TokenKind.PIPE)) {
+			List<Transition> transitions = parseTransitions();
+			jd.setTransitions(transitions);
+		}
+		return jd;
+	}
+
+	// [| state = target]*
+	// where state is an identifier/string literal whilst target is an identifier (target job).
+	private List<Transition> parseTransitions() {
+		List<Transition> transitions = new ArrayList<>();
+		while (tokens.maybeEat(TokenKind.PIPE)) {
+			Token transitionName = tokens.next();
+			if (!transitionName.isKind(TokenKind.IDENTIFIER) && !transitionName.isKind(TokenKind.LITERAL_STRING)) {
+				tokens.raiseException(transitionName.startpos, JobDSLMessage.EXPECTED_TRANSITION_NAME,
+						tokenToString(transitionName));
+			}
+			Token nextToken = tokens.peek();
+			if (!nextToken.isKind(TokenKind.EQUALS)) {
+				tokens.raiseException(nextToken.startpos, JobDSLMessage.EXPECTED_EQUALS_AFTER_TRANSITION_NAME,
+						tokenToString(nextToken));
+			}
+			else {
+				tokens.next();
+			}
+			Token targetJobName = tokens.eat(TokenKind.IDENTIFIER);
+			JobReference targetJobReference = new JobReference(targetJobName);
+			transitions.add(new Transition(transitionName, targetJobReference));
+		}
+		return transitions;
+	}
+
+	private String tokenToString(Token token) {
+		return token.stringValue() == null ? new String(token.kind.tokenChars)
+				: token.stringValue();
+	}
+
+	private JobDefinition parseJobDefinition() {
+		Token jobModuleToken = tokens.eat(TokenKind.IDENTIFIER);
+		Token jobName = tokens.eat(TokenKind.IDENTIFIER);
+		tokens.checkpoint();
+		ArgumentNode[] args = maybeEatModuleArgs();
+		return new JobDefinition(jobModuleToken, jobName, args);
+	}
+
+	// ['--'identifier:name'='identifier:value]*
+	private ArgumentNode[] maybeEatModuleArgs() {
+		List<ArgumentNode> args = null;
+		if (tokens.peek(TokenKind.DOUBLE_MINUS) && tokens.isNextAdjacent()) {
+			tokens.raiseException(tokens.peek().startpos, JobDSLMessage.EXPECTED_WHITESPACE_AFTER_NAME_BEFORE_ARGUMENT);
+		}
+		while (tokens.peek(TokenKind.DOUBLE_MINUS)) {
+			Token dashDash = tokens.next(); // skip the '--'
+			if (tokens.peek(TokenKind.IDENTIFIER) && !tokens.isNextAdjacent()) {
+				tokens.raiseException(tokens.peek().startpos, JobDSLMessage.NO_WHITESPACE_BEFORE_ARG_NAME);
+			}
+			Token argName = tokens.next();
+			if (!argName.isKind(TokenKind.IDENTIFIER)) {
+				tokens.raiseException(argName.startpos, JobDSLMessage.NOT_EXPECTED_TOKEN,
+						argName.data != null ? argName.data
+								: new String(argName.getKind().tokenChars));
+			}
+			if (tokens.peek(TokenKind.EQUALS) && !tokens.isNextAdjacent()) {
+				tokens.raiseException(tokens.peek().startpos, JobDSLMessage.NO_WHITESPACE_BEFORE_ARG_EQUALS);
+			}
+			tokens.eat(TokenKind.EQUALS);
+			if (tokens.peek(TokenKind.IDENTIFIER) && !tokens.isNextAdjacent()) {
+				tokens.raiseException(tokens.peek().startpos, JobDSLMessage.NO_WHITESPACE_BEFORE_ARG_VALUE);
+			}
+			// Process argument value:
+			Token t = tokens.peek();
+			String argValue = eatArgValue();
+			tokens.checkpoint();
+			if (args == null) {
+				args = new ArrayList<ArgumentNode>();
+			}
+			args.add(new ArgumentNode(argName.data, argValue, dashDash.startpos, t.endpos));
+		}
+		return args == null ? null : args.toArray(new ArgumentNode[args.size()]);
+	}
+
+	// [identifier | literal_string]
+	private String eatArgValue() {
+		Token t = tokens.next();
+		String argValue = null;
+		if (t.getKind() == TokenKind.IDENTIFIER) {
+			argValue = t.data;
+		}
+		else if (t.getKind() == TokenKind.LITERAL_STRING) {
+			String quotesUsed = t.data.substring(0, 1);
+			argValue = t.data.substring(1, t.data.length() - 1).replace(quotesUsed + quotesUsed, quotesUsed);
+		}
+		else {
+			tokens.raiseException(t.startpos, JobDSLMessage.EXPECTED_ARGUMENT_VALUE, t.data);
+		}
+		return argValue;
+	}
+
+	/**
+	 * Convert a token into its String representation.
+	 *
+	 * @param t the token
+	 * @return a string representation of the supplied token
+	 */
+	private static String toString(Token t) {
+		if (t.getKind().hasPayload()) {
+			return t.stringValue();
+		}
+		else {
+			return new String(t.kind.getTokenChars());
+		}
+	}
+
+	/**
+	 * Create a graph suitable for Flo to display.
+	 *
+	 * @param jobSpecification the textual definition of the specification
+	 * @return a Graph representation of the supplied specification
+	 */
+	public Graph getGraph(String jobSpecification) {
+		JobSpecification js = parse(jobSpecification);
+		return js.toGraph();
+	}
+
+	/**
+	 * Create an XML representation of the JobSpec.
+	 *
+	 * @param batchJobId the id that will be inserted into the XML document for the batch:job element
+	 * @param jobSpecification the textual definition of the specification
+	 * @return a String containing XML representing the supplied specification
+	 */
+	public String getXML(String batchJobId, String jobSpecification) {
+		JobSpecification js = parse(jobSpecification);
+		return js.toXML(batchJobId);
+	}
+
+	/**
+	 * Show the parsing progress in the output string.
+	 */
+	@Override
+	public String toString() {
+		// Only state of the token processing is interesting:
+		return tokens.toString();
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobParser.java
@@ -39,6 +39,10 @@ public class JobParser {
 	 * @throws JobSpecificationException if any problems occur during parsing
 	 */
 	public JobSpecification parse(String jobSpecification) {
+		jobSpecification = jobSpecification.trim();
+		if (jobSpecification.length() == 0) {
+			return new JobSpecification(jobSpecification, null);
+		}
 		tokens = new Tokens(jobSpecification);
 		JobNode jobNode = parseJobNode();
 		JobSpecification js = new JobSpecification(jobSpecification, jobNode);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobReference.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobReference.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+/**
+ * Represents a simple job reference. In the example spec "<tt>aa || bb</tt>" both <tt>aa</tt> and <tt>bb</tt> would
+ * be represented in the AST as JobReference nodes.
+ *
+ * @author Andy Clement
+ */
+public class JobReference extends JobDescriptor {
+
+	private Token jobReference;
+
+	public JobReference(Token jobReference) {
+		super(jobReference.startpos, jobReference.endpos);
+		this.jobReference = jobReference;
+	}
+
+	@Override
+	public String stringify(boolean includePositionInfo) {
+		StringBuilder s = new StringBuilder();
+		if (includePositionInfo) {
+			s.append(jobReference.stringValue()).append("[").append(getStartPos()).append(">").append(
+					getEndPos()).append("]");
+		}
+		else {
+			s.append(jobReference.stringValue());
+		}
+		if (hasTransitions()) {
+			for (Transition t : transitions) {
+				s.append(" ");
+				s.append(t.stringify(includePositionInfo));
+			}
+		}
+		return s.toString();
+	}
+
+	@Override
+	public String toString() {
+		return "JobReference: " + stringify(true);
+	}
+
+	@Override
+	public final boolean isReference() {
+		return true;
+	}
+
+	/**
+	 * @return the job named by this JobReference.
+	 */
+	public String getName() {
+		return this.jobReference.stringValue();
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSeries.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSeries.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+/**
+ * Common AST base class for nodes representing splits or flows.
+ *
+ * @author Andy Clement
+ */
+public abstract class JobSeries extends JobNode {
+
+	public JobSeries(int startPos, int endPos) {
+		super(startPos, endPos);
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
@@ -375,24 +375,6 @@ public class JobSpecification extends AstNode {
 			return new Element[] { step };
 		}
 
-		private List<String> definedFlowNames = new ArrayList<>();
-
-		/**
-		 * Create a unique name for a flow id. It is made up of the incoming prefix plus
-		 * a hyphen plus an integer.
-		 *
-		 * @param prefix the first part of the flow id
-		 */
-		private String generateFlowId(String prefix) {
-			int i = 1;
-			String id = null;
-			do {
-				id = prefix + "-" + Integer.toString(i++);
-			}
-			while (definedFlowNames.contains(id));
-			return id;
-		}
-
 		/**
 		 * Visit a job reference. Rules:
 		 * <ul>
@@ -402,7 +384,7 @@ public class JobSpecification extends AstNode {
 		@Override
 		public Element[] walk(Element[] context, JobReference jr) {
 			// Producing this kind of construct:
-			// <flow id="sqoop-6e44-1">
+			// <flow">
 			//   <step id="sqoop-6e44">
 			//	   <tasklet ref="jobRunner-6e44"/>
 			//	   <next on="*" to="sqoop-e07a"/>
@@ -410,11 +392,9 @@ public class JobSpecification extends AstNode {
 			//   </step>
 			// </flow>
 
-
 			boolean inSplit = currentElement.peek().getTagName().equals("split");
 			if (inSplit) {
 				Element flow = doc.createElement("flow");
-				flow.setAttribute("id", generateFlowId(jr.getName()));
 				currentElement.peek().appendChild(flow);
 				currentElement.push(flow);
 			}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
@@ -1,0 +1,557 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+
+import org.w3c.dom.DOMImplementation;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import org.springframework.xd.dirt.stream.JobDefinitionRepository;
+import org.springframework.xml.transform.StringResult;
+
+/**
+ * The root AST node for any AST parsed from a job specification.
+ *
+ * Andy Clement
+ */
+public class JobSpecification extends AstNode {
+
+	/**
+	 * The DSL text that was parsed to create this JobSpec.
+	 */
+	private String jobDefinitionText;
+
+	/**
+	 * The top level JobNode within this JobSpec.
+	 */
+	private JobNode jobNode;
+
+	/**
+	 * A list of jobs that were defined inline in the DSL text that was parsed
+	 * to create this Ast. Computed on first reference.
+	 */
+	private List<JobDefinition> jobDefinitions;
+
+	public JobSpecification(String jobDefinitionText, JobNode jobNode) {
+		super(jobNode.getStartPos(), jobNode.getEndPos());
+		this.jobDefinitionText = jobDefinitionText;
+		this.jobNode = jobNode;
+	}
+
+	@Override
+	public String stringify(boolean includePositionInfo) {
+		return jobNode.stringify(includePositionInfo);
+	}
+
+	public String getJobDefinitionText() {
+		return jobDefinitionText;
+	}
+
+	public JobNode getJobNode() {
+		return this.jobNode;
+	}
+
+	/**
+	 * A shortcut (avoiding traversing the tree) that returns the list
+	 * of all job definitions inlined somewhere in this AST. Computed
+	 * on demand.
+	 *
+	 * @return a list of inlined job definitions defined in this AST
+	 */
+	public List<JobDefinition> getJobDefinitions() {
+		if (jobDefinitions != null) {
+			return jobDefinitions;
+		}
+		JobDefinitionLocator jdl = new JobDefinitionLocator();
+		jdl.accept(this);
+		jobDefinitions = jdl.getJobDefinitions();
+		return jobDefinitions;
+	}
+
+	/**
+	 * Performs validation of the AST. Where the initial parse is about
+	 * checking the syntactic structure, validation is about checking more
+	 * semantic elements:<ul>
+	 * <li>Do the inline job definitions refer to valid job modules?
+	 * <li>Do the inline job definitions supply correct arguments?
+	 * <li>Do the job references point to valid job definitions?
+	 * </ul>
+	 * @param jobDefinitionRepository a repository to check job definitions against
+	 * @throws JobSpecificationException if validation fails
+	 */
+	public void validate(JobDefinitionRepository jobDefinitionRepository) {
+		// TODO !
+
+	}
+
+	/**
+	 * @return this AST converted to a Graph form for display by Flo
+	 */
+	public Graph toGraph() {
+		GraphGeneratorVisitor ggv = new GraphGeneratorVisitor();
+		ggv.accept(this);
+		return ggv.getGraph();
+	}
+
+	/**
+	 * @param batchJobId the id that will be inserted into the XML document for the batch:job element
+	 * @return this AST converted to an XML form
+	 */
+	public String toXML(String batchJobId) {
+		return toXML(batchJobId, false);
+	}
+
+	/**
+	 * @param batchJobId the id that will be inserted into the XML document for the batch:job element
+	 * @param prettyPrint determine if the XML should be human readable.
+	 * @return this AST converted to an XML form
+	 */
+	public String toXML(String batchJobId, boolean prettyPrint) {
+		XMLGeneratorVisitor xgv = new XMLGeneratorVisitor(batchJobId, prettyPrint);
+		xgv.accept(this);
+		return xgv.getXmlString();
+	}
+
+	/**
+	 * Basic visitor that simply collects up any inlined job definitions.
+	 */
+	static class JobDefinitionLocator extends JobSpecificationVisitor<Object> {
+
+		List<JobDefinition> jobDefinitions = new ArrayList<JobDefinition>();
+
+		public List<JobDefinition> getJobDefinitions() {
+			return jobDefinitions;
+		}
+
+		@Override
+		public Object walk(Object context, Flow sjs) {
+			for (JobNode jobNode : sjs.getSeries()) {
+				walk(context, jobNode);
+			}
+			return context;
+		}
+
+		@Override
+		public Object walk(Object context, JobDefinition jd) {
+			jobDefinitions.add(jd);
+			return context;
+		}
+
+		@Override
+		public Object walk(Object context, JobReference jr) {
+			return context;
+		}
+
+		@Override
+		public Object walk(Object context, Split pjs) {
+			for (JobNode jobNode : pjs.getSeries()) {
+				walk(context, jobNode);
+			}
+			return context;
+		}
+
+	}
+
+	/**
+	 * Visitor that produces an XML representation of the Job specification.
+	 */
+	static class XMLGeneratorVisitor extends JobSpecificationVisitor<Element[]> {
+
+		/**
+		 * containing document that can be used for element creation
+		 */
+		private Document doc;
+
+		/**
+		 * Where to append elements created during the visit
+		 */
+		private Element batchJobElement;
+
+		/**
+		 * Should the XML output be readable or compressed onto one line.
+		 */
+		private boolean prettyPrint;
+
+		/**
+		 * A stack that tracks the element that should have new children attached to it.
+		 * Initially populated with batchJobElement from above.
+		 */
+		private Stack<Element> currentElement = new Stack<>();
+
+		/**
+		 * Counter for the numeric suffix to attach to generated split id attributes.
+		 */
+		private int splitId = 1;
+
+		private List<String> jobRunnerIds = new ArrayList<>();
+
+		private String xmlString;
+
+		private String batchJobId;
+
+		XMLGeneratorVisitor(String batchJobId, boolean prettyPrint) {
+			this.batchJobId = batchJobId;
+			this.prettyPrint = prettyPrint;
+		}
+
+		public String getXmlString() {
+			return xmlString;
+		}
+
+		@Override
+		public void preJobSpecWalk() {
+			try {
+				DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+				DocumentBuilder db = dbf.newDocumentBuilder();
+				DOMImplementation domImplementation = db.getDOMImplementation();
+
+				// Generate:
+				// <beans xmlns="http://www.springframework.org/schema/beans"
+				//		  xmlns:batch="http://www.springframework.org/schema/batch"
+				//		  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				//		  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+				//		    http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+				this.doc = domImplementation.createDocument("http://www.springframework.org/schema/beans", "beans",
+						null);
+				doc.createElementNS("http://www.springframework.org/schema/batch", "batch");
+				doc.getDocumentElement().setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:batch",
+						"http://www.springframework.org/schema/batch");
+				doc.getDocumentElement().setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xsi",
+						"http://www.w3.org/2001/XMLSchema-instance");
+				doc.getDocumentElement().setAttributeNS("http://www.w3.org/2000/xsi/", "xsi:schemaLocation",
+						"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd");
+				// Setting this 'again' to get it on the front and look more like the above.
+				doc.getDocumentElement().setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns",
+						"http://www.springframework.org/schema/beans");
+
+				// Generate: <bean id="taskExecutor" class="org.springframework.core.task.SimpleAsyncTaskExecutor"/>
+				Element taskExecutor = doc.createElement("bean");
+				doc.getDocumentElement().appendChild(taskExecutor);
+				taskExecutor.setAttribute("id", "taskExecutor");
+				taskExecutor.setAttribute("class", "org.springframework.core.task.SimpleAsyncTaskExecutor");
+
+				// Generate: <batch:job id="streamName" xmlns="http://www.springframework.org/schema/batch">
+				this.batchJobElement = doc.createElement("batch:job");
+				doc.getDocumentElement().appendChild(batchJobElement);
+				batchJobElement.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns",
+						"http://www.springframework.org/schema/batch");
+				if (batchJobId != null) {
+					batchJobElement.setAttribute("id", batchJobId);
+				}
+				this.currentElement.push(batchJobElement);
+			}
+			catch (Exception e) {
+				// todo!
+			}
+		};
+
+		@Override
+		public void postJobSpecWalk() {
+			for (String jobRunnerId : jobRunnerIds) {
+				// Producing:
+				// <bean id="jobRunner-a6e0" class="JobRunningTasklet" scope="step"/>
+				Element bean = doc.createElement("bean");
+				bean.setAttribute("scope", "step");
+				bean.setAttribute("class", "JobRunningTasklet");
+				bean.setAttribute("id", jobRunnerId);
+				this.doc.getElementsByTagName("beans").item(0).appendChild(bean);
+			}
+			try {
+				// Write the content
+				TransformerFactory transformerFactory = TransformerFactory.newInstance();
+				javax.xml.transform.Transformer transformer;
+				transformer = transformerFactory.newTransformer();
+				if (prettyPrint) {
+					transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+					transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+				}
+				DOMSource source = new DOMSource(doc);
+				StringResult sr = new StringResult();
+				transformer.transform(source, sr);
+				xmlString = sr.toString().trim();
+			}
+			catch (TransformerException e) {
+				// TODO Auto-generated catch block
+			}
+		}
+
+		@Override
+		public Element[] walk(Element[] context, Flow jn) {
+			Element flow = doc.createElement("flow");
+			currentElement.peek().appendChild(flow);
+			currentElement.push(flow);
+			Element[] result = context;
+			for (JobNode j : jn.getSeries()) {
+				result = walk(result, j);
+			}
+			currentElement.pop();
+			return result;
+		}
+
+		@Override
+		public Element[] walk(Element[] context, JobDefinition jd) {
+			// TODO Auto-generated method stub
+			throw new UnsupportedOperationException("Auto-generated method stub");
+		}
+
+		@Override
+		public Element[] walk(Element[] context, JobReference jr) {
+			// Producing this kind of construct:
+			// <step id="sqoop-6e44">
+			//	 <tasklet ref="jobRunner-6e44"/>
+			//	 <next on="*" to="sqoop-e07a"/>
+			//	 <next on="FAILED" to="kill1"/>
+			// </step>
+
+			Element step = doc.createElement("step");
+			step.setAttribute("id", jr.getName());
+			Element tasklet = doc.createElement("tasklet");
+			String jobRunnerId = "jobRunner-" + jr.getName();
+			tasklet.setAttribute("ref", jobRunnerId);
+			jobRunnerIds.add(jobRunnerId);
+			step.appendChild(tasklet);
+			Element next = null;
+			if (jr.hasTransitions()) {
+				for (Transition t : jr.transitions) {
+					next = doc.createElement("next");
+					next.setAttribute("on", t.getStateName());
+					next.setAttribute("to", t.getTargetJobName());
+					step.appendChild(next);
+				}
+			}
+			if (context != null) {
+				// context is an array of earlier elements that should point to this one
+				Element[] elements = context;
+				for (Element element : elements) {
+					next = doc.createElement("next");
+					next.setAttribute("on", "*");
+					next.setAttribute("to", jr.getName());
+					element.appendChild(next);
+				}
+			}
+			this.currentElement.peek().appendChild(step);
+			return new Element[] { step };
+		}
+
+		@Override
+		public Element[] walk(Element[] context, Split pjs) {
+			// Producing this kind of output:
+			// <split id="split1" task-executor="taskExecutor">
+			//   ...
+			// </split>
+			Element split = doc.createElement("split");
+			split.setAttribute("task-executor", "taskExecutor");
+			split.setAttribute("id", "split" + (splitId++));
+			currentElement.peek().appendChild(split);
+			currentElement.push(split);
+			Element[] inputContext = context;
+			Element[] result = new Element[0];
+			for (JobNode jn : pjs.getSeries()) {
+				Object outputContext = walk(inputContext, jn);
+				result = merge(result, outputContext);
+			}
+			currentElement.pop();
+			return result;
+		}
+
+		Element[] merge(Element[] input, Object additional) {
+			Element[] additionalArrayData = (Element[]) additional;
+			Element[] result = new Element[input.length + additionalArrayData.length];
+			System.arraycopy(input, 0, result, 0, input.length);
+			System.arraycopy(additionalArrayData, 0, result, input.length, additionalArrayData.length);
+			return result;
+		}
+
+	}
+
+	/**
+	 * Visitor that produces a Graph representation of the Job specification suitable
+	 * for display by Flo.
+	 */
+	static class GraphGeneratorVisitor extends JobSpecificationVisitor<int[]> {
+
+		private int id = 0;
+
+		private Map<String, Node> createdNodes = new HashMap<>();
+
+		static class TransitionToMap {
+
+			int from;
+
+			String transitionName;
+
+			String targetJob;
+
+			public TransitionToMap(int from, String transitionName, String targetJob) {
+				super();
+				this.from = from;
+				this.transitionName = transitionName;
+				this.targetJob = targetJob;
+			}
+		}
+
+		private List<TransitionToMap> transitions = new ArrayList<>();
+
+		private List<Node> nodes = new ArrayList<>();
+
+		private List<Link> links = new ArrayList<>();
+
+		public Graph getGraph() {
+			Graph g = new Graph(nodes, links);
+			return g;
+		}
+
+		@Override
+		public void postJobSpecWalk() {
+			// Deal with transitions
+			for (TransitionToMap ttm : transitions) {
+				int nodeInGraph = findNode(ttm.targetJob);
+				if (nodeInGraph == -1) {
+					// target isn't in graph yet
+					int nextId = id++;
+					Node n = new Node(Integer.toString(nextId), ttm.targetJob);
+					nodes.add(n);
+					nodeInGraph = nextId;
+				}
+				links.add(new Link(ttm.from, nodeInGraph, ttm.transitionName));
+			}
+		}
+
+		private int findNode(String targetJob) {
+			for (Node n : nodes) {
+				if (n.name.equals(targetJob)) {
+					return Integer.parseInt(n.id);
+				}
+			}
+			return -1;
+		}
+
+		@Override
+		public int[] walk(int[] context, Flow jn) {
+			int[] result = context;
+			for (JobNode j : jn.getSeries()) {
+				result = walk(result, j);
+			}
+			// Only the last result is left dangling when visiting a sequence,
+			// return it here.
+			return result;
+		}
+
+		@Override
+		public int[] walk(int[] context, Split pjs) {
+			int[] inputContext = context;
+			int[] result = new int[0];
+			for (JobNode jn : pjs.getSeries()) {
+				Object outputContext = walk(inputContext, jn);
+				result = merge(result, outputContext);
+			}
+			return result;
+		}
+
+		int[] merge(int[] input, Object additional) {
+			int[] additionalArrayData = (int[]) additional;
+			int[] result = new int[input.length + additionalArrayData.length];
+			System.arraycopy(input, 0, result, 0, input.length);
+			System.arraycopy(additionalArrayData, 0, result, input.length, additionalArrayData.length);
+			return result;
+		}
+
+		@Override
+		public int[] walk(int[] context, JobReference jr) {
+			System.out.println("walk(JobReference)");
+			int nextId = id++;
+			Node node = new Node(Integer.toString(nextId), jr.getName());
+			nodes.add(node);
+			createdNodes.put(jr.getName(), node);
+			// Create links from the previous nodes to this one
+			if (context != null) {
+				int[] s = context;
+				for (int i : s) {
+					Link l = new Link(i, nextId);
+					links.add(l);
+				}
+			}
+			if (jr.hasTransitions()) {
+				for (Transition t : jr.getTransitions()) {
+					transitions.add(new TransitionToMap(nextId, t.getStateName(), t.getTargetJobName()));
+				}
+			}
+			return new int[] { nextId };
+		}
+
+		@Override
+		public int[] walk(int[] context, JobDefinition jd) {
+			int nextId = id++;
+			Map<String, String> properties = null;
+			ArgumentNode[] args = jd.getArguments();
+			if (args != null && args.length != 0) {
+				properties = new HashMap<>();
+				for (ArgumentNode arg : args) {
+					properties.put(arg.getName(), arg.getValue());
+				}
+			}
+			Node node = new Node(Integer.toString(nextId), jd.getJobName(), properties);
+			nodes.add(node);
+			createdNodes.put(node.name, node);
+			if (context != null) {
+				int[] s = context;
+				for (int i : s) {
+					Link l = new Link(i, nextId);
+					links.add(l);
+				}
+			}
+			if (jd.hasTransitions()) {
+				for (Transition t : jd.getTransitions()) {
+					transitions.add(new TransitionToMap(nextId, t.getStateName(), t.getTargetJobName()));
+				}
+			}
+			return new int[] { nextId };
+		}
+
+	}
+
+	public JobDefinition getJobDefinition(String jobName) {
+		for (JobDefinition jd : getJobDefinitions()) {
+			if (jd.getJobName().equals(jobName)) {
+				return jd;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Pretty print the text for this job specification, including appropriate
+	 * newlines and indentation.
+	 * @return formatted job specification.
+	 */
+	public String format() {
+		return jobNode.format(0);
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
@@ -208,7 +208,7 @@ public class JobSpecification extends AstNode {
 		/**
 		 * Counter for the numeric suffix to attach to generated split id attributes.
 		 */
-		private int splitId = 1;
+		private int splitIdCounter = 1;
 
 		private List<String> jobRunnerBeans = new ArrayList<>();
 
@@ -438,11 +438,24 @@ public class JobSpecification extends AstNode {
 			//   ...
 			// </split>
 			Element split = doc.createElement("split");
+			String splitId = "split" + (splitIdCounter++);
 			split.setAttribute("task-executor", "taskExecutor");
-			split.setAttribute("id", "split" + (splitId++));
+			split.setAttribute("id", splitId);
+
+			if (context != null) {
+				// context is an array of earlier elements that should point to this one
+				Element next = null;
+				for (Element element : context) {
+					next = doc.createElement("next");
+					next.setAttribute("on", "*");
+					next.setAttribute("to", splitId);
+					element.appendChild(next);
+				}
+			}
+
 			currentElement.peek().appendChild(split);
 			currentElement.push(split);
-			Element[] inputContext = context;
+			Element[] inputContext = new Element[] {};//context;
 			Element[] result = new Element[0];
 			for (JobNode jn : pjs.getSeries()) {
 				Object outputContext = walk(inputContext, jn);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
@@ -449,7 +449,9 @@ public class JobSpecification extends AstNode {
 				result = merge(result, outputContext);
 			}
 			currentElement.pop();
-			return result;
+			// The only element from here to connect to the 'next thing' is the split node.
+			// This means only the split gets a 'next on="*"' element.
+			return new Element[] { split };
 		}
 
 		Element[] merge(Element[] input, Object additional) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationException.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+/**
+ * Root exception for Job Flow DSL parsing related exceptions. Rather than holding a hard coded string indicating the problem, it
+ * records a message key and the inserts for the message. See {@link JobDSLMessage} for the list of all possible
+ * messages that can occur.
+ *
+ * @author Andy Clement
+ */
+@SuppressWarnings("serial")
+public class JobSpecificationException extends RuntimeException {
+
+	protected String expressionString;
+
+	protected int position; // -1 if not known - but should be known in all reasonable cases
+
+	protected JobDSLMessage message;
+
+	protected Object[] inserts;
+
+	public JobSpecificationException(String expressionString, int position, JobDSLMessage message,
+			Object... inserts) {
+		super(message.formatMessage(position, inserts));
+		this.position = position;
+		this.message = message;
+		this.inserts = inserts;
+		this.expressionString = expressionString;
+	}
+
+	/**
+	 * @return a formatted message with inserts applied
+	 */
+	@Override
+	public String getMessage() {
+		StringBuilder s = new StringBuilder();
+		if (message != null) {
+			s.append(message.formatMessage(position, inserts));
+		}
+		else {
+			s.append(super.getMessage());
+		}
+		if (expressionString != null && expressionString.length() > 0) {
+			s.append("\n").append(expressionString).append("\n");
+		}
+		if (position >= 0) {
+			for (int i = 0; i < position; i++) {
+				s.append(' ');
+			}
+			s.append("^\n");
+		}
+		return s.toString();
+	}
+
+	/**
+	 * @return the message code
+	 */
+	public JobDSLMessage getMessageCode() {
+		return this.message;
+	}
+
+	/**
+	 * @return the message inserts
+	 */
+	public Object[] getInserts() {
+		return inserts;
+	}
+
+	/**
+	 * @return the dsl expression text
+	 */
+	public final String getExpressionString() {
+		return this.expressionString;
+	}
+
+	/**
+	 * @return location of the error in the expression text
+	 */
+	public final int getPosition() {
+		return position;
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationException.java
@@ -16,6 +16,9 @@
 
 package org.springframework.xd.dirt.job.dsl;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Root exception for Job Flow DSL parsing related exceptions. Rather than holding a hard coded string indicating the problem, it
  * records a message key and the inserts for the message. See {@link JobDSLMessage} for the list of all possible
@@ -93,6 +96,25 @@ public class JobSpecificationException extends RuntimeException {
 	 */
 	public final int getPosition() {
 		return position;
+	}
+
+	/**
+	 * Produce a simple map of information about the exception that
+	 * can be sent to the client for display.
+	 * @return map of simple information including message and position
+	 */
+	public Map<String, Object> toExceptionDescriptor() {
+		Map<String, Object> descriptor = new HashMap<>();
+		String text = null;
+		if (message != null) {
+			text = message.formatMessage(position, inserts);
+		}
+		else {
+			text = super.getMessage();
+		}
+		descriptor.put("message", text);
+		descriptor.put("position", position);
+		return descriptor;
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationVisitor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationVisitor.java
@@ -30,7 +30,9 @@ public abstract class JobSpecificationVisitor<T> {
 	public final void accept(JobSpecification jobSpec) {
 		T context = preJobSpecWalk();
 		JobNode jn = jobSpec.getJobNode();
-		context = walk(context, jn);
+		if (jn != null) {
+			context = walk(context, jn);
+		}
 		postJobSpecWalk(context);
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationVisitor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationVisitor.java
@@ -28,10 +28,10 @@ public abstract class JobSpecificationVisitor<T> {
 	 * Called to start a visit of a specific JobSpec.
 	 */
 	public final void accept(JobSpecification jobSpec) {
-		preJobSpecWalk();
+		T context = preJobSpecWalk();
 		JobNode jn = jobSpec.getJobNode();
-		walk(null, jn);
-		postJobSpecWalk();
+		context = walk(context, jn);
+		postJobSpecWalk(context);
 	}
 
 	public final T walk(T context, JobNode jn) {
@@ -54,15 +54,17 @@ public abstract class JobSpecificationVisitor<T> {
 
 	/**
 	 * Override to provide code that will run just before the visit starts.
+	 * @return optionally return some context that will be passed to the first real visit operation
 	 */
-	public void preJobSpecWalk() {
-
+	public T preJobSpecWalk() {
+		return null;
 	}
 
 	/**
 	 * Override to provide code that will run just after the visit completes.
+	 * @param context the final context computed by the last of the main visit operations
 	 */
-	public void postJobSpecWalk() {
+	public void postJobSpecWalk(T context) {
 
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationVisitor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationVisitor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+/**
+ * very basic visitor pattern for a JobSpecVisitor. Provide a concrete implementation to participate in the
+ * visit.
+ *
+ * @param <T> the type of the context objects flowing across the visit
+ */
+public abstract class JobSpecificationVisitor<T> {
+
+	/**
+	 * Called to start a visit of a specific JobSpec.
+	 */
+	public final void accept(JobSpecification jobSpec) {
+		preJobSpecWalk();
+		JobNode jn = jobSpec.getJobNode();
+		walk(null, jn);
+		postJobSpecWalk();
+	}
+
+	public final T walk(T context, JobNode jn) {
+		if (jn instanceof Flow) {
+			return walk(context, (Flow) jn);
+		}
+		else if (jn instanceof JobDefinition) {
+			return walk(context, (JobDefinition) jn);
+		}
+		else if (jn instanceof JobReference) {
+			return walk(context, (JobReference) jn);
+		}
+		else if (jn instanceof Split) {
+			return walk(context, (Split) jn);
+		}
+		else {
+			throw new IllegalStateException("nyi:" + jn.getClass().getName());
+		}
+	}
+
+	/**
+	 * Override to provide code that will run just before the visit starts.
+	 */
+	public void preJobSpecWalk() {
+
+	}
+
+	/**
+	 * Override to provide code that will run just after the visit completes.
+	 */
+	public void postJobSpecWalk() {
+
+	}
+
+	/**
+	 * Visit a sequence of jobs (flow).
+	 * @param context any context this visitor is passing during visits
+	 * @param jobSeries a JobNode representing a series of jobs run in sequence
+	 * @return any context to pass along to the next visit calls
+	 */
+	public abstract T walk(T context, Flow jobSeries);
+
+	public abstract T walk(T context, JobDefinition jobDefinition);
+
+	public abstract T walk(T context, JobReference jobReference);
+
+	public abstract T walk(T context, Split jobSeries);
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Link.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Link.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Represents a node in a {@link Graph} object that Flo will display as a block.
+ *
+ * @author Andy Clement
+ */
+public class Link {
+
+	public int from;
+
+	public int to;
+
+	/**
+	 * Properties on a link can capture the name of a potential transition that
+	 * would lead to this link being taken when the 'from' job completes.
+	 */
+	public Map<String, String> properties = null;
+
+	public Link(int sourceId, int targetId) {
+		this.from = sourceId;
+		this.to = targetId;
+	}
+
+	public Link(int sourceId, int targetId, String transitionName) {
+		this.from = sourceId;
+		this.to = targetId;
+		properties = new HashMap<>();
+		properties.put("transitionName", transitionName);
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Link.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Link.java
@@ -19,17 +19,27 @@ package org.springframework.xd.dirt.job.dsl;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 
 /**
- * Represents a node in a {@link Graph} object that Flo will display as a block.
+ * Represents a link in a {@link Graph} object that Flo will display as a block.
  *
  * @author Andy Clement
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Link {
 
-	public int from;
+	//	public final static String TRANSITION_NAME = "transitionName";
 
-	public int to;
+	public String from;
+
+	public String to;
+
+	Link() {
+
+	}
 
 	/**
 	 * Properties on a link can capture the name of a potential transition that
@@ -38,14 +48,34 @@ public class Link {
 	public Map<String, String> properties = null;
 
 	public Link(int sourceId, int targetId) {
-		this.from = sourceId;
-		this.to = targetId;
+		this.from = Integer.toString(sourceId);
+		this.to = Integer.toString(targetId);
 	}
 
 	public Link(int sourceId, int targetId, String transitionName) {
-		this.from = sourceId;
-		this.to = targetId;
+		this.from = Integer.toString(sourceId);
+		this.to = Integer.toString(targetId);
 		properties = new HashMap<>();
 		properties.put("transitionName", transitionName);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder s = new StringBuilder();
+		s.append("Link[from=").append(from).append(",to=").append(to);
+		if (properties != null) {
+			s.append(",properties=").append(properties);
+		}
+		s.append("]");
+		return s.toString();
+	}
+
+	public boolean hasTransitionSet() {
+		return properties != null && properties.containsKey("transitionName");
+	}
+
+	@JsonIgnore
+	public String getTransitionName() {
+		return properties != null ? properties.get("transitionName") : null;
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
@@ -18,18 +18,26 @@ package org.springframework.xd.dirt.job.dsl;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * Represents a node in a {@link Graph} object that Flo will display as a block.
  *
  * @author Andy Clement
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Node {
 
-	public final String id;
+	public String id;
 
-	public final String name;
+	public String name;
 
-	public final Map<String, String> properties;
+	public Map<String, String> properties;
+
+	Node() {
+
+	}
 
 	Node(String id, String name) {
 		this.id = id;
@@ -41,5 +49,31 @@ public class Node {
 		this.id = id;
 		this.name = name;
 		this.properties = properties;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder s = new StringBuilder();
+		s.append("Node[id=").append(id).append(",name=").append(name);
+		if (properties != null) {
+			s.append(",properties=").append(properties);
+		}
+		s.append("]");
+		return s.toString();
+	}
+
+	@JsonIgnore
+	public boolean isStart() {
+		return name.equals("START");
+	}
+
+	@JsonIgnore
+	public boolean isEnd() {
+		return name.equals("END");
+	}
+
+	@JsonIgnore
+	public boolean isSync() {
+		return name.equals("SYNC");
 	}
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.Map;
+
+/**
+ * Represents a node in a {@link Graph} object that Flo will display as a block.
+ *
+ * @author Andy Clement
+ */
+public class Node {
+
+	public final String id;
+
+	public final String name;
+
+	public final Map<String, String> properties;
+
+	Node(String id, String name) {
+		this.id = id;
+		this.name = name;
+		this.properties = null;
+	}
+
+	Node(String id, String name, Map<String, String> properties) {
+		this.id = id;
+		this.name = name;
+		this.properties = properties;
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
@@ -29,9 +29,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Node {
 
+	public static final String METADATAKEY_JOBMODULENAME = "jobModuleName";
+
 	public String id;
 
 	public String name;
+
+	public Map<String, String> metadata;
 
 	public Map<String, String> properties;
 
@@ -45,9 +49,10 @@ public class Node {
 		this.properties = null;
 	}
 
-	Node(String id, String name, Map<String, String> properties) {
+	Node(String id, String name, Map<String, String> metadata, Map<String, String> properties) {
 		this.id = id;
 		this.name = name;
+		this.metadata = metadata;
 		this.properties = properties;
 	}
 
@@ -57,6 +62,9 @@ public class Node {
 		s.append("Node[id=").append(id).append(",name=").append(name);
 		if (properties != null) {
 			s.append(",properties=").append(properties);
+		}
+		if (metadata != null) {
+			s.append(",metadata=").append(metadata);
 		}
 		s.append("]");
 		return s.toString();

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Split.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Split.java
@@ -40,8 +40,6 @@ public class Split extends JobSeries {
 	@Override
 	public String stringify(boolean includePositionInfo) {
 		if (jobsInParallel.size() == 1) {
-			// TODO throw an exception when this situation is parsed?
-			// There is just the one sequence
 			return jobsInParallel.get(0).stringify(includePositionInfo);
 		}
 		else {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Split.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Split.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The AST node representing a split. A split is a series of jobs to execute in parallel. Those jobs
+ * can themselves be individual jobs or splits. In DSL form a flow is expressed like this:
+ * <pre><tt><aa & bb></tt></pre>.
+ *
+ * @author Andy Clement
+ */
+public class Split extends JobSeries {
+
+	private List<JobNode> jobsInParallel;
+
+	public Split(List<JobNode> parallelSequences) {
+		super(parallelSequences.get(0).getStartPos(),
+				parallelSequences.get(parallelSequences.size() - 1).getEndPos());
+		this.jobsInParallel = Collections.unmodifiableList(parallelSequences);
+	}
+
+
+	@Override
+	public String stringify(boolean includePositionInfo) {
+		if (jobsInParallel.size() == 1) {
+			// TODO throw an exception when this situation is parsed?
+			// There is just the one sequence
+			return jobsInParallel.get(0).stringify(includePositionInfo);
+		}
+		else {
+			StringBuilder s = new StringBuilder(TokenKind.SPLIT_OPEN.getTokenString());
+			for (int i = 0; i < jobsInParallel.size(); i++) {
+				JobNode jn = jobsInParallel.get(i);
+				if (i > 0) {
+					s.append(" ").append(TokenKind.AMPERSAND.getTokenString()).append(" ");
+				}
+				s.append(jn.stringify(includePositionInfo));
+			}
+			s.append(TokenKind.SPLIT_CLOSE.getTokenString());
+			return s.toString();
+		}
+	}
+
+	@Override
+	public int getSeriesLength() {
+		return jobsInParallel.size();
+	}
+
+	@Override
+	public JobNode getSeriesElement(int index) {
+		return jobsInParallel.get(index);
+	}
+
+	@Override
+	public List<JobNode> getSeries() {
+		return jobsInParallel;
+	}
+
+	@Override
+	boolean isSplit() {
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "[Split:" + stringify(true) + "]";
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Token.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Token.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+/**
+ * Holder for a kind of token, the associated data and its position in the input data stream (start/end).
+ *
+ * @author Andy Clement
+ */
+public class Token {
+
+	TokenKind kind; // the kind of token
+
+	String data; // any extra data for this token instance, e.g. the text for an identifier token
+
+	int startpos; // index of first character
+
+	int endpos; // index of char after the last character
+
+	/**
+	 * Constructor for use when there is no particular data for the token
+	 */
+	Token(TokenKind tokenKind, int startpos, int endpos) {
+		this.kind = tokenKind;
+		this.startpos = startpos;
+		this.endpos = endpos;
+	}
+
+	/**
+	 * Constructor for use when there is extra data to associate with a token. For example the text for an identifier
+	 * token.
+	 */
+	Token(TokenKind tokenKind, char[] tokenData, int pos, int endpos) {
+		this(tokenKind, pos, endpos);
+		this.data = new String(tokenData.clone());
+	}
+
+
+	public TokenKind getKind() {
+		return kind;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder s = new StringBuilder();
+		s.append("[").append(kind.toString());
+		if (kind.hasPayload()) {
+			s.append(":").append(data);
+		}
+		s.append("]");
+		s.append("(").append(startpos).append(",").append(endpos).append(")");
+		return s.toString();
+	}
+
+	public boolean isIdentifier() {
+		return kind == TokenKind.IDENTIFIER;
+	}
+
+	public String stringValue() {
+		return data;
+	}
+
+	@Override
+	public int hashCode() {
+		return this.kind.ordinal() * 37 + (this.startpos + this.endpos) * 37 +
+				(this.kind.hasPayload() ? this.data.hashCode() : 0);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof Token)) {
+			return false;
+		}
+		Token token = (Token) o;
+		boolean basicmatch = this.kind == token.kind &&
+				this.startpos == token.startpos && this.endpos == token.endpos;
+		if (!basicmatch)
+			return false;
+		if (this.kind.hasPayload()) {
+			if (!this.data.equals(token.data)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public boolean isKind(TokenKind desiredKind) {
+		return kind == desiredKind;
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/TokenKind.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/TokenKind.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+/**
+ * Enumeration of all the token types that may be found in a Job DSL specification.
+ *
+ * @author Andy Clement
+ */
+public enum TokenKind {
+	IDENTIFIER, //
+	AMPERSAND("&"), //
+	DOUBLE_PIPE("||"), //
+	DOUBLE_MINUS("--"), //
+	OPEN_PAREN("("), //
+	CLOSE_PAREN(")"), //
+	EQUALS("="), //
+	PIPE("|"), //
+	NEWLINE("\n"), //
+	SPLIT_OPEN("<"), //
+	SPLIT_CLOSE(">"), //
+	LITERAL_STRING,; //
+
+	char[] tokenChars;
+
+	private boolean hasPayload; // is there more to this token than simply the kind
+
+	private TokenKind(String tokenString) {
+		tokenChars = tokenString.toCharArray();
+		hasPayload = tokenChars.length == 0;
+	}
+
+	private TokenKind() {
+		this("");
+	}
+
+	@Override
+	public String toString() {
+		return this.name() + (tokenChars.length != 0 ? "(" + new String(tokenChars) + ")" : "");
+	}
+
+	public boolean hasPayload() {
+		return hasPayload;
+	}
+
+	public int getLength() {
+		return tokenChars.length;
+	}
+
+	/**
+	 * @return the chars representing simple fixed token (eg. : > --)
+	 */
+	public char[] getTokenChars() {
+		return tokenChars;
+	}
+
+	public String getTokenString() {
+		return new String(tokenChars);
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokenizer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokenizer.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.util.Assert;
+import org.springframework.xd.dirt.stream.dsl.StreamDefinitionException;
+import org.springframework.xd.dirt.stream.dsl.XDDSLMessages;
+
+/**
+ * Lex some input data into a stream of tokens that can then then be parsed.
+ *
+ * @author Andy Clement
+ */
+class Tokenizer {
+
+	private String expressionString; // The string to be tokenized
+
+	private char[] toProcess; // The expressionString as a char array
+
+	private int max; // Length of input data
+
+	private int pos; // Current lexing position in the input data
+
+	private List<Token> tokens = new ArrayList<Token>(); // Output stream of tokens
+
+	public Tokenizer(String inputdata) {
+		this.expressionString = inputdata;
+		this.toProcess = (inputdata + "\0").toCharArray();
+		this.max = toProcess.length;
+		this.pos = 0;
+		process();
+	}
+
+	private void process() {
+		boolean justProcessedEquals = false;
+		while (pos < max) {
+			char ch = toProcess[pos];
+
+			if (justProcessedEquals) {
+				if (!isWhitespace(ch) && ch != 0) {
+					// following an '=' we commence a variant of regular tokenization,
+					// here we consume everything up to the next special char.
+					// This allows SpEL expressions to be used without quoting in many
+					// situations.
+					lexArgValueIdentifier();
+				}
+				justProcessedEquals = false;
+				continue;
+			}
+
+			if (isAlphabetic(ch) || isDigit(ch) || ch == '_' || ch == '.') {
+				lexIdentifier();
+			}
+			else {
+				switch (ch) {
+					case '&':
+						pushCharToken(TokenKind.AMPERSAND);
+						break;
+					case '<':
+						pushCharToken(TokenKind.SPLIT_OPEN);
+						break;
+					case '>':
+						pushCharToken(TokenKind.SPLIT_CLOSE);
+						break;
+					case '|':
+						if (isTwoCharToken(TokenKind.DOUBLE_PIPE)) {
+							pushPairToken(TokenKind.DOUBLE_PIPE);
+						}
+						else {
+							pushPairToken(TokenKind.PIPE);
+						}
+						break;
+					case '-':
+						if (!isTwoCharToken(TokenKind.DOUBLE_MINUS)) {
+							throw new JobSpecificationException(
+									expressionString, pos,
+									JobDSLMessage.MISSING_CHARACTER, "-");
+						}
+						pushPairToken(TokenKind.DOUBLE_MINUS);
+						break;
+					case '=':
+						justProcessedEquals = true;
+						pushCharToken(TokenKind.EQUALS);
+						break;
+					case ' ':
+					case '\t':
+					case '\r':
+						// drift over white space
+						pos++;
+						break;
+					case '\n':
+						pos++;
+						//						pushCharToken(TokenKind.NEWLINE);
+						break;
+					//					case '.':
+					//						pushCharToken(TokenKind.DOT);
+					//						break;
+					//					case ':':
+					//						pushCharToken(TokenKind.COLON);
+					//						break;
+					case '(':
+						pushCharToken(TokenKind.OPEN_PAREN);
+						break;
+					case ')':
+						pushCharToken(TokenKind.CLOSE_PAREN);
+						break;
+					//					case ';':
+					//						pushCharToken(TokenKind.SEMICOLON);
+					//						break;
+					case '\'':
+						lexQuotedStringLiteral();
+						break;
+					case '"':
+						lexDoubleQuotedStringLiteral();
+						break;
+					//					case '@':
+					//						pushCharToken(TokenKind.REFERENCE);
+					//						break;
+					case 0:
+						// hit sentinel at end of char data
+						pos++; // will take us to the end
+						break;
+					case '\\':
+						throw new StreamDefinitionException(
+								expressionString, pos, XDDSLMessages.UNEXPECTED_ESCAPE_CHAR);
+					default:
+						throw new StreamDefinitionException(
+								expressionString, pos, XDDSLMessages.UNEXPECTED_DATA,
+								Character.valueOf(ch).toString());
+				}
+			}
+		}
+	}
+
+	public List<Token> getTokens() {
+		return tokens;
+	}
+
+	/**
+	 * Lex a string literal which uses single quotes as delimiters. To include a single quote within the literal, use a
+	 * pair ''
+	 */
+	private void lexQuotedStringLiteral() {
+		int start = pos;
+		boolean terminated = false;
+		while (!terminated) {
+			pos++;
+			char ch = toProcess[pos];
+			if (ch == '\'') {
+				// may not be the end if the char after is also a '
+				if (toProcess[pos + 1] == '\'') {
+					pos++; // skip over that too, and continue
+				}
+				else {
+					terminated = true;
+				}
+			}
+			if (ch == 0) {
+				throw new StreamDefinitionException(
+						expressionString, start, XDDSLMessages.NON_TERMINATING_QUOTED_STRING);
+			}
+		}
+		pos++;
+		tokens.add(new Token(TokenKind.LITERAL_STRING,
+				subarray(start, pos), start, pos));
+	}
+
+	/**
+	 * Lex a string literal which uses double quotes as delimiters. To include a single quote within the literal, use a
+	 * pair ""
+	 */
+	private void lexDoubleQuotedStringLiteral() {
+		int start = pos;
+		boolean terminated = false;
+		while (!terminated) {
+			pos++;
+			char ch = toProcess[pos];
+			if (ch == '"') {
+				// may not be the end if the char after is also a "
+				if (toProcess[pos + 1] == '"') {
+					pos++; // skip over that too, and continue
+				}
+				else {
+					terminated = true;
+				}
+			}
+			if (ch == 0) {
+				throw new StreamDefinitionException(
+						expressionString, start, XDDSLMessages.NON_TERMINATING_DOUBLE_QUOTED_STRING);
+			}
+		}
+		pos++;
+		tokens.add(new Token(TokenKind.LITERAL_STRING,
+				subarray(start, pos), start, pos));
+	}
+
+	private void lexIdentifier() {
+		int start = pos;
+		do {
+			pos++;
+		}
+		while (isIdentifier(toProcess[pos]));
+		char[] subarray = subarray(start, pos);
+		tokens.add(new Token(TokenKind.IDENTIFIER, subarray, start, pos));
+	}
+
+	/**
+	 * For the variant tokenizer (used following an '=' to parse an argument value) we only terminate that identifier if
+	 * encountering a small set of characters. If the argument has included a ' to put something in quotes, we remember
+	 * that and don't allow ' ' (space) and '\t' (tab) to terminate the value.
+	 */
+	private boolean isArgValueIdentifierTerminator(char ch, boolean quoteOpen) {
+		return (ch == '|' && !quoteOpen) || (ch == ';' && !quoteOpen) || ch == '\0' || (ch == ' ' && !quoteOpen)
+				|| (ch == '\t' && !quoteOpen) || (ch == '>' && !quoteOpen)
+				|| ch == '\r' || ch == '\n';
+	}
+
+	/**
+	 * To prevent the need to quote all argument values, this identifier lexing function is used just after an '=' when
+	 * we are about to digest an arg value. It is much more relaxed about what it will include in the identifier.
+	 */
+	private void lexArgValueIdentifier() {
+		// Much of the complexity in here relates to supporting cases like these:
+		// 'hi'+payload
+		// 'hi'+'world'
+		// In these situations it looks like a quoted string and that perhaps the entire
+		// argument value is being quoted, but in fact half way through it is discovered that the
+		// entire value is not quoted, only the first part of the argument value is a string literal.
+
+		int start = pos;
+		boolean quoteOpen = false;
+		int quoteClosedCount = 0; // Enables identification of this pattern: 'hello'+'world'
+		Character quoteInUse = null; // If set, indicates this is being treated as a quoted string
+		if (isQuote(toProcess[pos])) {
+			quoteOpen = true;
+			quoteInUse = toProcess[pos++];
+		}
+		do {
+			char ch = toProcess[pos];
+			if ((quoteInUse != null && ch == quoteInUse) || (quoteInUse == null && isQuote(ch))) {
+				if (quoteInUse != null && quoteInUse == '\'' && ch == '\'' && toProcess[pos + 1] == '\'') {
+					pos++; // skip over that too, and continue
+				}
+				else {
+					quoteOpen = !quoteOpen;
+					if (!quoteOpen) {
+						quoteClosedCount++;
+					}
+				}
+			}
+			pos++;
+		}
+		while (!isArgValueIdentifierTerminator(toProcess[pos], quoteOpen));
+		char[] subarray = null;
+		if (quoteClosedCount < 2 && sameQuotes(start, pos - 1)) {
+			tokens.add(new Token(TokenKind.LITERAL_STRING,
+					subarray(start, pos), start, pos));
+		}
+		else {
+			subarray = subarray(start, pos);
+			tokens.add(new Token(TokenKind.IDENTIFIER, subarray, start, pos));
+		}
+	}
+
+	private boolean sameQuotes(int pos1, int pos2) {
+		if (toProcess[pos1] == '\'') {
+			return toProcess[pos2] == '\'';
+		}
+		else if (toProcess[pos1] == '"') {
+			return toProcess[pos2] == '"';
+		}
+		return false;
+	}
+
+	private char[] subarray(int start, int end) {
+		char[] result = new char[end - start];
+		System.arraycopy(toProcess, start, result, 0, end - start);
+		return result;
+	}
+
+	/**
+	 * Check if this might be a two character token.
+	 */
+	private boolean isTwoCharToken(TokenKind kind) {
+		Assert.isTrue(kind.tokenChars.length == 2);
+		Assert.isTrue(toProcess[pos] == kind.tokenChars[0]);
+		return toProcess[pos + 1] == kind.tokenChars[1];
+	}
+
+	/**
+	 * Push a token of just one character in length.
+	 */
+	private void pushCharToken(TokenKind kind) {
+		tokens.add(new Token(kind, pos, pos + 1));
+		pos++;
+	}
+
+	/**
+	 * Push a token of two characters in length.
+	 */
+	private void pushPairToken(TokenKind kind) {
+		tokens.add(new Token(kind, pos, pos + 2));
+		pos += 2;
+	}
+
+	// ID: ('a'..'z'|'A'..'Z'|'_'|'$') ('a'..'z'|'A'..'Z'|'_'|'$'|'0'..'9'|DOT_ESCAPED|'-'|'.')*
+	private boolean isIdentifier(char ch) {
+		return isAlphabetic(ch) || isDigit(ch) || ch == '_' || ch == '$' || ch == '-' || ch == '.';
+	}
+
+	private boolean isQuote(char ch) {
+		return ch == '\'' || ch == '"';
+	}
+
+	private boolean isWhitespace(char ch) {
+		return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n';
+	}
+
+	private boolean isDigit(char ch) {
+		if (ch > 255) {
+			return false;
+		}
+		return (flags[ch] & IS_DIGIT) != 0;
+	}
+
+	private boolean isAlphabetic(char ch) {
+		if (ch > 255) {
+			return false;
+		}
+		return (flags[ch] & IS_ALPHA) != 0;
+	}
+
+	private static final byte flags[] = new byte[256];
+
+	private static final byte IS_DIGIT = 0x01;
+
+	private static final byte IS_HEXDIGIT = 0x02;
+
+	private static final byte IS_ALPHA = 0x04;
+
+	static {
+		for (int ch = '0'; ch <= '9'; ch++) {
+			flags[ch] |= IS_DIGIT | IS_HEXDIGIT;
+		}
+		for (int ch = 'A'; ch <= 'F'; ch++) {
+			flags[ch] |= IS_HEXDIGIT;
+		}
+		for (int ch = 'a'; ch <= 'f'; ch++) {
+			flags[ch] |= IS_HEXDIGIT;
+		}
+		for (int ch = 'A'; ch <= 'Z'; ch++) {
+			flags[ch] |= IS_ALPHA;
+		}
+		for (int ch = 'a'; ch <= 'z'; ch++) {
+			flags[ch] |= IS_ALPHA;
+		}
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder s = new StringBuilder();
+		s.append(this.expressionString).append("\n");
+		for (int i = 0; i < this.pos; i++) {
+			s.append(" ");
+		}
+		s.append("^\n");
+		s.append(tokens).append("\n");
+		return s.toString();
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokenizer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokenizer.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.util.Assert;
-import org.springframework.xd.dirt.stream.dsl.StreamDefinitionException;
-import org.springframework.xd.dirt.stream.dsl.XDDSLMessages;
 
 /**
  * Lex some input data into a stream of tokens that can then then be parsed.
@@ -102,47 +100,32 @@ class Tokenizer {
 					case ' ':
 					case '\t':
 					case '\r':
+					case '\n':
 						// drift over white space
 						pos++;
 						break;
-					case '\n':
-						pos++;
-						//						pushCharToken(TokenKind.NEWLINE);
-						break;
-					//					case '.':
-					//						pushCharToken(TokenKind.DOT);
-					//						break;
-					//					case ':':
-					//						pushCharToken(TokenKind.COLON);
-					//						break;
 					case '(':
 						pushCharToken(TokenKind.OPEN_PAREN);
 						break;
 					case ')':
 						pushCharToken(TokenKind.CLOSE_PAREN);
 						break;
-					//					case ';':
-					//						pushCharToken(TokenKind.SEMICOLON);
-					//						break;
 					case '\'':
 						lexQuotedStringLiteral();
 						break;
 					case '"':
 						lexDoubleQuotedStringLiteral();
 						break;
-					//					case '@':
-					//						pushCharToken(TokenKind.REFERENCE);
-					//						break;
 					case 0:
 						// hit sentinel at end of char data
 						pos++; // will take us to the end
 						break;
 					case '\\':
-						throw new StreamDefinitionException(
-								expressionString, pos, XDDSLMessages.UNEXPECTED_ESCAPE_CHAR);
+						throw new JobSpecificationException(
+								expressionString, pos, JobDSLMessage.UNEXPECTED_ESCAPE_CHAR);
 					default:
-						throw new StreamDefinitionException(
-								expressionString, pos, XDDSLMessages.UNEXPECTED_DATA,
+						throw new JobSpecificationException(
+								expressionString, pos, JobDSLMessage.UNEXPECTED_DATA,
 								Character.valueOf(ch).toString());
 				}
 			}
@@ -173,8 +156,8 @@ class Tokenizer {
 				}
 			}
 			if (ch == 0) {
-				throw new StreamDefinitionException(
-						expressionString, start, XDDSLMessages.NON_TERMINATING_QUOTED_STRING);
+				throw new JobSpecificationException(
+						expressionString, start, JobDSLMessage.NON_TERMINATING_QUOTED_STRING);
 			}
 		}
 		pos++;
@@ -202,8 +185,8 @@ class Tokenizer {
 				}
 			}
 			if (ch == 0) {
-				throw new StreamDefinitionException(
-						expressionString, start, XDDSLMessages.NON_TERMINATING_DOUBLE_QUOTED_STRING);
+				throw new JobSpecificationException(
+						expressionString, start, JobDSLMessage.NON_TERMINATING_DOUBLE_QUOTED_STRING);
 			}
 		}
 		pos++;
@@ -227,7 +210,8 @@ class Tokenizer {
 	 * that and don't allow ' ' (space) and '\t' (tab) to terminate the value.
 	 */
 	private boolean isArgValueIdentifierTerminator(char ch, boolean quoteOpen) {
-		return (ch == '|' && !quoteOpen) || (ch == ';' && !quoteOpen) || ch == '\0' || (ch == ' ' && !quoteOpen)
+		return (ch == '&' && !quoteOpen) || (ch == '|' && !quoteOpen) || (ch == ';' && !quoteOpen) || ch == '\0'
+				|| (ch == ' ' && !quoteOpen)
 				|| (ch == '\t' && !quoteOpen) || (ch == '>' && !quoteOpen)
 				|| ch == '\r' || ch == '\n';
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokens.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokens.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Class that converts an expression into a list of {@link Token tokens}.
+ * Furthermore, this class provides methods to process the tokens and
+ * keeps track of the current token being processed.
+ *
+ * @author Andy Clement
+ * @author Patrick Peralta
+ */
+public class Tokens {
+
+	/**
+	 * Expression string to be parsed.
+	 */
+	private final String expression;
+
+	/**
+	 * List of tokens created from {@link #expression}.
+	 */
+	private final List<Token> tokenStream;
+
+	/**
+	 * Index of token currently being processed.
+	 */
+	private int position = 0;
+
+	/**
+	 * Index of last token that was successfully processed.
+	 */
+	private int lastGoodPosition = 0;
+
+
+	/**
+	 * Construct a {@code Tokens} object based on the provided string expression.
+	 *
+	 * @param expression string expression to convert into {@link Token tokens}.
+	 */
+	public Tokens(String expression) {
+		this.expression = expression;
+		this.tokenStream = Collections.unmodifiableList(new Tokenizer(expression).getTokens());
+	}
+
+	/**
+	 * Return the expression string converted to tokens.
+	 *
+	 * @return expression string
+	 */
+	protected String getExpression() {
+		return expression;
+	}
+
+	/**
+	 * Decrement the current token position and return the new position.
+	 *
+	 * @return new token position
+	 */
+	protected int decrementPosition() {
+		return --position;
+	}
+
+	/**
+	 * Return the current token position.
+	 *
+	 * @return current token position
+	 */
+	protected int position() {
+		return position;
+	}
+
+	/**
+	 * Return an immutable list of {@link Token tokens}
+	 *
+	 * @return list of tokens
+	 */
+	public List<Token> getTokenStream() {
+		return tokenStream;
+	}
+
+	/**
+	 * Return {@code true} if the token in the position indicated
+	 * by {@link #position} + {@code distance} matches
+	 * the token indicated by {@code desiredTokenKind}.
+	 *
+	 * @param distance number of token positions past the current position
+	 * @param desiredTokenKind the token to check for
+	 * @return true if the token at the indicated position matches
+	 * {@code desiredTokenKind}
+	 */
+	protected boolean lookAhead(int distance, TokenKind desiredTokenKind) {
+		if ((position + distance) >= tokenStream.size()) {
+			return false;
+		}
+		Token t = tokenStream.get(position + distance);
+		return t.kind == desiredTokenKind;
+	}
+
+	/**
+	 * Return {@code true} if there are more tokens to process.
+	 *
+	 * @return {@code true} if there are more tokens to process
+	 */
+	protected boolean hasNext() {
+		return position < tokenStream.size();
+	}
+
+	/**
+	 * Return the token at the current position. If there are no more tokens,
+	 * return {@code null}.
+	 *
+	 * @return token at current position or {@code null} if there are no more tokens
+	 */
+	protected Token peek() {
+		return hasNext() ? tokenStream.get(position) : null;
+	}
+
+	/**
+	 * Return the token at the specified offset from the current position. If there
+	 * are no more tokens, return {@code null}.
+	 *
+	 * @return token at specified offset from current position or {@code null} if there are no more tokens
+	 */
+	protected Token peek(int offset) {
+		if ((position + offset) >= tokenStream.size()) {
+			return null;
+		}
+		return tokenStream.get(position + offset);
+	}
+
+	/**
+	 * Peek at the token at an offset (relative to the current position) - if the token
+	 * matches the indicated kind, return true, otherwise return false.
+	 *
+	 * @param offset the offset from the current position to peek at
+	 * @param tokenKind the tokenKind to check against
+	 * @return true if the token at the specified offset matches the indicated kind, otherwise false
+	 */
+	protected boolean peek(int offset, TokenKind tokenKind) {
+		if ((position + offset) >= tokenStream.size()) {
+			return false;
+		}
+		Token nextToken = tokenStream.get(position + offset);
+		return (nextToken.getKind() == tokenKind);
+	}
+
+	/**
+	 * Return {@code true} if the indicated token matches the current token
+	 * position.
+	 *
+	 * @param desiredTokenKind token to match
+	 * @return true if the current token kind matches the provided token kind
+	 */
+	protected boolean peek(TokenKind desiredTokenKind) {
+		return peek(desiredTokenKind, false);
+	}
+
+	/**
+	 * Return {@code true} if the indicated token matches the current token
+	 * position.
+	 *
+	 * @param desiredTokenKind token to match
+	 * @param consumeIfMatched if {@code true}, advance the current token position
+	 * @return true if the current token kind matches the provided token kind
+	 */
+	private boolean peek(TokenKind desiredTokenKind, boolean consumeIfMatched) {
+		if (!hasNext()) {
+			return false;
+		}
+		Token t = peek();
+		if (t.kind == desiredTokenKind) {
+			if (consumeIfMatched) {
+				position++;
+			}
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+	/**
+	 * Return the next {@link Token} and advance the current token position.
+	 *
+	 * @return next {@code Token}
+	 */
+	protected Token next() {
+		if (!hasNext()) {
+			raiseException(expression.length(), JobDSLMessage.OOD);
+		}
+		return tokenStream.get(position++);
+	}
+
+	/**
+	 * Consume the next token if it matches the indicated token kind;
+	 * otherwise throw {@link CheckPointedParseException}.
+	 *
+	 * @param expectedKind the expected token kind
+	 * @return the next token
+	 * @throws CheckPointedParseException if the next token does not match
+	 * the expected token kind
+	 */
+	protected Token eat(TokenKind expectedKind) {
+		Token t = next();
+		if (t == null) {
+			raiseException(expression.length(), JobDSLMessage.OOD);
+		}
+		if (t.kind != expectedKind) {
+			raiseException(t.startpos, JobDSLMessage.NOT_EXPECTED_TOKEN,
+					expectedKind.toString().toLowerCase(),
+					t.getKind().toString().toLowerCase() + (t.data == null ? "" : "(" + t.data + ")"));
+		}
+		return t;
+	}
+
+	/**
+	 * Consume the next token if it matches the desired token kind and return true; otherwise
+	 * return false.
+	 *
+	 * @param desiredKind the desired token to eat
+	 * @return true if the token was consumed, otherwise false
+	 */
+	protected boolean maybeEat(TokenKind desiredKind) {
+		if (peek(desiredKind)) {
+			next();
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
+
+	/**
+	 * Return {@code true} if the first character of the token at the current position
+	 * is the same as the last character of the token at the previous position.
+	 *
+	 * @return true if the first character of the current token matches the last
+	 * character of the previous token
+	 */
+	protected boolean isNextAdjacent() {
+		if (!hasNext()) {
+			return false;
+		}
+
+		Token last = tokenStream.get(position - 1);
+		Token next = tokenStream.get(position);
+		return next.startpos == last.endpos;
+	}
+
+	/**
+	 * Indicate that the current token has been successfully processed.
+	 *
+	 * @see #lastGoodPosition
+	 */
+	protected void checkpoint() {
+		lastGoodPosition = position;
+	}
+
+	/**
+	 * Throw a new {@link CheckPointedParseException} based on the current and
+	 * last successfully processed token position.
+	 *
+	 * @param position position where parse error occurred
+	 * @param message  parse exception message
+	 * @param inserts  variables that may be inserted in the error message
+	 */
+	protected void raiseException(int position, JobDSLMessage message, Object... inserts) {
+		throw new CheckpointedJobDefinitionException(expression, position, this.position,
+				lastGoodPosition, tokenStream, message, inserts);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder s = new StringBuilder();
+		s.append(tokenStream).append("\n");
+		s.append(expression).append("\n");
+		Token t = tokenStream.get(position);
+		int i = 0;
+		for (; i < t.startpos; i++) {
+			s.append(" ");
+		}
+		for (; i < t.endpos; i++) {
+			s.append("^");
+		}
+		s.append("\n");
+		return s.toString();
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokens.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokens.java
@@ -211,11 +211,11 @@ public class Tokens {
 
 	/**
 	 * Consume the next token if it matches the indicated token kind;
-	 * otherwise throw {@link CheckPointedParseException}.
+	 * otherwise throw {@link CheckpointedJobDefinitionException}.
 	 *
 	 * @param expectedKind the expected token kind
 	 * @return the next token
-	 * @throws CheckPointedParseException if the next token does not match
+	 * @throws CheckpointedJobDefinitionException if the next token does not match
 	 * the expected token kind
 	 */
 	protected Token eat(TokenKind expectedKind) {
@@ -267,7 +267,7 @@ public class Tokens {
 	}
 
 	/**
-	 * Indicate that the current token has been successfully processed.
+	 * Indicate that a piece of the DSL has been successfully processed.
 	 *
 	 * @see #lastGoodPosition
 	 */
@@ -276,7 +276,7 @@ public class Tokens {
 	}
 
 	/**
-	 * Throw a new {@link CheckPointedParseException} based on the current and
+	 * Throw a new {@link CheckpointedJobDefinitionException} based on the current and
 	 * last successfully processed token position.
 	 *
 	 * @param position position where parse error occurred

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Transition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Transition.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import org.springframework.xd.dirt.stream.dsl.AstNode;
+
+/**
+ * An AST node representing a transition found in the parsed Job specification. A transition
+ * is expressed in the form "<tt>| STATE = TARGET_JOB</tt>" and if the job attached to the
+ * transition finishes in the specified <tt>STATE</tt> then the next job to run should be
+ * the <tt>TARGET_JOB</tt>. If the state has a space in it (or other funky characters) it can
+ * be quoted.
+ *
+ * @author Andy Clement
+ */
+public class Transition extends AstNode {
+
+	private Token stateNameToken;
+
+	private String stateName;
+
+	private JobReference targetJobReference;
+
+	public Transition(Token stateNameToken, JobReference targetJobReference) {
+		super(stateNameToken.startpos, targetJobReference.getEndPos());
+		this.stateNameToken = stateNameToken;
+		this.targetJobReference = targetJobReference;
+		// If it is quoted, strip them off to determine real stateName
+		if (stateNameToken.isKind(TokenKind.LITERAL_STRING)) {
+			String quotesUsed = stateNameToken.data.substring(0, 1);
+			this.stateName = stateNameToken.data.substring(1, stateNameToken.data.length() - 1).replace(
+					quotesUsed + quotesUsed, quotesUsed);
+		}
+		else {
+			this.stateName = this.stateNameToken.stringValue();
+		}
+	}
+
+	@Override
+	public String stringify(boolean includePositionInfo) {
+		StringBuilder s = new StringBuilder();
+		s.append("| ");
+		s.append(stateNameToken.stringValue()).append(" = ").append(targetJobReference.getName());
+		return s.toString();
+	}
+
+	public String getStateName() {
+		return stateName;
+	}
+
+	public String getTargetJobName() {
+		return targetJobReference.getName();
+	}
+
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Transition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Transition.java
@@ -66,4 +66,15 @@ public class Transition extends AstNode {
 		return targetJobReference.getName();
 	}
 
+	/**
+	 * Basic names do not need wrapping in quotes but special characters, like
+	 * asterisk do. This returns the state name in a form suitable for inclusion
+	 * in DSL text (so with the quotes if that's how it was specified
+	 * when the Transition object was built).
+	 * @return the transition name suitable for inclusion in the DSL
+	 */
+	public String getStateNameInDSLForm() {
+		return stateNameToken.data;
+	}
+
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ToolsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ToolsController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.xd.dirt.job.dsl.Graph;
+import org.springframework.xd.dirt.job.dsl.JobParser;
 import org.springframework.xd.dirt.stream.DocumentParseResult;
 import org.springframework.xd.dirt.stream.XDStreamParser;
 import org.springframework.xd.rest.domain.DocumentParseResultResource;
@@ -31,27 +33,39 @@ import org.springframework.xd.rest.domain.DocumentParseResultResource;
  * A controller for integrating with frontend tools.
  *
  * @author Eric Bottard
+ * @author Andy Clement
  */
 @RestController
 @RequestMapping("/tools")
 public class ToolsController {
 
-	private XDStreamParser.MultiLineDocumentParser multilineParser;
+	private XDStreamParser.MultiLineDocumentParser multilineStreamParser;
+
+	private JobParser jobParser;
 
 	private DocumentParseResultResourceAssembler assembler = new DocumentParseResultResourceAssembler();
 
 	@Autowired
-	public ToolsController(XDStreamParser parser) {
-		this.multilineParser = new XDStreamParser.MultiLineDocumentParser(parser);
+	public ToolsController(XDStreamParser streamParser) {
+		this.multilineStreamParser = new XDStreamParser.MultiLineDocumentParser(streamParser);
+		this.jobParser = new JobParser();
 	}
 
 	/**
-     * Accept a whole list of definitions and report whether they are valid as a whole or not.
+	 * Accept a whole list of definitions and report whether they are valid as a whole or not.
 	 */
 	@RequestMapping(value = "/parse", method = RequestMethod.GET)
 	public DocumentParseResultResource validate(@RequestParam("definitions") String definitions) {
-		DocumentParseResult parse = multilineParser.parse(definitions.split("\n"));
+		DocumentParseResult parse = multilineStreamParser.parse(definitions.split("\n"));
 		return assembler.toResource(parse);
+	}
+
+	/**
+	 * Parse a single job specification into a graph structure.
+	 */
+	@RequestMapping(value = "/parseJob", method = RequestMethod.GET)
+	public Graph parseJob(@RequestParam("specification") String specification) {
+		return jobParser.getGraph(specification);
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ToolsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ToolsController.java
@@ -18,7 +18,6 @@
 
 package org.springframework.xd.dirt.rest;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -88,8 +87,12 @@ public class ToolsController {
 	 */
 	@RequestMapping(value = "/convertJobGraphToText", method = RequestMethod.GET)
 	public Map<String, Object> convertJobGrabToText(@RequestParam("graph") String graphAsString) {
-		ObjectMapper mapper = new ObjectMapper();
 		Map<String, Object> response = new HashMap<>();
+		if (graphAsString.trim().length() == 0) {
+			response.put("text", "");
+			return response;
+		}
+		ObjectMapper mapper = new ObjectMapper();
 		try {
 			Graph graph = mapper.readValue(graphAsString, Graph.class);
 			String dslText = graph.toDSLText();
@@ -98,7 +101,7 @@ public class ToolsController {
 		catch (JobSpecificationException jse) {
 			response.put("error", jse.toExceptionDescriptor());
 		}
-		catch (IOException e) {
+		catch (Throwable e) {
 			response.put("error", e.toString());
 		}
 		return response;

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/job/dsl/JobParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/job/dsl/JobParserTests.java
@@ -553,6 +553,18 @@ public class JobParserTests {
 	}
 
 	@Test
+	public void toXmlFlowSplit() {
+		js = parse("AA || <BB & CC> || DD");
+		assertEquals(loadXml("flowSplit"), js.toXML("test1", true));
+	}
+
+	@Test
+	public void toXmlLongFlowSplit() {
+		js = parse("AA || <BB || CC & DD> || EE");
+		assertEquals(loadXml("flowSplit2"), js.toXML("test1", true));
+	}
+
+	@Test
 	public void inlineJobDefinitionWithOptions() {
 		js = parse("jobModuleA jobNameA --foo=bar --boo=gar");
 		JobNode jn = js.getJobNode();

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/job/dsl/JobParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/job/dsl/JobParserTests.java
@@ -1,0 +1,730 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.job.dsl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Parse job specifications and verify either the correct abstract syntax tree is produced or the current exception comes out.
+ * The parser does not semantic validation, it is purely syntax checking.
+ *
+ * @author Andy Clement
+ */
+public class JobParserTests {
+
+	private JobSpecification js;
+
+	@Test
+	public void oneJobReference() {
+		js = parse("foojob");
+
+		// Basic data:
+		assertEquals("foojob", js.getJobDefinitionText());
+		assertEquals(0, js.getStartPos());
+		assertEquals(6, js.getEndPos());
+
+		// The job itself:
+		assertEquals("foojob", js.stringify());
+		JobNode jn = js.getJobNode();
+		assertFalse(jn.isSplit());
+		assertFalse(jn.isFlow());
+
+		JobReference jd = (JobReference) jn;
+		assertTrue(jd.isReference());
+		assertEquals("foojob", jd.getName());
+	}
+
+	@Test
+	public void simpleJobSequence() {
+		js = parse("jobA || jobB");
+		assertEquals("jobA || jobB", js.getJobDefinitionText());
+		assertEquals("jobA || jobB", js.stringify());
+		JobNode jn = js.getJobNode();
+		assertFalse(jn.isSplit());
+		assertTrue(jn.isFlow());
+		assertEquals(2, jn.getSeriesLength());
+		JobNode j1 = jn.getSeriesElement(0);
+		JobNode j2 = jn.getSeriesElement(1);
+		assertEquals("jobA[0>4]", j1.stringify(true));
+		assertEquals("jobB[8>12]", j2.stringify(true));
+	}
+
+	@Test
+	public void tripleJobSequence() {
+		js = parse("jobA || jobB || jobC");
+		assertEquals("jobA || jobB || jobC", js.getJobDefinitionText());
+		assertEquals("jobA || jobB || jobC", js.stringify());
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isFlow());
+		assertEquals(3, jn.getSeriesLength());
+		JobNode j1 = jn.getSeriesElement(0);
+		JobNode j2 = jn.getSeriesElement(1);
+		JobNode j3 = jn.getSeriesElement(2);
+		assertEquals("jobA[0>4]", j1.stringify(true));
+		assertEquals("jobB[8>12]", j2.stringify(true));
+		assertEquals("jobC[16>20]", j3.stringify(true));
+	}
+
+	@Test
+	public void parentheses() {
+		js = parse("jobA || (jobB || jobC)");
+		assertEquals("jobA || (jobB || jobC)", js.getJobDefinitionText());
+		assertEquals("jobA || jobB || jobC", js.stringify());
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isFlow());
+		assertEquals(3, jn.getSeriesLength());
+		JobNode j1 = jn.getSeriesElement(0);
+		JobNode j2 = jn.getSeriesElement(1);
+		JobNode j3 = jn.getSeriesElement(2);
+		assertEquals("jobA[0>4]", j1.stringify(true));
+		assertEquals("jobB[9>13]", j2.stringify(true));
+		assertEquals("jobC[17>21]", j3.stringify(true));
+	}
+
+	@Test
+	public void simpleParallelSequence() {
+		js = parse("<jobA & jobB>");
+		assertEquals("<jobA & jobB>", js.getJobDefinitionText());
+		assertEquals("<jobA & jobB>", js.stringify());
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isSplit());
+		assertEquals(2, jn.getSeriesLength());
+		JobNode j1 = jn.getSeriesElement(0);
+		JobNode j2 = jn.getSeriesElement(1);
+		assertEquals("jobA[1>5]", j1.stringify(true));
+		assertEquals("jobB[8>12]", j2.stringify(true));
+	}
+
+	@Test
+	public void tripleParallelSequence() {
+		js = parse("<jobA & jobB & jobC>");
+		assertEquals("<jobA & jobB & jobC>", js.getJobDefinitionText());
+		assertEquals("<jobA & jobB & jobC>", js.stringify());
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isSplit());
+		assertEquals(3, jn.getSeriesLength());
+		JobNode js1 = jn.getSeriesElement(0);
+		JobNode js2 = jn.getSeriesElement(1);
+		JobNode js3 = jn.getSeriesElement(2);
+		assertEquals("jobA[1>5]", js1.stringify(true));
+		assertEquals("jobB[8>12]", js2.stringify(true));
+		assertEquals("jobC[15>19]", js3.stringify(true));
+		assertTrue(js1 instanceof JobReference);
+		assertEquals("jobA", ((JobReference) js1).getName());
+		assertEquals("jobB", ((JobReference) js2).getName());
+		assertEquals("jobC", ((JobReference) js3).getName());
+	}
+
+	@Test
+	public void parentheses2() {
+		js = parse("<(jobA || jobB || jobC) & jobC>");
+		assertEquals("<(jobA || jobB || jobC) & jobC>", js.getJobDefinitionText());
+		assertEquals("<jobA || jobB || jobC & jobC>", js.stringify());
+	}
+
+	@Test
+	public void simpleParallelAndSequential() {
+		js = parse("<jobA || jobA2 & jobB || jobB2 & jobC || jobC2>");
+		assertEquals("<jobA || jobA2 & jobB || jobB2 & jobC || jobC2>", js.getJobDefinitionText());
+		assertEquals("<jobA || jobA2 & jobB || jobB2 & jobC || jobC2>", js.stringify());
+		JobNode jobNode = js.getJobNode();
+		assertTrue(jobNode instanceof Split);
+		Split pjs = (Split) jobNode;
+		assertEquals(3, pjs.getSeriesLength());
+		JobNode js1 = pjs.getSeriesElement(0);
+		JobNode js2 = pjs.getSeriesElement(1);
+		JobNode js3 = pjs.getSeriesElement(2);
+		assertEquals("jobA[1>5] || jobA2[9>14]", js1.stringify(true));
+		assertEquals("jobB[17>21] || jobB2[25>30]", js2.stringify(true));
+		assertEquals("jobC[33>37] || jobC2[41>46]", js3.stringify(true));
+		assertEquals(2, js1.getSeriesLength());
+		assertEquals(2, js2.getSeriesLength());
+		assertEquals(2, js3.getSeriesLength());
+	}
+
+	@Test
+	public void funnyJobNames() {
+		js = parse("a.b.c");
+		assertEquals("a.b.c", ((JobReference) js.getJobNode()).getName());
+		js = parse("a_b.c");
+		assertEquals("a_b.c", ((JobReference) js.getJobNode()).getName());
+		js = parse("a_b_c");
+		assertEquals("a_b_c", ((JobReference) js.getJobNode()).getName());
+	}
+
+	@Test
+	public void nestedSplit1() {
+		js = parse("<<jobA & jobB> & jobC>");
+		assertEquals("<<jobA & jobB> & jobC>", js.getJobDefinitionText());
+		assertEquals("<<jobA & jobB> & jobC>", js.stringify());
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isSplit());
+		Split pjs = (Split) jn;
+		assertEquals(2, pjs.getSeriesLength());
+		JobNode j1 = pjs.getSeriesElement(0);
+		assertTrue(j1.isSplit());
+		assertEquals(2, j1.getSeriesLength());
+		JobNode j2 = pjs.getSeriesElement(1);
+		assertFalse(j2.isSplit());
+	}
+
+	@Test
+	public void nestedSplit2() {
+		js = parse("<jobA & <jobB & jobC> & jobD>");
+		assertEquals("<jobA & <jobB & jobC> & jobD>", js.getJobDefinitionText());
+		assertEquals("<jobA & <jobB & jobC> & jobD>", js.stringify());
+		JobNode jn = js.getJobNode();
+
+		assertTrue(jn.isSplit());
+		assertEquals(3, jn.getSeriesLength());
+
+		JobNode j1 = jn.getSeriesElement(0);
+		assertTrue(j1.isJobDescriptor());
+		assertEquals("jobA", j1.stringify());
+
+		JobNode j2 = jn.getSeriesElement(1);
+		assertTrue(j2.isSplit());
+		assertEquals(2, j2.getSeriesLength());
+
+		JobNode j3 = jn.getSeriesElement(2);
+		assertTrue(j3.isJobDescriptor());
+		assertEquals("jobD", j3.stringify());
+	}
+
+	@Test
+	public void mixSplitSerial() {
+		js = parse("<jobA & jobB || jobC & jobD>");
+		assertEquals("<jobA & jobB || jobC & jobD>", js.getJobDefinitionText());
+		assertEquals("<jobA & jobB || jobC & jobD>", js.stringify());
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isSplit());
+		assertEquals(3, jn.getSeriesLength());
+		JobNode ja = jn.getSeriesElement(0);
+		assertTrue(ja.isJobDescriptor());
+		assertTrue(((JobDescriptor) ja).isReference());
+		assertEquals("jobA", ((JobReference) ja).getName());
+		JobNode jb = jn.getSeriesElement(1);
+		assertTrue(jb.isFlow());
+		assertEquals("jobB", jb.getSeriesElement(0).stringify());
+		assertEquals("jobC", jb.getSeriesElement(1).stringify());
+	}
+
+	@Test
+	public void splitJoin() {
+		js = parse("<jobA & jobB> || jobC");
+		assertEquals("<jobA & jobB> || jobC", js.getJobDefinitionText());
+		assertEquals("<jobA & jobB> || jobC", js.stringify());
+	}
+
+	@Test
+	public void inlineJobDefinition() {
+		js = parse("jobModuleA jobNameA");
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isJobDescriptor());
+		JobDefinition jd = (JobDefinition) jn;
+		assertFalse(jd.isReference());
+		assertTrue(jd.isDefinition());
+		assertEquals("jobModuleA", jd.getJobModuleName());
+		assertEquals("jobNameA", jd.getJobName());
+	}
+
+	@Test
+	public void singleTransition() {
+		js = parse("foo | completed = bar");
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isJobDescriptor());
+		JobDescriptor jd = (JobDescriptor) jn;
+		List<Transition> transitions = jd.getTransitions();
+		assertEquals(1, transitions.size());
+		assertEquals("completed", transitions.get(0).getStateName());
+		assertEquals("bar", transitions.get(0).getTargetJobName());
+	}
+
+	@Test
+	public void doubleTransition() {
+		js = parse("foo | completed = bar | wibble=wobble");
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isJobDescriptor());
+		JobDescriptor jd = (JobDescriptor) jn;
+		List<Transition> transitions = jd.getTransitions();
+		assertEquals(2, transitions.size());
+		assertEquals("completed", transitions.get(0).getStateName());
+		assertEquals("bar", transitions.get(0).getTargetJobName());
+		assertEquals("wibble", transitions.get(1).getStateName());
+		assertEquals("wobble", transitions.get(1).getTargetJobName());
+	}
+
+	@Test
+	public void inlineJobDefWithTransition() {
+		js = parse("foo bar --aaa=bbb | completed = bar | wibble=wobble");
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isJobDescriptor());
+		JobDescriptor jd = (JobDescriptor) jn;
+		assertTrue(jd.isDefinition());
+		JobDefinition jobdef = (JobDefinition) jd;
+		assertEquals("foo", jobdef.getJobModuleName());
+		assertEquals("bar", jobdef.getJobName());
+		ArgumentNode[] args = jobdef.getArguments();
+		assertEquals(1, args.length);
+		assertEquals("aaa", args[0].getName());
+		assertEquals("bbb", args[0].getValue());
+		List<Transition> transitions = jd.getTransitions();
+		assertEquals(2, transitions.size());
+		assertEquals("completed", transitions.get(0).getStateName());
+		assertEquals("bar", transitions.get(0).getTargetJobName());
+		assertEquals("wibble", transitions.get(1).getStateName());
+		assertEquals("wobble", transitions.get(1).getTargetJobName());
+	}
+
+	@Test
+	public void wildcardTransition() {
+		js = parse("foo | '*' = wibble");
+		assertEquals("foo | '*' = wibble", js.stringify());
+		js = parse("foo | \"*\" = wibble");
+		assertEquals("foo | \"*\" = wibble", js.stringify());
+	}
+
+	@Test
+	public void splitWithTransition() {
+		js = parse("<foo | completed=kill & bar>");
+		assertEquals("<foo | completed=kill & bar>", js.getJobDefinitionText());
+		assertEquals("<foo | completed = kill & bar>", js.stringify());
+	}
+
+	@Test
+	public void splitWithTransitionLiterals() {
+		js = parse("<foo | 'completed'=kill & bar>");
+		assertEquals("<foo | 'completed'=kill & bar>", js.getJobDefinitionText());
+		assertEquals("<foo | 'completed' = kill & bar>", js.stringify());
+	}
+
+	@Test
+	public void multiLine() {
+		js = parse("<foo\n"
+				+ "  | 'completed'=kill\n"
+				+ "  | '*' = custard\n"
+				+ "  & bar>");
+		assertEquals("<foo\n"
+				+ "  | 'completed'=kill\n"
+				+ "  | '*' = custard\n"
+				+ "  & bar>", js.getJobDefinitionText());
+		assertEquals("<foo | 'completed' = kill | '*' = custard & bar>", js.stringify());
+		//		assertEquals("<foo | 'completed' = kill | '*' = custard & bar>", js.format());
+	}
+
+	@Test
+	public void toGraphSequence() {
+		js = parse("foo || bar");
+		assertEquals(toExpectedGraph("n:0:foo,n:1:bar,l:0:1"), js.toGraph().toJSON());
+	}
+
+	@Test
+	public void toGraphInlineJob() {
+		js = parse("filejdbc foo --aaa=bbb || bar");
+		assertEquals(toExpectedGraph("n:0:foo:aaa=bbb,n:1:bar,l:0:1"), js.toGraph().toJSON());
+	}
+
+	@Test
+	public void toGraphSequence2() {
+		js = parse("foo || bar || boo");
+		assertEquals(toExpectedGraph("n:0:foo,n:1:bar,n:2:boo,l:0:1,l:1:2"), js.toGraph().toJSON());
+	}
+
+	@Test
+	public void toGraphSplit() {
+		js = parse("<foo & bar> || boo");
+		assertEquals(
+				toExpectedGraph("n:0:foo,n:1:bar,n:2:boo,l:0:2,l:1:2"),
+				js.toGraph().toJSON());
+	}
+
+	// TODO should & end the boo job name? Don't think it does right now
+	// 	js = parse("<foo | completed=boo& bar> || boo");
+
+	@Test
+	public void toGraphWithTransition() {
+		js = parse("<foo | completed=goo & bar> || boo || goo");
+		assertEquals(
+				toExpectedGraph("n:0:foo,n:1:bar,n:2:boo,n:3:goo,l:0:2,l:1:2,l:2:3,l:0:3:transitionName=completed"),
+				js.toGraph().toJSON());
+	}
+
+	@Test
+	public void toGraphWithTransition2() {
+		// The target transition node is not elsewhere on the list
+		js = parse("<foo | completed=hoo & bar> || boo || goo");
+		assertEquals(
+				toExpectedGraph(
+						"n:0:foo,n:1:bar,n:2:boo,n:3:goo,n:4:hoo,l:0:2,l:1:2,l:2:3,l:0:4:transitionName=completed"),
+				js.toGraph().toJSON());
+	}
+
+	@Test
+	public void toXML() {
+		js = parse("foo");
+		assertEquals(loadXml("simpleJob"), js.toXML("test1", true));
+	}
+
+	@Ignore
+	@Test
+	public void toXMLSqoopExample() {
+		js = parse("<(sqoop-6e44 | 'FAILED' = kill1\n" +
+				"  || sqoop-e07a | 'FAILED' = kill1) & \n" +
+				" (sqoop-035f | 'FAILED' = kill2\n" +
+				"  || sqoop-9408 | 'FAILED' = kill2\n" +
+				"  || sqoop-a6e0 | 'FAILED' = kill2\n" +
+				"  || sqoop-e522 | 'FAILED' = kill2\n" +
+				"  || shell-b521 | 'FAILED' = kill2) & \n" +
+				" (sqoop-6420 | 'FAILED' = kill3)>");
+		assertEquals(loadXml("sqoopJob"), js.toXML("test1", true));
+	}
+
+	// TODO [asc] errors in XML file simpleFlow.xml - what are we generating wrong?
+	@Test
+	public void toXMLFlow() {
+		js = parse("foo || bar");
+		assertEquals(loadXml("simpleFlow"), js.toXML("test1", true));
+	}
+
+	// TODO [asc] errors in XML file simpleSplit.xml - what are we generating wrong?
+	@Test
+	public void toXMLSplit() {
+		js = parse("<foo & bar>");
+		assertEquals(loadXml("simpleSplit"), js.toXML("test1", true));
+	}
+
+	@Test
+	public void inlineJobDefinitionWithOptions() {
+		js = parse("jobModuleA jobNameA --foo=bar --boo=gar");
+		JobNode jn = js.getJobNode();
+		assertTrue(jn.isJobDescriptor());
+		JobDefinition jd = (JobDefinition) jn;
+		assertFalse(jd.isReference());
+		assertTrue(jd.isDefinition());
+		assertEquals("jobModuleA", jd.getJobModuleName());
+		assertEquals("jobNameA", jd.getJobName());
+		ArgumentNode[] args = jd.getArguments();
+		assertEquals(2, args.length);
+		assertEquals("--foo=bar", args[0].stringify());
+		assertEquals("--boo=gar", args[1].stringify());
+	}
+
+	@Test
+	public void extraneousDataError() {
+		String jobSpecification = "<a & b> rubbish";
+		checkForParseError(jobSpecification, JobDSLMessage.UNEXPECTED_DATA_AFTER_JOBSPEC, 8, "rubbish");
+	}
+
+	@Test
+	public void incorrectTransition() {
+		checkForParseError("foo | || = bar", JobDSLMessage.EXPECTED_TRANSITION_NAME, 6, "||");
+	}
+
+	@Test
+	public void spacesInTransitionNameRequireQuotes() {
+		checkForParseError("foo | abc def = bar", JobDSLMessage.EXPECTED_EQUALS_AFTER_TRANSITION_NAME, 10, "def");
+		parse("foo | 'abc def' = bar");
+	}
+
+	@Test
+	public void inlineJobDefWithTwoArguments() {
+		js = parse("foo foo --name=value --x=y");
+		List<JobDefinition> jds = js.getJobDefinitions();
+		assertEquals(1, jds.size());
+		assertEquals("foo foo --name=value --x=y", jds.get(0).stringify(false));
+	}
+
+	@Test
+	public void inlineJobDefDottedArgName() {
+		js = parse("foo foo --nam.eee=value --x=y");
+		List<JobDefinition> jds = js.getJobDefinitions();
+		assertEquals(1, jds.size());
+		assertEquals("foo foo --nam.eee=value --x=y", jds.get(0).stringify(false));
+	}
+
+	@Test
+	public void inlineJobDefDottedArgValue() {
+		js = parse("foo foo --name=abc.def --x=y");
+		List<JobDefinition> jds = js.getJobDefinitions();
+		assertEquals(1, jds.size());
+		assertEquals("foo foo --name=abc.def --x=y", jds.get(0).stringify(false));
+	}
+
+	@Test
+	public void inlineJobDefWithArgumentsAndTransitions() {
+		js = parse("foo foo --name=value --x=y | aaa=bbb | ccc=ddd | eee=fff");
+		List<JobDefinition> jds = js.getJobDefinitions();
+		assertEquals(1, jds.size());
+		assertEquals("foo foo --name=value --x=y | aaa = bbb | ccc = ddd | eee = fff", jds.get(0).stringify(false));
+
+		js = parse("foo foo --name=value --x=y | aaa=bbb | ccc=ddd | eee=fff || bar bart || goo good");
+		jds = js.getJobDefinitions();
+		assertEquals(3, jds.size());
+		assertEquals("bar bart", jds.get(1).stringify(false));
+	}
+
+	@Test
+	public void inlineJobDefinitionNeedsName() {
+		checkForParseError("foo || transform --expression=new StringBuilder(payload).reverse() || bar",
+				JobDSLMessage.MISSING_JOB_NAME_IN_INLINEJOBDEF, 17);
+	}
+
+	@Test
+	public void argumentsNeedQuotesAroundArgValueWithSpaces() {
+		checkForParseError("foo || transform bar --expression=new StringBuilder(payload).reverse() || bar",
+				JobDSLMessage.UNEXPECTED_DATA_AFTER_JOBSPEC, 38);
+		// TODO [asc] How/when are the quotes removed for these argument values?
+		js = parse("foo || transform bar --expression='new StringBuilder(payload).reverse()' || bar");
+	}
+
+
+	@Test
+	public void moduleArguments_xd1613() {
+		// notice no space between the ' and final >
+		js = parse(
+				"transform X --expression='payload.toUpperCase()' || filter Y --expression='payload.length() > 4'");
+		assertEquals("payload.toUpperCase()", js.getJobDefinition("X").getArguments()[0].getValue());
+		assertEquals("payload.length() > 4", js.getJobDefinition("Y").getArguments()[0].getValue());
+
+		js = parse(
+				"time || transform X --expression='T(org.joda.time.format.DateTimeFormat).forPattern(\"yyyy-MM-dd HH:mm:ss\").parseDateTime(payload)'");
+		assertEquals(
+				"T(org.joda.time.format.DateTimeFormat).forPattern(\"yyyy-MM-dd HH:mm:ss\").parseDateTime(payload)",
+				js.getJobDefinition("X").getArguments()[0].getValue());
+
+		// allow for pipe/semicolon if quoted
+		js = parse("http || transform X --outputType='text/plain|charset=UTF-8' || log");
+		assertEquals("text/plain|charset=UTF-8", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		js = parse("http || transform X --outputType='text/plain;charset=UTF-8' || log");
+		assertEquals("text/plain;charset=UTF-8", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		// Want to treat all of 'hi'+payload as the argument value
+		js = parse("http || transform X --expression='hi'+payload || log");
+		assertEquals("'hi'+payload", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		// Want to treat all of payload+'hi' as the argument value
+		js = parse("http || transform X --expression=payload+'hi' || log");
+		assertEquals("payload+'hi'", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		// Alternatively, can quote all around it to achieve the same thing
+		js = parse("http || transform X --expression='payload+''hi''' || log");
+		assertEquals("payload+'hi'", js.getJobDefinition("X").getArguments()[0].getValue());
+		js = parse("http || transform X --expression='''hi''+payload' || log");
+		assertEquals("'hi'+payload", js.getJobDefinition("X").getArguments()[0].getValue());
+
+
+		js = parse("http || transform X --expression=\"payload+'hi'\" || log");
+		assertEquals("payload+'hi'", js.getJobDefinition("X").getArguments()[0].getValue());
+		js = parse("http || transform X --expression=\"'hi'+payload\" || log");
+		assertEquals("'hi'+payload", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		js = parse("http || transform X --expression=payload+'hi'--param2='foobar' || log");
+		assertEquals("payload+'hi'--param2='foobar'", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		js = parse("http || transform X --expression='hi'+payload--param2='foobar' || log");
+		assertEquals("'hi'+payload--param2='foobar'", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		// This also works, which is cool
+		js = parse("http || transform X --expression='hi'+'world' || log");
+		assertEquals("'hi'+'world'", js.getJobDefinition("X").getArguments()[0].getValue());
+		js = parse("http || transform X --expression=\"'hi'+'world'\" || log");
+		assertEquals("'hi'+'world'", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		js = parse("http || filter X --expression=payload.matches('hello world') || log");
+		assertEquals("payload.matches('hello world')", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		js = parse("http || transform X --expression='''hi''' || log");
+		assertEquals("'hi'", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		js = parse("http || transform X --expression=\"''''hi''''\" || log");
+		assertEquals("''''hi''''", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		js = parse("http asdf --port=9014 || filter X --expression=\"payload == 'foo'\" || log");
+		assertEquals("payload == 'foo'", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		js = parse("http asdf --port=9014 || filter X --expression='new Foo()' || log");
+		assertEquals("new Foo()", js.getJobDefinition("X").getArguments()[0].getValue());
+
+		js = parse("http || transform XX --expression='payload.replace(\"abc\", \"\")' || log");
+		assertEquals("payload.replace(\"abc\", \"\")", js.getJobDefinition("XX").getArguments()[0].getValue());
+
+		js = parse("http || transform XX --expression='payload.replace(\"abc\", '''')' || log");
+		assertEquals("payload.replace(\"abc\", '')", js.getJobDefinition("XX").getArguments()[0].getValue());
+	}
+
+	// Parameters must be constructed via adjacent tokens
+	@Test
+	public void needAdjacentTokensForParameters() {
+		checkForParseError("foo a -- name=value", JobDSLMessage.NO_WHITESPACE_BEFORE_ARG_NAME, 9);
+		checkForParseError("foo a --name =value", JobDSLMessage.NO_WHITESPACE_BEFORE_ARG_EQUALS, 13);
+		checkForParseError("foo a --name= value", JobDSLMessage.NO_WHITESPACE_BEFORE_ARG_VALUE, 14);
+	}
+
+	// --
+
+	/**
+	 * Create a parser for test use.
+	 */
+	private JobParser getParser() {
+		return new JobParser();
+	}
+
+	JobSpecification parse(String jobSpecification) {
+		JobSpecification jobSpec = getParser().parse(jobSpecification);
+		return jobSpec;
+	}
+
+	/**
+	 * Convert the supplied internal DSL (for test usage only) into a graph against which we can
+	 * compare the actual output from the graph creation code.
+	 * @param graphTestDSL the shorthand DSL for a graph description
+	 * @return a JSON string representing the complete graph
+	 */
+	public String toExpectedGraph(String graphTestDSL) {
+		StringBuilder s = new StringBuilder();
+		s.append("{");
+		s.append("\"nodes\":[");
+		StringTokenizer st = new StringTokenizer(graphTestDSL, ",");
+		boolean onLinksNow = false;
+		int counter = 0;
+		while (st.hasMoreElements()) {
+			String element = st.nextToken();
+			StringTokenizer elementTokenizer = new StringTokenizer(element, ":");
+			String type = elementTokenizer.nextToken();
+			if (type.equals("n")) {
+				String nodeId = elementTokenizer.nextToken();
+				String nodeName = elementTokenizer.nextToken();
+				if (counter > 0) {
+					s.append(",");
+				}
+				s.append("{\"id\":\"" + nodeId + "\",\"name\":\"" + nodeName + "\"");
+				if (elementTokenizer.hasMoreTokens()) {
+					String properties = elementTokenizer.nextToken();
+					StringTokenizer propertyTokenizer = new StringTokenizer(properties, ";");
+					s.append(",\"properties\":{");
+					int propertyCount = 0;
+					while (propertyTokenizer.hasMoreTokens()) {
+						if (propertyCount > 0) {
+							s.append(",");
+						}
+						String property = propertyTokenizer.nextToken();
+						int equals = property.indexOf("=");
+						String key = property.substring(0, equals);
+						String value = property.substring(equals + 1);
+						s.append("\"" + key + "\":\"" + value + "\"");
+					}
+					s.append("}");
+				}
+				s.append("}");
+			}
+			else {
+				if (!onLinksNow) {
+					s.append("],\"links\":[");
+					onLinksNow = true;
+					counter = 0;
+				}
+				if (counter > 0) {
+					s.append(",");
+				}
+				String sourceId = elementTokenizer.nextToken();
+				String targetId = elementTokenizer.nextToken();
+				s.append("{\"from\":" + sourceId + ",\"to\":" + targetId);
+				if (elementTokenizer.hasMoreTokens()) {
+					String properties = elementTokenizer.nextToken();
+					StringTokenizer propertyTokenizer = new StringTokenizer(properties, ";");
+					s.append(",\"properties\":{");
+					int propertyCount = 0;
+					while (propertyTokenizer.hasMoreTokens()) {
+						if (propertyCount > 0) {
+							s.append(",");
+						}
+						String property = propertyTokenizer.nextToken();
+						int equals = property.indexOf("=");
+						String key = property.substring(0, equals);
+						String value = property.substring(equals + 1);
+						s.append("\"" + key + "\":\"" + value + "\"");
+					}
+					s.append("}");
+				}
+				s.append("}");
+			}
+			counter++;
+		}
+		s.append("]}");
+		return s.toString();
+	}
+
+	/**
+	 * Load a resource XML file that represents the expected test output.
+	 */
+	private String loadXml(String xmlfile) {
+		try {
+			String resourceName = this.getClass().getPackage().getName().toString().replace('.', File.separatorChar)
+					+ File.separator
+					+ xmlfile + ".xml";
+			InputStream istream = getClass().getClassLoader().getResourceAsStream(resourceName);
+			BufferedInputStream bis = new BufferedInputStream(istream);
+			byte[] theData = new byte[10000000];
+			int dataReadSoFar = 0;
+			byte[] buffer = new byte[1024];
+			int read = 0;
+			while ((read = bis.read(buffer)) != -1) {
+				System.arraycopy(buffer, 0, theData, dataReadSoFar, read);
+				dataReadSoFar += read;
+			}
+			bis.close();
+			byte[] returnData = new byte[dataReadSoFar];
+			System.arraycopy(theData, 0, returnData, 0, dataReadSoFar);
+			return new String(returnData);
+		}
+		catch (IOException ioe) {
+			throw new IllegalStateException(ioe);
+		}
+	}
+
+	private void checkForParseError(String jobSpecification, JobDSLMessage msg, int pos, Object... inserts) {
+		try {
+			JobSpecification js = parse(jobSpecification);
+			fail("expected to fail but parsed " + js.stringify());
+		}
+		catch (JobSpecificationException e) {
+			System.out.println(e);
+			assertEquals(msg, e.getMessageCode());
+			assertEquals(pos, e.getPosition());
+			if (inserts != null) {
+				for (int i = 0; i < inserts.length; i++) {
+					assertEquals(inserts[i], e.getInserts()[i]);
+				}
+			}
+		}
+	}
+
+}

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
@@ -11,15 +11,14 @@
       <flow>
         <step id="BB">
           <tasklet ref="jobRunner-BB"/>
-          <next on="*" to="DD"/>
         </step>
       </flow>
       <flow>
         <step id="CC">
           <tasklet ref="jobRunner-CC"/>
-          <next on="*" to="DD"/>
         </step>
       </flow>
+      <next on="*" to="DD"/>
     </split>
     <step id="DD">
       <tasklet ref="jobRunner-DD"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
@@ -4,8 +4,7 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="AA">
       <tasklet ref="jobRunner-AA"/>
-      <next on="*" to="BB"/>
-      <next on="*" to="CC"/>
+      <next on="*" to="split1"/>
     </step>
     <split id="split1" task-executor="taskExecutor">
       <flow>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
@@ -8,13 +8,13 @@
       <next on="*" to="CC"/>
     </step>
     <split id="split1" task-executor="taskExecutor">
-      <flow id="BB-1">
+      <flow>
         <step id="BB">
           <tasklet ref="jobRunner-BB"/>
           <next on="*" to="DD"/>
         </step>
       </flow>
-      <flow id="CC-1">
+      <flow>
         <step id="CC">
           <tasklet ref="jobRunner-CC"/>
           <next on="*" to="DD"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+  <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
+  <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
+    <step id="AA">
+      <tasklet ref="jobRunner-AA"/>
+      <next on="*" to="BB"/>
+      <next on="*" to="CC"/>
+    </step>
+    <split id="split1" task-executor="taskExecutor">
+      <flow id="BB-1">
+        <step id="BB">
+          <tasklet ref="jobRunner-BB"/>
+          <next on="*" to="DD"/>
+        </step>
+      </flow>
+      <flow id="CC-1">
+        <step id="CC">
+          <tasklet ref="jobRunner-CC"/>
+          <next on="*" to="DD"/>
+        </step>
+      </flow>
+    </split>
+    <step id="DD">
+      <tasklet ref="jobRunner-DD"/>
+    </step>
+  </batch:job>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-AA" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="AA"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-BB" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="BB"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-CC" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="CC"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-DD" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="DD"/>
+  </bean>
+</beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
@@ -4,8 +4,7 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="AA">
       <tasklet ref="jobRunner-AA"/>
-      <next on="*" to="BB"/>
-      <next on="*" to="DD"/>
+      <next on="*" to="split1"/>
     </step>
     <split id="split1" task-executor="taskExecutor">
       <flow>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
@@ -15,15 +15,14 @@
         </step>
         <step id="CC">
           <tasklet ref="jobRunner-CC"/>
-          <next on="*" to="EE"/>
         </step>
       </flow>
       <flow>
         <step id="DD">
           <tasklet ref="jobRunner-DD"/>
-          <next on="*" to="EE"/>
         </step>
       </flow>
+      <next on="*" to="EE"/>
     </split>
     <step id="EE">
       <tasklet ref="jobRunner-EE"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
@@ -18,7 +18,7 @@
           <next on="*" to="EE"/>
         </step>
       </flow>
-      <flow id="DD-1">
+      <flow>
         <step id="DD">
           <tasklet ref="jobRunner-DD"/>
           <next on="*" to="EE"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+  <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
+  <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
+    <step id="AA">
+      <tasklet ref="jobRunner-AA"/>
+      <next on="*" to="BB"/>
+      <next on="*" to="DD"/>
+    </step>
+    <split id="split1" task-executor="taskExecutor">
+      <flow>
+        <step id="BB">
+          <tasklet ref="jobRunner-BB"/>
+          <next on="*" to="CC"/>
+        </step>
+        <step id="CC">
+          <tasklet ref="jobRunner-CC"/>
+          <next on="*" to="EE"/>
+        </step>
+      </flow>
+      <flow id="DD-1">
+        <step id="DD">
+          <tasklet ref="jobRunner-DD"/>
+          <next on="*" to="EE"/>
+        </step>
+      </flow>
+    </split>
+    <step id="EE">
+      <tasklet ref="jobRunner-EE"/>
+    </step>
+  </batch:job>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-AA" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="AA"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-BB" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="BB"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-CC" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="CC"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-DD" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="DD"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-EE" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="EE"/>
+  </bean>
+</beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlow.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlow.xml
@@ -10,6 +10,16 @@
       <tasklet ref="jobRunner-bar"/>
     </step>
   </batch:job>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step"/>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step"/>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="foo"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="bar"/>
+  </bean>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlow.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlow.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2000/xsi/" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
+  <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
+    <flow>
+      <step id="foo">
+        <tasklet ref="jobRunner-foo"/>
+        <next on="*" to="bar"/>
+      </step>
+      <step id="bar">
+        <tasklet ref="jobRunner-bar"/>
+      </step>
+    </flow>
+  </batch:job>
+  <bean class="JobRunningTasklet" id="jobRunner-foo" scope="step"/>
+  <bean class="JobRunningTasklet" id="jobRunner-bar" scope="step"/>
+</beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlow.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlow.xml
@@ -1,17 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2000/xsi/" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
-    <flow>
-      <step id="foo">
-        <tasklet ref="jobRunner-foo"/>
-        <next on="*" to="bar"/>
-      </step>
-      <step id="bar">
-        <tasklet ref="jobRunner-bar"/>
-      </step>
-    </flow>
+    <step id="foo">
+      <tasklet ref="jobRunner-foo"/>
+      <next on="*" to="bar"/>
+    </step>
+    <step id="bar">
+      <tasklet ref="jobRunner-bar"/>
+    </step>
   </batch:job>
-  <bean class="JobRunningTasklet" id="jobRunner-foo" scope="step"/>
-  <bean class="JobRunningTasklet" id="jobRunner-bar" scope="step"/>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step"/>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step"/>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleJob.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleJob.xml
@@ -6,5 +6,10 @@
       <tasklet ref="jobRunner-foo"/>
     </step>
   </batch:job>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step"/>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="foo"/>
+  </bean>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleJob.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleJob.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2000/xsi/" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
+  <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
+    <step id="foo">
+      <tasklet ref="jobRunner-foo"/>
+    </step>
+  </batch:job>
+  <bean class="JobRunningTasklet" id="jobRunner-foo" scope="step"/>
+</beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleJob.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleJob.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2000/xsi/" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
     </step>
   </batch:job>
-  <bean class="JobRunningTasklet" id="jobRunner-foo" scope="step"/>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step"/>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
@@ -11,6 +11,16 @@
       </step>
     </split>
   </batch:job>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step"/>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step"/>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="foo"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="bar"/>
+  </bean>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2000/xsi/" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <split id="split1" task-executor="taskExecutor">
@@ -11,6 +11,6 @@
       </step>
     </split>
   </batch:job>
-  <bean class="JobRunningTasklet" id="jobRunner-foo" scope="step"/>
-  <bean class="JobRunningTasklet" id="jobRunner-bar" scope="step"/>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step"/>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step"/>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2000/xsi/" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
+  <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
+    <split id="split1" task-executor="taskExecutor">
+      <step id="foo">
+        <tasklet ref="jobRunner-foo"/>
+      </step>
+      <step id="bar">
+        <tasklet ref="jobRunner-bar"/>
+      </step>
+    </split>
+  </batch:job>
+  <bean class="JobRunningTasklet" id="jobRunner-foo" scope="step"/>
+  <bean class="JobRunningTasklet" id="jobRunner-bar" scope="step"/>
+</beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
@@ -3,12 +3,12 @@
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <split id="split1" task-executor="taskExecutor">
-      <flow id="foo-1">
+      <flow>
         <step id="foo">
           <tasklet ref="jobRunner-foo"/>
         </step>
       </flow>
-      <flow id="bar-1">
+      <flow>
         <step id="bar">
           <tasklet ref="jobRunner-bar"/>
         </step>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplit.xml
@@ -3,12 +3,16 @@
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <split id="split1" task-executor="taskExecutor">
-      <step id="foo">
-        <tasklet ref="jobRunner-foo"/>
-      </step>
-      <step id="bar">
-        <tasklet ref="jobRunner-bar"/>
-      </step>
+      <flow id="foo-1">
+        <step id="foo">
+          <tasklet ref="jobRunner-foo"/>
+        </step>
+      </flow>
+      <flow id="bar-1">
+        <step id="bar">
+          <tasklet ref="jobRunner-bar"/>
+        </step>
+      </flow>
     </split>
   </batch:job>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step">

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/sqoopJob.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/sqoopJob.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+  <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
+  <batch:job id="streamName" xmlns="http://www.springframework.org/schema/batch">
+    <split id="split1" task-executor="taskExecutor">
+      <flow>
+        <step id="sqoop-6e44">
+          <tasklet ref="jobRunner-sqoop-6e44"/>
+          <next on="FAILED" to="kill1"/>
+          <next on="*" to="sqoop-e07a"/>
+        </step>
+        <step id="sqoop-e07a">
+          <tasklet ref="jobRunner-sqoop-e07a"/>
+          <next on="FAILED" to="kill1"/>
+        </step>
+        <step id="kill1"/>
+      </flow>
+      <flow>
+        <step id="sqoop-035f">
+          <tasklet ref="jobRunner-sqoop-035f"/>
+          <next on="FAILED" to="kill2"/>
+          <next on="*" to="sqoop-9408"/>
+        </step>
+        <step id="sqoop-9408">
+          <tasklet ref="jobRunner-sqoop-9408"/>
+          <next on="FAILED" to="kill2"/>
+          <next on="*" to="sqoop-a6e0"/>
+        </step>
+        <step id="sqoop-a6e0">
+          <tasklet ref="jobRunner-sqoop-a6e0"/>
+          <next on="FAILED" to="kill2"/>
+          <next on="*" to="sqoop-e522"/>
+        </step>
+        <step id="sqoop-e522">
+          <tasklet ref="jobRunner-sqoop-e522"/>
+          <next on="FAILED" to="kill2"/>
+          <next on="*" to="shell-b521"/>
+        </step>
+        <step id="shell-b521">
+          <tasklet ref="jobRunner-shell-b521"/>
+          <next on="FAILED" to="kill2"/>
+        </step>
+        <step id="kill2"/>
+      </flow>
+      <flow>
+        <step id="sqoop-6420">
+          <tasklet ref="jobRunner-sqoop-6420"/>
+          <next on="FAILED" to="kill3"/>
+        </step>
+        <step id="kill3"/>
+      </flow>
+    </split>
+  </batch:job>
+
+  <bean class="JobRunningTasklet" id="jobRunner-sqoop-6e44" scope="step"/>
+  <bean class="JobRunningTasklet" id="jobRunner-sqoop-e07a" scope="step"/>
+  <bean class="JobRunningTasklet" id="jobRunner-sqoop-035f" scope="step"/>
+  <bean class="JobRunningTasklet" id="jobRunner-sqoop-9408" scope="step"/>
+  <bean class="JobRunningTasklet" id="jobRunner-sqoop-a6e0" scope="step"/>
+  <bean class="JobRunningTasklet" id="jobRunner-sqoop-e522" scope="step"/>
+  <bean class="JobRunningTasklet" id="jobRunner-shell-b521" scope="step"/>
+  <bean class="JobRunningTasklet" id="jobRunner-sqoop-6420" scope="step"/>
+</beans>


### PR DESCRIPTION
Related to https://jira.spring.io/browse/XD-3603

I now have code blindness from staring at these changes and it is time for some feedback from you guys. This commit adds a package alongside `...dirt.stream.dsl` called `...dirt.job.dsl` and includes a `JobParser` for the Job DSL we have been talking about.
Notes:
-  it is not an extension of the stream parser, it is a different parser. Different tokenization, differing syntax.
-  unlike the stream parser which mixed up syntactic with semantic checking, this one is pure syntax checking. There is a basic visitor pattern that could be exploited for the parsed AST where semantic validation could easily be done (i.e. is the job definition supplying the right arguments? Are the job references all references to real jobs?).
- I have (in a basic way) wired it into the ToolsController for use by Flo (similarly to how the stream parser was wired in).
- The stream parser used to return a structure back to the client which then got converted to a graph for Flo display. This parser can build the graph directly for return to the client. Are we ok with this? (See the Graph return value on the ToolsController request mapping)
- This AST that is returned has a `toXML(batchJobId)` endpoint that produces some basic XML based on a quick exchange with Michael, this will likely need tweaking but should prove a useful start.

More work to be done (in October...):
- validation
- error handling (passing errors to the client).

Syntax:

Jobs are either defined inline or reference names are used (reference names are to existing job definitions).

- single job:  `foo`
- single inline job definition, called 'foo': `filejdbc foo --aaa=bbb --ccc=ddd`
- two jobs in a sequence: `aaa || bbb`
- two jobs in parallel: `<aaa & bbb>`
- a job that transitions to a different state when it exits in a certain 'state'. Here 'aaa' will jump to 'ccc' if it exits in COMPLETED state (skipping 'ddd'):
  `<aaa | COMPLETED=ccc & bbb> || ddd || ccc`
- transition states can be quoted if include spaces or other funky chars
- multiple transition states can be specified by including multiple `| state = targetJobReference`

Any feedback welcome.