### PR TITLE
[Sprint: 60] XD-3627 Remove spring-xd-spi-common project with XDRuntimeException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,6 @@ ext {
 			'spring-xd-extension-kafka',
 			'spring-xd-extension-cassandra',
 			'spring-xd-messagebus-spi',
-			'spring-xd-spi-common'
 	].collect { p -> project(p) } + messagebusProjects
 }
 
@@ -997,14 +996,9 @@ project('spring-xd-rest-domain') {
 	}
 }
 
-project('spring-xd-spi-common') {
-	description = 'Spring XD SPI shared code'
-}
-
 project('spring-xd-messagebus-spi') {
 	description = 'Spring XD MessageBus Service Provider Interface'
 	dependencies {
-		compile project(':spring-xd-spi-common')
 		compile "org.springframework:spring-messaging"
 		compile "org.springframework:spring-web"
 		compile "org.springframework.retry:spring-retry"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,5 @@
 rootProject.name = 'spring-xd'
 
-include 'spring-xd-spi-common'
-
 include 'spring-xd-analytics'
 include 'spring-xd-analytics-ml'
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/DirtException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/DirtException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.springframework.xd.dirt.zookeeper;
-
-import org.springframework.xd.dirt.DirtException;
+package org.springframework.xd.dirt;
 
 /**
- * Runtime exception used to wrap native ZooKeeper checked exceptions thrown while
- * accessing ZooKeeper nodes.
- * @author dturanski
+ * Root of the hierarchy of exceptions for DIRT (Distributed Integration RunTime).
+ * 
+ * @author Mark Pollack
  */
 @SuppressWarnings("serial")
-public class ZooKeeperAccessException extends DirtException {
+public class DirtException extends RuntimeException {
 
-	public ZooKeeperAccessException(String message, Throwable cause) {
+    public DirtException(String message) {
+        super(message);
+    }
+	public DirtException(String message, Throwable cause) {
 		super(message, cause);
 	}
-
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/analytics/NoSuchMetricException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/analytics/NoSuchMetricException.java
@@ -16,7 +16,7 @@
 
 package org.springframework.xd.dirt.analytics;
 
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 /**
  * Thrown when trying to access a named metric that does not exist.
@@ -24,7 +24,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Eric Bottard
  */
 @SuppressWarnings("serial")
-public class NoSuchMetricException extends XDRuntimeException {
+public class NoSuchMetricException extends DirtException {
 
 	private final String offendingName;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/RuntimeIOException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/RuntimeIOException.java
@@ -18,16 +18,16 @@ package org.springframework.xd.dirt.core;
 
 import java.io.IOException;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
+import org.springframework.xd.dirt.DirtException;
 
 /**
- * Thrown when something goes wrong during some IO operation. Unchecked, as opposed to the {@link IOException} it wraps.
+ * Thrown when something goes wrong during some IO operation. Unchecked, as opposed to the
+ * {@link IOException} it wraps.
  * 
  * @author Eric Bottard
  */
 @SuppressWarnings("serial")
-public class RuntimeIOException extends XDRuntimeException {
+public class RuntimeIOException extends DirtException {
 
 	public RuntimeIOException(String message, IOException cause) {
 		super(message, cause);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/RuntimeTimeoutException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/RuntimeTimeoutException.java
@@ -18,22 +18,22 @@ package org.springframework.xd.dirt.core;
 
 import java.util.concurrent.TimeoutException;
 
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 /**
- * Exception thrown when a blocking operation times out. This
- * is a runtime version of {@link TimeoutException} and can accept
- * an instance of {@code TimeoutException} as a root cause.
+ * Exception thrown when a blocking operation times out. This is a runtime version of
+ * {@link TimeoutException} and can accept an instance of {@code TimeoutException} as a
+ * root cause.
  *
  * @author Patrick Peralta
  */
 @SuppressWarnings("serial")
-public class RuntimeTimeoutException extends XDRuntimeException {
+public class RuntimeTimeoutException extends DirtException {
 
 	/**
 	 * Construct a {@code RuntimeTimeoutException}.
 	 *
-	 * @param message  detailed message
+	 * @param message detailed message
 	 */
 	public RuntimeTimeoutException(String message) {
 		super(message);
@@ -43,7 +43,7 @@ public class RuntimeTimeoutException extends XDRuntimeException {
 	 * Construct a {@code RuntimeTimeoutException}.
 	 *
 	 * @param message detailed message
-	 * @param cause   root cause exception
+	 * @param cause root cause exception
 	 */
 	public RuntimeTimeoutException(String message, TimeoutException cause) {
 		super(message, cause);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/ConversionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/ConversionException.java
@@ -16,7 +16,7 @@
 
 package org.springframework.xd.dirt.integration.bus.converter;
 
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 
 /**
@@ -25,7 +25,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author David Turanski
  */
 @SuppressWarnings("serial")
-public class ConversionException extends XDRuntimeException {
+public class ConversionException extends DirtException {
 
 	public ConversionException(String message) {
 		super(message);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/BatchJobAlreadyExistsException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/BatchJobAlreadyExistsException.java
@@ -16,16 +16,13 @@
 
 package org.springframework.xd.dirt.job;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
-
 /**
  * Exception thrown when the batch job with the given name already exists.
  * 
  * @author Ilayaperumal Gopinathan
  */
 @SuppressWarnings("serial")
-public class BatchJobAlreadyExistsException extends XDRuntimeException {
+public class BatchJobAlreadyExistsException extends JobException {
 
 	public BatchJobAlreadyExistsException(String name) {
 		super("Batch Job with the name " + name + " already exists");

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,23 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.springframework.xd.dirt;
+package org.springframework.xd.dirt.job;
 
 /**
- * Base class for all XD-related exceptions.
- * 
- * @author Eric Bottard
+ * Root of the hierarchy of exceptions for Job processing in DIRT.
+ *
+ * @author Mark Pollack
  */
 @SuppressWarnings("serial")
-public abstract class XDRuntimeException extends RuntimeException {
+public class JobException extends RuntimeException {
 
-	public XDRuntimeException(String message, Throwable cause) {
-		super(message, cause);
-	}
-
-	public XDRuntimeException(String message) {
-		super(message);
-	}
-
+    public JobException(String message) {
+        super(message);
+    }
+    public JobException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionAlreadyRunningException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionAlreadyRunningException.java
@@ -16,8 +16,6 @@
 
 package org.springframework.xd.dirt.job;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
 /**
  * Exception that is raised when {@link org.springframework.batch.core.JobExecution}
  * is already running.
@@ -25,7 +23,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")
-public class JobExecutionAlreadyRunningException extends XDRuntimeException {
+public class JobExecutionAlreadyRunningException extends JobException {
 
 	public JobExecutionAlreadyRunningException(String message) {
 		super(message);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionNotRunningException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionNotRunningException.java
@@ -16,16 +16,13 @@
 
 package org.springframework.xd.dirt.job;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
-
 /**
  * Exception for the job execution that is not running.
  * 
  * @author Ilayaperumal Gopinathan
  */
 @SuppressWarnings("serial")
-public class JobExecutionNotRunningException extends XDRuntimeException {
+public class JobExecutionNotRunningException extends JobException {
 
 	public JobExecutionNotRunningException(Long executionId) {
 		super("Job execution with executionId " + executionId + " is not running.");

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceAlreadyCompleteException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceAlreadyCompleteException.java
@@ -17,7 +17,6 @@
 package org.springframework.xd.dirt.job;
 
 import org.springframework.batch.core.JobInstance;
-import org.springframework.xd.dirt.XDRuntimeException;
 
 /**
  * Exception thrown when the {@link JobInstance} is already complete.
@@ -25,7 +24,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")
-public class JobInstanceAlreadyCompleteException extends XDRuntimeException {
+public class JobInstanceAlreadyCompleteException extends JobException {
 
 	public JobInstanceAlreadyCompleteException(String message) {
 		super(message);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobParametersInvalidException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobParametersInvalidException.java
@@ -16,15 +16,13 @@
 
 package org.springframework.xd.dirt.job;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
 /**
  * Exception thrown when the job parameters are invalid.
  *
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")
-public class JobParametersInvalidException extends XDRuntimeException {
+public class JobParametersInvalidException extends JobException {
 
 	public JobParametersInvalidException(String message) {
 		super(message);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobRestartException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobRestartException.java
@@ -16,15 +16,13 @@
 
 package org.springframework.xd.dirt.job;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
 /**
  * Exception thrown where the batch job is not restartable.
  *
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")
-public class JobRestartException extends XDRuntimeException {
+public class JobRestartException extends JobException {
 
 	public JobRestartException(String message) {
 		super(message);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobException.java
@@ -16,15 +16,13 @@
 
 package org.springframework.xd.dirt.job;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
 /**
  * Exception thrown when there is no such batch job with the given name.
  * 
  * @author Ilayaperumal Gopinathan
  */
 @SuppressWarnings("serial")
-public class NoSuchBatchJobException extends XDRuntimeException {
+public class NoSuchBatchJobException extends JobException {
 
 	public NoSuchBatchJobException(String name) {
 		super("Batch Job with the name " + name + " doesn't exist");

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobInstanceException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobInstanceException.java
@@ -16,15 +16,13 @@
 
 package org.springframework.xd.dirt.job;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
 /**
  * Exception thrown when there is no such batch job instance with the given instanceId.
  * 
  * @author Ilayaperumal Gopinathan
  */
 @SuppressWarnings("serial")
-public class NoSuchBatchJobInstanceException extends XDRuntimeException {
+public class NoSuchBatchJobInstanceException extends JobException {
 
 	public NoSuchBatchJobInstanceException(long instanceId) {
 		super("Batch Job instance with the id " + instanceId + " doesn't exist");

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchJobExecutionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchJobExecutionException.java
@@ -17,7 +17,6 @@
 package org.springframework.xd.dirt.job;
 
 import org.springframework.batch.core.JobExecution;
-import org.springframework.xd.dirt.XDRuntimeException;
 
 /**
  * Thrown when attempting to refer to {@link JobExecution} that does not exist.
@@ -25,7 +24,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")
-public class NoSuchJobExecutionException extends XDRuntimeException {
+public class NoSuchJobExecutionException extends JobException {
 
 	/**
 	 * Create a new exception.

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchStepExecutionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchStepExecutionException.java
@@ -17,7 +17,6 @@
 package org.springframework.xd.dirt.job;
 
 import org.springframework.batch.core.StepExecution;
-import org.springframework.xd.dirt.XDRuntimeException;
 
 /**
  * Thrown when attempting to refer to {@link StepExecution} that does not exist.
@@ -25,7 +24,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Ilayaperumal Gopinathan
  */
 @SuppressWarnings("serial")
-public class NoSuchStepExecutionException extends XDRuntimeException {
+public class NoSuchStepExecutionException extends JobException {
 
 	/**
 	 * Create a new exception.

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/DependencyException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/DependencyException.java
@@ -18,7 +18,6 @@ package org.springframework.xd.dirt.module;
 
 import java.util.Set;
 
-import org.springframework.xd.dirt.XDRuntimeException;
 import org.springframework.xd.module.ModuleType;
 
 
@@ -28,7 +27,7 @@ import org.springframework.xd.module.ModuleType;
  * @author Eric Bottard
  */
 @SuppressWarnings("serial")
-public class /* Module? */DependencyException extends XDRuntimeException {
+public class DependencyException extends ModuleException {
 
 	private final Set<String> dependents;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleAlreadyExistsException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleAlreadyExistsException.java
@@ -16,7 +16,6 @@
 
 package org.springframework.xd.dirt.module;
 
-import org.springframework.xd.dirt.XDRuntimeException;
 import org.springframework.xd.module.ModuleType;
 
 
@@ -26,7 +25,7 @@ import org.springframework.xd.module.ModuleType;
  * @author Eric Bottard
  */
 @SuppressWarnings("serial")
-public class ModuleAlreadyExistsException extends XDRuntimeException {
+public class ModuleAlreadyExistsException extends ModuleException {
 
 	private final String name;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.springframework.xd.dirt.zookeeper;
-
-import org.springframework.xd.dirt.DirtException;
+package org.springframework.xd.dirt.module;
 
 /**
- * Runtime exception used to wrap native ZooKeeper checked exceptions thrown while
- * accessing ZooKeeper nodes.
- * @author dturanski
+ * Root of the hierarchy of exceptions for Module processing in DIRT.
+ *
+ * @author Mark Pollack
  */
-@SuppressWarnings("serial")
-public class ZooKeeperAccessException extends DirtException {
+public class ModuleException extends RuntimeException {
 
-	public ZooKeeperAccessException(String message, Throwable cause) {
-		super(message, cause);
-	}
+    public ModuleException(String message) {
+        super(message);
+    }
 
+    public ModuleException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleNotDeployedException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleNotDeployedException.java
@@ -16,15 +16,13 @@
 
 package org.springframework.xd.dirt.module;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
 /**
  * Exception thrown when a module doesn't exist in the container.
  *
  * @author Ilayaperumal Gopinathan
  */
 @SuppressWarnings("serial")
-public class ModuleNotDeployedException extends XDRuntimeException {
+public class ModuleNotDeployedException extends ModuleException {
 
 	public ModuleNotDeployedException(String containerId, String moduleId) {
 		super("The module with id '" + moduleId + "' doesn't exist in the container with id '" + containerId + "'");

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ResourceDefinitionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ResourceDefinitionException.java
@@ -16,15 +16,13 @@
 
 package org.springframework.xd.dirt.module;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
 /**
  * Thrown when a problem is detected with the (DSL) definition of an XD resource.
  *
  * @author Eric Bottard
  */
 @SuppressWarnings("serial")
-public class ResourceDefinitionException extends XDRuntimeException {
+public class ResourceDefinitionException extends ModuleException {
 
 	public ResourceDefinitionException(String message, Throwable cause) {
 		super(message, cause);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ModuleConfigurationException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ModuleConfigurationException.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 import org.springframework.xd.module.ModuleType;
 
 
@@ -30,7 +30,7 @@ import org.springframework.xd.module.ModuleType;
  * @author David Turanski
  */
 @SuppressWarnings("serial")
-public class ModuleConfigurationException extends XDRuntimeException {
+public class ModuleConfigurationException extends DirtException {
 
 	public ModuleConfigurationException(String message) {
 		super(message);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobAlreadyExistsInRegistryException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobAlreadyExistsInRegistryException.java
@@ -18,7 +18,7 @@ package org.springframework.xd.dirt.plugins.job;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.configuration.JobRegistry;
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 
 /**
@@ -27,7 +27,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Mark Pollack
  */
 @SuppressWarnings("serial")
-public class BatchJobAlreadyExistsInRegistryException extends XDRuntimeException {
+public class BatchJobAlreadyExistsInRegistryException extends DirtException {
 
 	/**
 	 * Creates a new {@link BatchJobAlreadyExistsInRegistryException} with the given job name.

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminPortNotAvailableException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminPortNotAvailableException.java
@@ -16,7 +16,7 @@
 
 package org.springframework.xd.dirt.server.admin;
 
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 
 /**
@@ -25,7 +25,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Ilayaperumal Gopinathan
  */
 @SuppressWarnings("serial")
-public class AdminPortNotAvailableException extends XDRuntimeException {
+public class AdminPortNotAvailableException extends DirtException {
 
 	/**
 	 * Construct an {@code AdminPortNotAvailableException}.

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentException.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.xd.dirt.server.admin.deployment;
 
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 /**
  * Exception thrown when {@link DeploymentHandler} encounters problem
@@ -24,7 +24,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Ilayaperumal Gopinathan
  */
 @SuppressWarnings("serial")
-public class DeploymentException extends XDRuntimeException {
+public class DeploymentException extends DirtException {
 
 	public DeploymentException(String message){
 		super(message);

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AlreadyDeployedException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AlreadyDeployedException.java
@@ -16,7 +16,7 @@
 
 package org.springframework.xd.dirt.stream;
 
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 /**
  * Thrown when an attempt is made to deploy a definition that is already deployed.
@@ -25,7 +25,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  *
  */
 @SuppressWarnings("serial")
-public class AlreadyDeployedException extends XDRuntimeException {
+public class AlreadyDeployedException extends DirtException {
 
 	/**
 	 * Create a new exception.

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DefinitionAlreadyExistsException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DefinitionAlreadyExistsException.java
@@ -16,7 +16,7 @@
 
 package org.springframework.xd.dirt.stream;
 
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 /**
  * Exception which is raised when a resource definition with the same name already exists.
@@ -24,7 +24,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Luke Taylor
  */
 @SuppressWarnings("serial")
-public class DefinitionAlreadyExistsException extends XDRuntimeException {
+public class DefinitionAlreadyExistsException extends DirtException {
 
 	private final String offendingName;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/NoSuchDefinitionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/NoSuchDefinitionException.java
@@ -16,7 +16,7 @@
 
 package org.springframework.xd.dirt.stream;
 
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 /**
  * Exception which is raised when a named resource definition cannot be found.
@@ -24,7 +24,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Luke Taylor
  */
 @SuppressWarnings("serial")
-public class NoSuchDefinitionException extends XDRuntimeException {
+public class NoSuchDefinitionException extends DirtException {
 
 	private final String offendingName;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/NotDeployedException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/NotDeployedException.java
@@ -16,7 +16,7 @@
 
 package org.springframework.xd.dirt.stream;
 
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 /**
  * Thrown when a definition was assumed to be deployed when it actually was not.
@@ -24,7 +24,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Eric Bottard
  */
 @SuppressWarnings("serial")
-public class NotDeployedException extends XDRuntimeException {
+public class NotDeployedException extends DirtException {
 
 	private final String offendingName;
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/PageNotFoundException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/PageNotFoundException.java
@@ -17,7 +17,7 @@
 package org.springframework.xd.dirt.util;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.xd.dirt.XDRuntimeException;
+import org.springframework.xd.dirt.DirtException;
 
 /**
  * Exception thrown when a {@link Pageable} requests a page that does not exist.
@@ -25,7 +25,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @author Gunnar Hillert
  */
 @SuppressWarnings("serial")
-public class PageNotFoundException extends XDRuntimeException {
+public class PageNotFoundException extends DirtException {
 
 	public PageNotFoundException(String message) {
 		super(message);

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusException.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusException.java
@@ -26,6 +26,10 @@ package org.springframework.xd.dirt.integration.bus;
 @SuppressWarnings("serial")
 public class MessageBusException extends RuntimeException {
 
+	public MessageBusException(String message) {
+		super(message);
+	}
+
 	public MessageBusException(String message, Throwable cause) {
 		super(message, cause);
 	}

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitAdminException.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitAdminException.java
@@ -16,9 +16,6 @@
 
 package org.springframework.xd.dirt.integration.bus;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
-
 /**
  * Exceptions thrown while interfacing with the RabbitMQ admin plugin.
  *
@@ -26,7 +23,7 @@ import org.springframework.xd.dirt.XDRuntimeException;
  * @since 1.2
  */
 @SuppressWarnings("serial")
-public class RabbitAdminException extends XDRuntimeException {
+public class RabbitAdminException extends MessageBusException {
 
 	public RabbitAdminException(String message, Throwable cause) {
 		super(message, cause);

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/SerializationException.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/SerializationException.java
@@ -16,19 +16,13 @@
 
 package org.springframework.xd.dirt.integration.bus;
 
-import org.springframework.xd.dirt.XDRuntimeException;
-
 /**
  * Thrown when something goes wrong with inter-module communication.
  *
  * @author David Turanski
  */
 @SuppressWarnings("serial")
-public class SerializationException extends XDRuntimeException {
-
-	public SerializationException(String message) {
-		super(message);
-	}
+public class SerializationException extends MessageBusException {
 
 	public SerializationException(String message, Throwable t) {
 		super(message, t);


### PR DESCRIPTION
* Create DirtException as a replacement to XDRuntimeException
* Create package specific exceptions where it looked useful