### PR TITLE
XD-3556: JobLaunchingTasklet updates

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
@@ -67,6 +67,8 @@ public class JobLaunchingTasklet implements Tasklet, MessageHandler {
 
 	public static final String XD_ORCHESTRATION_ID = "xd_orchestration_id";
 
+	public static final String XD_PARENT_JOB_EXECUTION_ID = "xd_parent_execution_id";
+
 	private long timeout;
 
 	private long pollInterval;
@@ -149,8 +151,11 @@ public class JobLaunchingTasklet implements Tasklet, MessageHandler {
 
 		JobParameters originalJobParameters = chunkContext.getStepContext().getStepExecution().getJobParameters();
 
+		String jobExecutionId = String.valueOf(chunkContext.getStepContext().getStepExecution().getJobExecution().getId());
+
 		JobParameters jobParameters = new JobParametersBuilder(originalJobParameters)
 				.addParameter(XD_ORCHESTRATION_ID, new JobParameter(this.orchestrationId))
+				.addParameter(XD_PARENT_JOB_EXECUTION_ID, new JobParameter(jobExecutionId))
 				.toJobParameters();
 
 		String jobParametersString = this.extractor.extract(jobParameters);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/TaskletType.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/TaskletType.java
@@ -26,6 +26,7 @@ import org.springframework.data.hadoop.batch.mapreduce.ToolTasklet;
 import org.springframework.data.hadoop.batch.pig.PigTasklet;
 import org.springframework.data.hadoop.batch.scripting.ScriptTasklet;
 import org.springframework.util.StringUtils;
+import org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet;
 
 /**
  * Types of {@link org.springframework.batch.core.step.tasklet.Tasklet} implementations known by Spring XD.  These
@@ -75,6 +76,10 @@ public enum TaskletType {
 	 * {@link org.springframework.data.hadoop.batch.mapreduce.ToolTasklet}
 	 */
 	TOOL_TASKLET(ToolTasklet.class.getName(), "Tool Step"),
+	/**
+	 * {@link org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet}
+	 */
+	JOB_LAUNCHING_TASKLET(JobLaunchingTasklet.class.getName(), "Job Launching Tasklet"),
 	/**
 	 * Used when the type of tasklet is unknown to the system
 	 */


### PR DESCRIPTION
Adds the ability to configure both the timeout for a child job's
execution (how long the Tasklet will wait for a response) as well as how
often it checks that the response has came.