### PR TITLE
XD-3556: Creation of a JobLaunchingTasklet

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.batch.tasklet;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameter;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.UnexpectedJobExecutionException;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.xd.dirt.integration.bus.MessageBus;
+import org.springframework.xd.dirt.stream.JobDefinition;
+import org.springframework.xd.dirt.stream.JobDefinitionRepository;
+import org.springframework.xd.dirt.stream.NoSuchDefinitionException;
+import org.springframework.xd.dirt.stream.NotDeployedException;
+import org.springframework.xd.store.DomainRepository;
+
+/**
+ * A {@link Tasklet} implementation that uses the Spring XD {@link MessageBus} to launch
+ * jobs deployed within the same Spring XD cluster.  This tasklet also receives the
+ * results of the job from the same message bus.
+ *
+ * The result of the step executing this tasklet should match that of the job that was
+ * executed by this job.  So if the tasklet executes the job foo and foo returns an
+ * {@link org.springframework.batch.core.ExitStatus} of "BAR", the ExitStatus of this step
+ * will also be "BAR".
+ *
+ * @author Michael Minella
+ * @since 1.3.0
+ */
+public class JobLaunchingTasklet implements Tasklet, MessageHandler {
+
+	public static final String XD_ORCHESTRATION_ID = "xd_orchestration_id";
+
+	//TODO: Make this configurable
+	private long timeout = -1;
+
+	//TODO: Make this configurable
+	private long pollInterval = 1000;
+
+	private String jobName;
+
+	private MessageBus messageBus;
+
+	private volatile JobExecution results = null;
+
+	private JobDefinitionRepository definitionRepository;
+
+	private DomainRepository<JobDefinition, String> instanceRepository;
+
+	private String orchestrationId;
+
+	private JobParametersExtractor extractor = new JobParametersExtractor();
+
+	private MessageChannel launchingChannel;
+
+	private PublishSubscribeChannel listeningChannel;
+
+	@Autowired
+	public JobLaunchingTasklet(MessageBus messageBus,
+			JobDefinitionRepository jobDefinitionRepository,
+			DomainRepository instanceRepository, String jobName) {
+		this(messageBus, jobDefinitionRepository, instanceRepository, jobName,
+				new DirectChannel(),
+				new PublishSubscribeChannel((new SimpleAsyncTaskExecutor())));
+	}
+
+	/**
+	 * Provided for testing to be able to inject the channels for mocking.
+	 *
+	 * @param messageBus Message bus reference to launch a job and receive it's results
+	 * @param jobDefinitionRepository Repository used to look up the child job definition
+	 * @param instanceRepository Repository used to look up that the child job is deployed
+	 * @param jobName The name of the child job definition
+	 * @param launchingChannel The channel used to send the launch request
+	 * @param listeningChannel The channel used to listen for the job results
+	 */
+	protected JobLaunchingTasklet(MessageBus messageBus,
+			JobDefinitionRepository jobDefinitionRepository,
+			DomainRepository instanceRepository, String jobName,
+			MessageChannel launchingChannel, PublishSubscribeChannel listeningChannel) {
+		Assert.notNull(messageBus, "A message bus is required.");
+		Assert.notNull(jobDefinitionRepository, "A JobDefinitionRepository is required");
+		Assert.notNull(instanceRepository, "A DomainRepository is required");
+		Assert.notNull(jobName, "A job name is required");
+
+		this.jobName = jobName;
+		this.messageBus = messageBus;
+		this.definitionRepository = jobDefinitionRepository;
+		this.instanceRepository = instanceRepository;
+		this.launchingChannel = launchingChannel;
+		this.listeningChannel = listeningChannel;
+	}
+
+	/**
+	 * Uses the {@link MessageBus} to execute a job deployed in a Spring XD cluster.
+	 *
+	 * @param contribution The contribution to the step's metrics.  Not used in this case
+	 * @param chunkContext Used to get a handle on the JobExecution and JobInstance
+	 * @return RepeatStatus.FINISHED
+	 * @throws Exception
+	 */
+	@Override
+	public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+
+		setOrchestrationId(chunkContext);
+
+		configureChannels();
+
+		validateJobDeployment();
+
+		JobParameters originalJobParameters = chunkContext.getStepContext().getStepExecution().getJobParameters();
+
+		JobParameters jobParameters = new JobParametersBuilder(originalJobParameters)
+				.addParameter(XD_ORCHESTRATION_ID, new JobParameter(this.orchestrationId))
+				.toJobParameters();
+
+		String jobParametersString = this.extractor.extract(jobParameters);
+
+		this.launchingChannel.send(MessageBuilder.withPayload(jobParametersString).build());
+
+		Date startTime = new Date();
+
+		while(results == null && !timeout(startTime)) {
+			Thread.sleep(this.pollInterval);
+		}
+
+		if(results != null) {
+			processResult(contribution);
+		}
+		else {
+			throw new UnexpectedJobExecutionException("The job timed out while waiting for a result");
+		}
+
+		return RepeatStatus.FINISHED;
+	}
+
+	private void processResult(StepContribution contribution) {
+		contribution.setExitStatus(results.getExitStatus());
+
+		if(results.getStatus().isUnsuccessful()) {
+			List<Throwable> allFailureExceptions = results.getAllFailureExceptions();
+
+			Throwable failureException = null;
+
+			if(allFailureExceptions.size() > 0) {
+				failureException = allFailureExceptions.get(0);
+			}
+
+			throw new UnexpectedJobExecutionException(String.format("Step failure: %s failed.", jobName), failureException);
+		}
+	}
+
+	private void configureChannels() {
+		messageBus.bindPubSubConsumer(getEventListenerChannelName(jobName), this.listeningChannel, null);
+		this.listeningChannel.subscribe(this);
+
+		messageBus.bindProducer("job:" + jobName, this.launchingChannel, null);
+	}
+
+	private void validateJobDeployment() {
+		// Double check so that user gets an informative error message
+		JobDefinition job = definitionRepository.findOne(jobName);
+		if (job == null) {
+			throw new NoSuchDefinitionException(jobName,
+					String.format("There is no %s definition named '%%s'", "job"));
+		}
+		if (instanceRepository.findOne(jobName) == null) {
+			throw new NotDeployedException(jobName, String.format("The %s named '%%s' is not currently deployed",
+					"job"));
+		}
+	}
+
+	private void setOrchestrationId(ChunkContext chunkContext) {
+		this.orchestrationId = String.valueOf(chunkContext.getStepContext().getStepExecution().getJobExecution().getJobInstance().getInstanceId());
+
+		ExecutionContext stepExecutionContext = chunkContext.getStepContext().getStepExecution().getExecutionContext();
+
+		if(stepExecutionContext.containsKey(XD_ORCHESTRATION_ID)) {
+			this.orchestrationId = (String) stepExecutionContext.get(XD_ORCHESTRATION_ID);
+		}
+		else {
+			stepExecutionContext.put(XD_ORCHESTRATION_ID, this.orchestrationId);
+		}
+	}
+
+	private String getEventListenerChannelName(String jobName) {
+		return String.format("tap:job:%s.job", jobName);
+	}
+
+	private boolean timeout(Date startTime) {
+		return this.timeout >= 0 &&
+				new Date().getTime() - startTime.getTime() > this.timeout;
+	}
+
+	/**
+	 * Called as job events are received from the job launched in the
+	 * {@link #execute(StepContribution, ChunkContext)} method.
+	 *
+	 * @param message The event
+	 * @throws MessagingException
+	 */
+	@Override
+	public void handleMessage(Message<?> message) throws MessagingException {
+		JobExecution jobExecution = (JobExecution) message.getPayload();
+
+		String curOrchestrationId = jobExecution.getJobParameters().getString(XD_ORCHESTRATION_ID);
+
+		if(StringUtils.hasText(curOrchestrationId) &&
+				curOrchestrationId.equalsIgnoreCase(this.orchestrationId)) {
+			if(!jobExecution.isRunning()) {
+				this.results = jobExecution;
+			}
+		}
+	}
+
+	private static class JobParametersExtractor {
+
+		private ObjectMapper mapper = new ObjectMapper();
+
+		public String extract(JobParameters jobParameters) throws JsonProcessingException {
+			Map<String, Object> parameters = new HashMap<>(jobParameters.getParameters().size());
+
+			for (Map.Entry<String, JobParameter> curParameterEntry : jobParameters.getParameters().entrySet()) {
+				JobParameter curParameter = curParameterEntry.getValue();
+				String dataTypeToUse = "(" + curParameter.getType().toString().toLowerCase() + ")";
+
+				if(curParameter.isIdentifying()) {
+					parameters.put("+" + curParameterEntry.getKey() + dataTypeToUse, curParameter.getValue());
+				}
+				else {
+					parameters.put("-" + curParameterEntry.getKey() + dataTypeToUse, curParameter.getValue());
+				}
+			}
+
+			return mapper.writeValueAsString(parameters);
+		}
+	}
+}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
@@ -113,7 +113,7 @@ public class JobLaunchingTasklet implements Tasklet, MessageHandler {
 			JobDefinitionRepository jobDefinitionRepository,
 			DomainRepository instanceRepository, String jobName,
 			MessageChannel launchingChannel, PublishSubscribeChannel listeningChannel) {
-		Assert.notNull(messageBus, "A message bus is required.");
+		Assert.notNull(messageBus, "A message bus is required");
 		Assert.notNull(jobDefinitionRepository, "A JobDefinitionRepository is required");
 		Assert.notNull(instanceRepository, "A DomainRepository is required");
 		Assert.notNull(jobName, "A job name is required");

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
@@ -33,7 +33,6 @@ import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.repeat.RepeatStatus;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
@@ -92,7 +91,6 @@ public class JobLaunchingTasklet implements Tasklet, MessageHandler {
 
 	private PublishSubscribeChannel listeningChannel;
 
-	@Autowired
 	public JobLaunchingTasklet(MessageBus messageBus,
 			JobDefinitionRepository jobDefinitionRepository,
 			DomainRepository instanceRepository, String jobName) {

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTaskletTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTaskletTests.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.xd.dirt.batch.tasklet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.UnexpectedJobExecutionException;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.integration.amqp.channel.PublishSubscribeAmqpChannel;
+import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.xd.dirt.integration.bus.MessageBus;
+import org.springframework.xd.dirt.stream.JobDefinition;
+import org.springframework.xd.dirt.stream.JobDefinitionRepository;
+import org.springframework.xd.dirt.stream.NoSuchDefinitionException;
+import org.springframework.xd.dirt.stream.NotDeployedException;
+import org.springframework.xd.store.DomainRepository;
+
+/**
+ * @author Michael Minella
+ */
+public class JobLaunchingTaskletTests {
+
+	private JobLaunchingTasklet tasklet;
+
+	@Mock
+	private MessageBus bus;
+
+	@Mock
+	private JobDefinitionRepository jobDefinitionRepository;
+
+	@Mock
+	private DomainRepository<JobDefinition, String> instanceRepository;
+
+	@Mock
+	private MessageChannel launchingChannel;
+
+	@Spy
+	private PublishSubscribeChannel listeningChannel;
+
+	private TaskExecutor taskExecutor = new SimpleAsyncTaskExecutor();
+
+	@Before
+	public void setUp() {
+		this.listeningChannel = new PublishSubscribeChannel(new SimpleAsyncTaskExecutor());
+		MockitoAnnotations.initMocks(this);
+
+		this.tasklet = new JobLaunchingTasklet(bus, jobDefinitionRepository, instanceRepository, "foo", launchingChannel, listeningChannel);
+	}
+
+	@Test
+	public void testInitialLaunch() throws Exception {
+		JobInstance jobInstance = new JobInstance(3l, "masterFoo");
+		JobExecution jobExecution = new JobExecution(5l);
+		jobExecution.setJobInstance(jobInstance);
+		StepExecution stepExecution = new StepExecution("masterFoo", jobExecution, 7l);
+		final StepContribution stepContribution = new StepContribution(stepExecution);
+		final ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+		JobDefinition jobDefinition = new JobDefinition("foo", "foo");
+		when(jobDefinitionRepository.findOne("foo")).thenReturn(jobDefinition);
+		when(instanceRepository.findOne("foo")).thenReturn(jobDefinition);
+		doReturn(true).when(launchingChannel).send(any(Message.class));
+
+		FutureTask<RepeatStatus> result = new FutureTask<RepeatStatus>(new Callable<RepeatStatus>() {
+			@Override
+			public RepeatStatus call() throws Exception {
+				return tasklet.execute(stepContribution, chunkContext);
+			}
+		});
+
+		taskExecutor.execute(result);
+
+		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
+		slaveExecution.setStatus(BatchStatus.COMPLETED);
+		slaveExecution.setEndTime(new Date());
+
+		//This is to allow the job to "start" before mocking the sending of the event
+		Thread.sleep(1000l);
+
+		tasklet.handleMessage(MessageBuilder.withPayload(slaveExecution).build());
+
+		assertEquals(result.get(5, TimeUnit.SECONDS), RepeatStatus.FINISHED);
+
+		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+
+		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
+	}
+
+	@Test
+	public void testInitialLaunchWithOneJobParameter() throws ExecutionException, InterruptedException, TimeoutException {
+		JobParameters originalJobParameters = new JobParametersBuilder().addString("bar", "baz").toJobParameters();
+		JobInstance jobInstance = new JobInstance(3l, "masterFoo");
+		JobExecution jobExecution = new JobExecution(5l, originalJobParameters);
+		jobExecution.setJobInstance(jobInstance);
+		StepExecution stepExecution = new StepExecution("masterFoo", jobExecution, 7l);
+		final StepContribution stepContribution = new StepContribution(stepExecution);
+		final ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+		JobDefinition jobDefinition = new JobDefinition("foo", "foo");
+		when(jobDefinitionRepository.findOne("foo")).thenReturn(jobDefinition);
+		when(instanceRepository.findOne("foo")).thenReturn(jobDefinition);
+		doReturn(true).when(launchingChannel).send(any(Message.class));
+
+		FutureTask<RepeatStatus> result = new FutureTask<RepeatStatus>(new Callable<RepeatStatus>() {
+			@Override
+			public RepeatStatus call() throws Exception {
+				assertEquals(chunkContext.getStepContext().getStepExecution().getJobParameters().getString("bar"), "baz");
+				return tasklet.execute(stepContribution, chunkContext);
+			}
+		});
+
+		taskExecutor.execute(result);
+
+		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
+		slaveExecution.setStatus(BatchStatus.COMPLETED);
+		slaveExecution.setEndTime(new Date());
+
+		//This is to allow the job to "start" before mocking the sending of the event
+		Thread.sleep(1000l);
+
+		tasklet.handleMessage(MessageBuilder.withPayload(slaveExecution).build());
+
+		assertEquals(result.get(5, TimeUnit.SECONDS), RepeatStatus.FINISHED);
+
+		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+
+		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
+	}
+
+	@Test
+	public void testInitialLaunchWithThreeJobParameters() throws ExecutionException, InterruptedException, TimeoutException {
+		JobParameters originalJobParameters = new JobParametersBuilder()
+				.addString("string", "baz")
+				.addLong("long", 5l)
+				.addDate("date", new Date(1l))
+				.toJobParameters();
+		JobInstance jobInstance = new JobInstance(3l, "masterFoo");
+		JobExecution jobExecution = new JobExecution(5l, originalJobParameters);
+		jobExecution.setJobInstance(jobInstance);
+		StepExecution stepExecution = new StepExecution("masterFoo", jobExecution, 7l);
+		final StepContribution stepContribution = new StepContribution(stepExecution);
+		final ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+		JobDefinition jobDefinition = new JobDefinition("foo", "foo");
+		when(jobDefinitionRepository.findOne("foo")).thenReturn(jobDefinition);
+		when(instanceRepository.findOne("foo")).thenReturn(jobDefinition);
+		doReturn(true).when(launchingChannel).send(any(Message.class));
+
+		FutureTask<RepeatStatus> result = new FutureTask<RepeatStatus>(new Callable<RepeatStatus>() {
+			@Override
+			public RepeatStatus call() throws Exception {
+				JobParameters jobParameters = chunkContext.getStepContext().getStepExecution().getJobParameters();
+				assertEquals(jobParameters.getString("string"), "baz");
+				assertEquals((long) jobParameters.getLong("long"), 5l);
+				assertEquals(jobParameters.getDate("date"), new Date(1));
+
+				return tasklet.execute(stepContribution, chunkContext);
+			}
+		});
+
+		taskExecutor.execute(result);
+
+		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
+		slaveExecution.setStatus(BatchStatus.COMPLETED);
+		slaveExecution.setEndTime(new Date());
+
+		//This is to allow the job to "start" before mocking the sending of the event
+		Thread.sleep(1000l);
+
+		tasklet.handleMessage(MessageBuilder.withPayload(slaveExecution).build());
+
+		assertEquals(result.get(5, TimeUnit.SECONDS), RepeatStatus.FINISHED);
+
+		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+
+		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
+	}
+
+	@Test
+	public void testJobNotDefined() throws InterruptedException, ExecutionException, TimeoutException {
+		JobInstance jobInstance = new JobInstance(3l, "masterFoo");
+		JobExecution jobExecution = new JobExecution(5l);
+		jobExecution.setJobInstance(jobInstance);
+		StepExecution stepExecution = new StepExecution("masterFoo", jobExecution, 7l);
+		final StepContribution stepContribution = new StepContribution(stepExecution);
+		final ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+		FutureTask<RepeatStatus> result = new FutureTask<RepeatStatus>(new Callable<RepeatStatus>() {
+			@Override
+			public RepeatStatus call() throws Exception {
+				return tasklet.execute(stepContribution, chunkContext);
+			}
+		});
+
+		taskExecutor.execute(result);
+
+		try {
+			result.get(5, TimeUnit.SECONDS);
+		}
+		catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			assertEquals(cause.getClass(), NoSuchDefinitionException.class);
+			assertEquals(cause.getMessage(), "There is no job definition named 'foo'");
+		}
+	}
+
+	@Test
+	public void testJobNotDeployed() throws TimeoutException, InterruptedException {
+		JobInstance jobInstance = new JobInstance(3l, "masterFoo");
+		JobExecution jobExecution = new JobExecution(5l);
+		jobExecution.setJobInstance(jobInstance);
+		StepExecution stepExecution = new StepExecution("masterFoo", jobExecution, 7l);
+		final StepContribution stepContribution = new StepContribution(stepExecution);
+		final ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+		JobDefinition jobDefinition = new JobDefinition("foo", "foo");
+		when(jobDefinitionRepository.findOne("foo")).thenReturn(jobDefinition);
+
+		FutureTask<RepeatStatus> result = new FutureTask<RepeatStatus>(new Callable<RepeatStatus>() {
+			@Override
+			public RepeatStatus call() throws Exception {
+				return tasklet.execute(stepContribution, chunkContext);
+			}
+		});
+
+		taskExecutor.execute(result);
+
+		try {
+			result.get(5, TimeUnit.SECONDS);
+		}
+		catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			assertEquals(cause.getClass(), NotDeployedException.class);
+			assertEquals(cause.getMessage(), "The job named 'foo' is not currently deployed");
+		}
+	}
+
+	@Test
+	public void testJobFailed() throws InterruptedException, ExecutionException, TimeoutException {
+		JobInstance jobInstance = new JobInstance(3l, "masterFoo");
+		JobExecution jobExecution = new JobExecution(5l);
+		jobExecution.setJobInstance(jobInstance);
+		StepExecution stepExecution = new StepExecution("masterFoo", jobExecution, 7l);
+		final StepContribution stepContribution = new StepContribution(stepExecution);
+		final ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+		JobDefinition jobDefinition = new JobDefinition("foo", "foo");
+		when(jobDefinitionRepository.findOne("foo")).thenReturn(jobDefinition);
+		when(instanceRepository.findOne("foo")).thenReturn(jobDefinition);
+		doReturn(true).when(launchingChannel).send(any(Message.class));
+
+		FutureTask<RepeatStatus> result = new FutureTask<RepeatStatus>(new Callable<RepeatStatus>() {
+			@Override
+			public RepeatStatus call() throws Exception {
+				return tasklet.execute(stepContribution, chunkContext);
+			}
+		});
+
+		taskExecutor.execute(result);
+
+		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
+		slaveExecution.setStatus(BatchStatus.FAILED);
+		slaveExecution.setExitStatus(new ExitStatus("Job Failure"));
+		slaveExecution.setEndTime(new Date());
+
+		//This is to allow the job to "start" before mocking the sending of the event
+		Thread.sleep(1000l);
+
+		tasklet.handleMessage(MessageBuilder.withPayload(slaveExecution).build());
+
+		try {
+			assertEquals(result.get(5, TimeUnit.SECONDS), RepeatStatus.FINISHED);
+		}
+		catch (ExecutionException e) {
+			Throwable cause = e.getCause();
+			assertEquals(cause.getClass(), UnexpectedJobExecutionException.class);
+			assertEquals(cause.getMessage(), "Step failure: foo failed.");
+		}
+
+		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+
+		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
+	}
+
+	@Test
+	public void testRestart() throws InterruptedException, ExecutionException, TimeoutException {
+		JobInstance jobInstance = new JobInstance(3l, "masterFoo");
+		JobExecution jobExecution = new JobExecution(5l);
+		jobExecution.setJobInstance(jobInstance);
+		StepExecution stepExecution = new StepExecution("masterFoo", jobExecution, 7l);
+		stepExecution.getExecutionContext().put("xd_orchestration_id", "3");
+		final StepContribution stepContribution = new StepContribution(stepExecution);
+		final ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+		JobDefinition jobDefinition = new JobDefinition("foo", "foo");
+		when(jobDefinitionRepository.findOne("foo")).thenReturn(jobDefinition);
+		when(instanceRepository.findOne("foo")).thenReturn(jobDefinition);
+		doReturn(true).when(launchingChannel).send(any(Message.class));
+
+		FutureTask<RepeatStatus> result = new FutureTask<RepeatStatus>(new Callable<RepeatStatus>() {
+			@Override
+			public RepeatStatus call() throws Exception {
+				return tasklet.execute(stepContribution, chunkContext);
+			}
+		});
+
+		taskExecutor.execute(result);
+
+		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
+		slaveExecution.setStatus(BatchStatus.COMPLETED);
+		slaveExecution.setEndTime(new Date());
+
+		//This is to allow the job to "start" before mocking the sending of the event
+		Thread.sleep(1000l);
+
+		tasklet.handleMessage(MessageBuilder.withPayload(slaveExecution).build());
+
+		assertEquals(result.get(5, TimeUnit.SECONDS), RepeatStatus.FINISHED);
+
+		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+
+		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
+	}
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTaskletTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTaskletTests.java
@@ -118,7 +118,7 @@ public class JobLaunchingTaskletTests {
 
 		taskExecutor.execute(result);
 
-		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobParameters jobParameters = new JobParametersBuilder().addString(JobLaunchingTasklet.XD_ORCHESTRATION_ID, "3").toJobParameters();
 		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
 		slaveExecution.setStatus(BatchStatus.COMPLETED);
 		slaveExecution.setEndTime(new Date());
@@ -130,7 +130,7 @@ public class JobLaunchingTaskletTests {
 
 		assertEquals(result.get(5, TimeUnit.SECONDS), RepeatStatus.FINISHED);
 
-		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+		assertEquals(stepExecution.getExecutionContext().get(JobLaunchingTasklet.XD_ORCHESTRATION_ID), "3");
 
 		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
 	}
@@ -160,7 +160,7 @@ public class JobLaunchingTaskletTests {
 
 		taskExecutor.execute(result);
 
-		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobParameters jobParameters = new JobParametersBuilder().addString(JobLaunchingTasklet.XD_ORCHESTRATION_ID, "3").toJobParameters();
 		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
 		slaveExecution.setStatus(BatchStatus.COMPLETED);
 		slaveExecution.setEndTime(new Date());
@@ -172,7 +172,7 @@ public class JobLaunchingTaskletTests {
 
 		assertEquals(result.get(5, TimeUnit.SECONDS), RepeatStatus.FINISHED);
 
-		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+		assertEquals(stepExecution.getExecutionContext().get(JobLaunchingTasklet.XD_ORCHESTRATION_ID), "3");
 
 		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
 	}
@@ -210,7 +210,7 @@ public class JobLaunchingTaskletTests {
 
 		taskExecutor.execute(result);
 
-		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobParameters jobParameters = new JobParametersBuilder().addString(JobLaunchingTasklet.XD_ORCHESTRATION_ID, "3").toJobParameters();
 		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
 		slaveExecution.setStatus(BatchStatus.COMPLETED);
 		slaveExecution.setEndTime(new Date());
@@ -222,7 +222,7 @@ public class JobLaunchingTaskletTests {
 
 		assertEquals(result.get(5, TimeUnit.SECONDS), RepeatStatus.FINISHED);
 
-		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+		assertEquals(stepExecution.getExecutionContext().get(JobLaunchingTasklet.XD_ORCHESTRATION_ID), "3");
 
 		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
 	}
@@ -309,7 +309,7 @@ public class JobLaunchingTaskletTests {
 
 		taskExecutor.execute(result);
 
-		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobParameters jobParameters = new JobParametersBuilder().addString(JobLaunchingTasklet.XD_ORCHESTRATION_ID, "3").toJobParameters();
 		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
 		slaveExecution.setStatus(BatchStatus.FAILED);
 		slaveExecution.setExitStatus(new ExitStatus("Job Failure"));
@@ -329,7 +329,7 @@ public class JobLaunchingTaskletTests {
 			assertEquals(cause.getMessage(), "Step failure: foo failed.");
 		}
 
-		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+		assertEquals(stepExecution.getExecutionContext().get(JobLaunchingTasklet.XD_ORCHESTRATION_ID), "3");
 
 		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
 	}
@@ -340,7 +340,7 @@ public class JobLaunchingTaskletTests {
 		JobExecution jobExecution = new JobExecution(5l);
 		jobExecution.setJobInstance(jobInstance);
 		StepExecution stepExecution = new StepExecution("masterFoo", jobExecution, 7l);
-		stepExecution.getExecutionContext().put("xd_orchestration_id", "3");
+		stepExecution.getExecutionContext().put(JobLaunchingTasklet.XD_ORCHESTRATION_ID, "3");
 		final StepContribution stepContribution = new StepContribution(stepExecution);
 		final ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
 
@@ -358,7 +358,7 @@ public class JobLaunchingTaskletTests {
 
 		taskExecutor.execute(result);
 
-		JobParameters jobParameters = new JobParametersBuilder().addString("xd_orchestration_id", "3").toJobParameters();
+		JobParameters jobParameters = new JobParametersBuilder().addString(JobLaunchingTasklet.XD_ORCHESTRATION_ID, "3").toJobParameters();
 		JobExecution slaveExecution = new JobExecution(9l, jobParameters);
 		slaveExecution.setStatus(BatchStatus.COMPLETED);
 		slaveExecution.setEndTime(new Date());
@@ -370,7 +370,7 @@ public class JobLaunchingTaskletTests {
 
 		assertEquals(result.get(5, TimeUnit.SECONDS), RepeatStatus.FINISHED);
 
-		assertEquals(stepExecution.getExecutionContext().get("xd_orchestration_id"), "3");
+		assertEquals(stepExecution.getExecutionContext().get(JobLaunchingTasklet.XD_ORCHESTRATION_ID), "3");
 
 		verify(bus).bindPubSubConsumer(eq("tap:job:foo.job"), any(PublishSubscribeAmqpChannel.class), (Properties) isNull());
 	}


### PR DESCRIPTION
This commit creates a Tasklet implementation that utilizes Spring XD's
infrastructure to launch a job that is already deployed within the
Spring XD cluster.  In a future PR we'll make the timeout and polling
interval configurable.