### PR TITLE
[Sprint: 60] XD-2882 Adding options to provide 'enableSync' and 'syncTimeout' values

### DIFF
--- a/modules/sink/hdfs/config/hdfs.properties
+++ b/modules/sink/hdfs/config/hdfs.properties
@@ -40,6 +40,14 @@ options.closeTimeout.description = timeout in ms, regardless of activity, after 
 options.closeTimeout.type = long
 options.closeTimeout.default = 0
 
+options.flushTimeout.description = timeout in ms, regardless of activity, after which data written to file will be flushed
+options.flushTimeout.type = long
+options.flushTimeout.default = 0
+
+options.enableSync.description = whether writer will sync to datanode when flush is called, setting this to 'true' could impact throughput
+options.enableSync.type = boolean
+options.enableSync.default = false
+
 options.inUseSuffix.description = suffix for files currently being written
 options.inUseSuffix.type = String
 options.inUseSuffix.default = .tmp

--- a/modules/sink/hdfs/config/hdfs.xml
+++ b/modules/sink/hdfs/config/hdfs.xml
@@ -55,6 +55,8 @@
 		overwrite="${overwrite}"
 		idle-timeout="${idleTimeout}"
 		close-timeout="${closeTimeout}"
+		flush-timeout="${flushTimeout}"
+		enable-sync="${enableSync}"
 		in-use-suffix="${inUseSuffix}"
 		in-use-prefix="${inUsePrefix}"
 		rollover-strategy="fileRolloverStrategy"

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterFactoryBean.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterFactoryBean.java
@@ -62,6 +62,10 @@ public class StoreWriterFactoryBean implements InitializingBean, DisposableBean,
 
 	private volatile long closeTimeout;
 
+	private volatile long flushTimeout;
+
+	private volatile boolean enableSync = false;
+
 	private volatile String inUseSuffix;
 
 	private volatile String inUsePrefix;
@@ -123,6 +127,8 @@ public class StoreWriterFactoryBean implements InitializingBean, DisposableBean,
 					partitionStrategy);
 			writer.setIdleTimeout(idleTimeout);
 			writer.setCloseTimeout(closeTimeout);
+			writer.setFlushTimeout(flushTimeout);
+			writer.setSyncable(enableSync);
 			writer.setInWritingPrefix(inUsePrefix);
 			writer.setInWritingSuffix(inUseSuffix);
 			writer.setOverwrite(overwrite);
@@ -143,6 +149,8 @@ public class StoreWriterFactoryBean implements InitializingBean, DisposableBean,
 			writer.setInWritingPrefix(inUsePrefix);
 			writer.setInWritingSuffix(inUseSuffix);
 			writer.setOverwrite(overwrite);
+			writer.setFlushTimeout(flushTimeout);
+			writer.setSyncable(enableSync);
 			writer.setFileNamingStrategy(fileNamingStrategy);
 			writer.setRolloverStrategy(rolloverStrategy);
 			if (beanFactory != null) {
@@ -230,6 +238,24 @@ public class StoreWriterFactoryBean implements InitializingBean, DisposableBean,
 	 */
 	public void setCloseTimeout(long closeTimeout) {
 		this.closeTimeout = closeTimeout;
+	}
+
+	/**
+	 * Sets the flush timeout for the writer.
+	 *
+	 * @param flushTimeout the new flush timeout
+	 */
+	public void setFlushTimeout(long flushTimeout) {
+		this.flushTimeout = flushTimeout;
+	}
+
+	/**
+	 * Enables the syncable flag for the writer.
+	 *
+	 * @param enableSync the new syncable flag
+	 */
+	public void setEnableSync(boolean enableSync) {
+		this.enableSync = enableSync;
 	}
 
 	/**

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterParser.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterParser.java
@@ -46,6 +46,8 @@ public class StoreWriterParser extends AbstractSimpleBeanDefinitionParser {
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "in-use-prefix");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "idle-timeout");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "close-timeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "flush-timeout");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "enable-sync");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "overwrite");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "naming-strategy");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "rollover-strategy");

--- a/spring-xd-hadoop/src/main/resources/org/springframework/xd/integration/hadoop/config/spring-integration-hadoop.xsd
+++ b/spring-xd-hadoop/src/main/resources/org/springframework/xd/integration/hadoop/config/spring-integration-hadoop.xsd
@@ -72,6 +72,8 @@
 			<xsd:attribute name="overwrite" use="optional"/>
 			<xsd:attribute name="idle-timeout" use="optional"/>
 			<xsd:attribute name="close-timeout" use="optional"/>
+			<xsd:attribute name="flush-timeout" use="optional"/>
+			<xsd:attribute name="enable-sync" use="optional"/>
 			<xsd:attribute name="in-use-suffix" use="optional"/>
 			<xsd:attribute name="in-use-prefix" use="optional"/>
 			<xsd:attribute name="rollover-strategy" use="optional"/>

--- a/src/docs/asciidoc/Sinks.asciidoc
+++ b/src/docs/asciidoc/Sinks.asciidoc
@@ -805,10 +805,12 @@ The **$$hdfs$$** $$sink$$ has the following options:
 $$closeTimeout$$:: $$timeout in ms, regardless of activity, after which file will be automatically closed$$ *($$long$$, default: `0`)*
 $$codec$$:: $$compression codec alias name (gzip, snappy, bzip2, lzo, or slzo)$$ *($$String$$, default: ``)*
 $$directory$$:: $$where to output the files in the Hadoop FileSystem$$ *($$String$$, default: `/xd/<stream name>`)*
+$$enableSync$$:: $$whether writer will sync to datanode when flush is called, setting this to 'true' could impact throughput$$ *($$boolean$$, default: `false`)*
 $$fileExtension$$:: $$the base filename extension to use for the created files$$ *($$String$$, default: `txt`)*
 $$fileName$$:: $$the base filename to use for the created files$$ *($$String$$, default: `<stream name>`)*
 $$fileOpenAttempts$$:: $$maximum number of file open attempts to find a path$$ *($$int$$, default: `10`)*
 $$fileUuid$$:: $$whether file name should contain uuid$$ *($$boolean$$, default: `false`)*
+$$flushTimeout$$:: $$timeout in ms, regardless of activity, after which data written to file will be flushed$$ *($$long$$, default: `0`)*
 $$fsUri$$:: $$the URI to use to access the Hadoop FileSystem$$ *($$String$$, default: `${spring.hadoop.fsUri}`)*
 $$idleTimeout$$:: $$inactivity timeout in ms after which file will be automatically closed$$ *($$long$$, default: `0`)*
 $$inUsePrefix$$:: $$prefix for files currently being written$$ *($$String$$, default: ``)*


### PR DESCRIPTION
- using '--enableSync=true' and '--syncTimeout=10000' will flush the data written every 10 seconds and make it available for reads from the datanode. Using these options will have an impact on throughput.