### PR TITLE
[Sprint: 60] Modifying parsing, graph and XML generation to reflect current thinking

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
@@ -150,22 +150,6 @@ public class Graph {
 			}
 		}
 		return candidate;
-		//		if (unvisitedLinks.size() == 0) {
-		//			return null;
-		//		}
-		//		Link candidate = unvisitedLinks.get(0);
-		//		boolean changedCandidate = true;
-		//		while (changedCandidate) {
-		//			changedCandidate = false;
-		//			Node n = findNodeById(candidate.from);
-		//			for (Link link : unvisitedLinks) {
-		//				if (link.to == n.id) {
-		//					changedCandidate = true;
-		//					candidate = link;
-		//				}
-		//			}
-		//		}
-		//		return findNodeById(candidate.from);
 	}
 
 	/**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
@@ -339,16 +339,6 @@ public class Graph {
 		printNode(graphText, target, unvisitedNodes);
 		List<Link> toFollow = findLinksFrom(target, false);
 		printTransitions(graphText, unfollowedLinks, toFollow);
-
-		// if there isn't a node to finish following at and to follow is empty - look for the next 'head' ?
-		//		if (nodeToFinishFollowingAt == null && toFollow.size() == 0 && unvisitedNodes.size() != 0) {
-		//			// Find another head to follow. We will join it via '||' which is not right but it is all we have...
-		//			// I'm asserting it will be OK because it won't be confusing or misrepresent the actual definition.
-		//			// What else can we assert here? Assert the previous node had 'all exits covered' ?
-		//			int stop = 1;
-		//			findNexth
-		//		}
-
 		followLinks(graphText, toFollow, nodeToFinishFollowingAt, unvisitedNodes, unfollowedLinks);
 	}
 

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
@@ -81,6 +81,11 @@ public class Node {
 	}
 
 	@JsonIgnore
+	public boolean isFail() {
+		return name.equals("FAIL");
+	}
+
+	@JsonIgnore
 	public boolean isSync() {
 		return name.equals("SYNC");
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokenizer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokenizer.java
@@ -63,7 +63,7 @@ class Tokenizer {
 				continue;
 			}
 
-			if (isAlphabetic(ch) || isDigit(ch) || ch == '_' || ch == '.') {
+			if (isAlphabetic(ch) || isDigit(ch) || ch == '_' || ch == '.' || ch == '$') {
 				lexIdentifier();
 			}
 			else {
@@ -82,7 +82,7 @@ class Tokenizer {
 							pushPairToken(TokenKind.DOUBLE_PIPE);
 						}
 						else {
-							pushPairToken(TokenKind.PIPE);
+							pushCharToken(TokenKind.PIPE);
 						}
 						break;
 					case '-':

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Transition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Transition.java
@@ -29,6 +29,10 @@ import org.springframework.xd.dirt.stream.dsl.AstNode;
  */
 public class Transition extends AstNode {
 
+	public final static String FAIL = "$FAIL";
+
+	public final static String END = "$END";
+
 	private Token stateNameToken;
 
 	private String stateName;
@@ -75,6 +79,23 @@ public class Transition extends AstNode {
 	 */
 	public String getStateNameInDSLForm() {
 		return stateNameToken.data;
+	}
+
+	/**
+	 * Some target names for a transition are 'well known' like $FAIL and $END - these
+	 * do not indicate a following job step, they instead indicate a termination state.
+	 * @return true if the target of this transition is a special state ($FAIL/$END)
+	 */
+	public boolean isSpecialTransition() {
+		return isFailTransition() || isEndTransition();
+	}
+
+	public boolean isFailTransition() {
+		return getStateNameInDSLForm().equals(FAIL);
+	}
+
+	public boolean isEndTransition() {
+		return getStateNameInDSLForm().equals(END);
 	}
 
 }

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ToolsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ToolsController.java
@@ -47,14 +47,11 @@ public class ToolsController {
 
 	private XDStreamParser.MultiLineDocumentParser multilineStreamParser;
 
-	private JobParser jobParser;
-
 	private DocumentParseResultResourceAssembler assembler = new DocumentParseResultResourceAssembler();
 
 	@Autowired
 	public ToolsController(XDStreamParser streamParser) {
 		this.multilineStreamParser = new XDStreamParser.MultiLineDocumentParser(streamParser);
-		this.jobParser = new JobParser();
 	}
 
 	/**
@@ -72,6 +69,7 @@ public class ToolsController {
 	@RequestMapping(value = "/parseJobToGraph", method = RequestMethod.GET)
 	public Map<String, Object> parseJobToGraph(@RequestParam("specification") String specification) {
 		Map<String, Object> response = new HashMap<>();
+		JobParser jobParser = new JobParser();
 		try {
 			Graph graph = jobParser.getGraph(specification);
 			response.put("graph", graph);

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/allExitsCovered.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/allExitsCovered.xml
@@ -2,27 +2,26 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
-    <step id="foo">
-      <tasklet ref="jobRunner-foo"/>
-      <next on="failed" to="bbb"/>
-      <next on="error" to="bbb"/>
-      <next on="COMPLETED" to="bar"/>
-      <fail on="*"/>
-    </step>
-    <step id="bar">
-      <tasklet ref="jobRunner-bar"/>
-      <next on="failed" to="bbb"/>
-      <fail on="*"/>
+    <step id="aaa">
+      <tasklet ref="jobRunner-aaa"/>
+      <end on="foo"/>
+      <next on="B" to="bbb"/>
+      <next on="*" to="ccc"/>
     </step>
     <step id="bbb">
       <tasklet ref="jobRunner-bbb"/>
+      <next on="COMPLETED" to="ccc"/>
+      <fail on="*"/>
+    </step>
+    <step id="ccc">
+      <tasklet ref="jobRunner-ccc"/>
     </step>
   </batch:job>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step">
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-aaa" scope="step">
     <constructor-arg ref="messageBus"/>
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="foo"/>
+    <constructor-arg value="aaa"/>
     <constructor-arg value="${timeout}"/>
   </bean>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
@@ -32,11 +31,11 @@
     <constructor-arg value="bbb"/>
     <constructor-arg value="${timeout}"/>
   </bean>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step">
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ccc" scope="step">
     <constructor-arg ref="messageBus"/>
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="bar"/>
+    <constructor-arg value="ccc"/>
     <constructor-arg value="${timeout}"/>
   </bean>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/end1.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/end1.xml
@@ -4,18 +4,8 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="failed" to="bbb"/>
-      <next on="error" to="bbb"/>
-      <next on="COMPLETED" to="bar"/>
+      <end on="oranges"/>
       <fail on="*"/>
-    </step>
-    <step id="bar">
-      <tasklet ref="jobRunner-bar"/>
-      <next on="failed" to="bbb"/>
-      <fail on="*"/>
-    </step>
-    <step id="bbb">
-      <tasklet ref="jobRunner-bbb"/>
     </step>
   </batch:job>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step">
@@ -23,20 +13,6 @@
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
     <constructor-arg value="foo"/>
-    <constructor-arg value="${timeout}"/>
-  </bean>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
-    <constructor-arg ref="messageBus"/>
-    <constructor-arg ref="jobDefinitionRepository"/>
-    <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="bbb"/>
-    <constructor-arg value="${timeout}"/>
-  </bean>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step">
-    <constructor-arg ref="messageBus"/>
-    <constructor-arg ref="jobDefinitionRepository"/>
-    <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="bar"/>
     <constructor-arg value="${timeout}"/>
   </bean>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/end2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/end2.xml
@@ -2,27 +2,26 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
-    <step id="foo">
-      <tasklet ref="jobRunner-foo"/>
-      <next on="failed" to="bbb"/>
-      <next on="error" to="bbb"/>
-      <next on="COMPLETED" to="bar"/>
-      <fail on="*"/>
-    </step>
-    <step id="bar">
-      <tasklet ref="jobRunner-bar"/>
-      <next on="failed" to="bbb"/>
-      <fail on="*"/>
+    <step id="aaa">
+      <tasklet ref="jobRunner-aaa"/>
+      <end on="foo"/>
+      <next on="B" to="bbb"/>
+      <next on="*" to="ccc"/>
     </step>
     <step id="bbb">
       <tasklet ref="jobRunner-bbb"/>
+      <next on="COMPLETED" to="ccc"/>
+      <fail on="*"/>
+    </step>
+    <step id="ccc">
+      <tasklet ref="jobRunner-ccc"/>
     </step>
   </batch:job>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step">
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-aaa" scope="step">
     <constructor-arg ref="messageBus"/>
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="foo"/>
+    <constructor-arg value="aaa"/>
     <constructor-arg value="${timeout}"/>
   </bean>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
@@ -32,11 +31,11 @@
     <constructor-arg value="bbb"/>
     <constructor-arg value="${timeout}"/>
   </bean>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step">
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ccc" scope="step">
     <constructor-arg ref="messageBus"/>
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="bar"/>
+    <constructor-arg value="ccc"/>
     <constructor-arg value="${timeout}"/>
   </bean>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/end3.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/end3.xml
@@ -2,27 +2,21 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
-    <step id="foo">
-      <tasklet ref="jobRunner-foo"/>
-      <next on="failed" to="bbb"/>
-      <next on="error" to="bbb"/>
-      <next on="COMPLETED" to="bar"/>
-      <fail on="*"/>
-    </step>
-    <step id="bar">
-      <tasklet ref="jobRunner-bar"/>
-      <next on="failed" to="bbb"/>
-      <fail on="*"/>
+    <step id="aaa">
+      <tasklet ref="jobRunner-aaa"/>
+      <end on="foo"/>
+      <next on="B" to="bbb"/>
+      <end on="*"/>
     </step>
     <step id="bbb">
       <tasklet ref="jobRunner-bbb"/>
     </step>
   </batch:job>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step">
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-aaa" scope="step">
     <constructor-arg ref="messageBus"/>
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="foo"/>
+    <constructor-arg value="aaa"/>
     <constructor-arg value="${timeout}"/>
   </bean>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
@@ -30,13 +24,6 @@
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
     <constructor-arg value="bbb"/>
-    <constructor-arg value="${timeout}"/>
-  </bean>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step">
-    <constructor-arg ref="messageBus"/>
-    <constructor-arg ref="jobDefinitionRepository"/>
-    <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="bar"/>
     <constructor-arg value="${timeout}"/>
   </bean>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/fail1.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/fail1.xml
@@ -4,18 +4,8 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="failed" to="bbb"/>
-      <next on="error" to="bbb"/>
-      <next on="COMPLETED" to="bar"/>
+      <fail on="oranges"/>
       <fail on="*"/>
-    </step>
-    <step id="bar">
-      <tasklet ref="jobRunner-bar"/>
-      <next on="failed" to="bbb"/>
-      <fail on="*"/>
-    </step>
-    <step id="bbb">
-      <tasklet ref="jobRunner-bbb"/>
     </step>
   </batch:job>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-foo" scope="step">
@@ -23,20 +13,6 @@
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
     <constructor-arg value="foo"/>
-    <constructor-arg value="${timeout}"/>
-  </bean>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
-    <constructor-arg ref="messageBus"/>
-    <constructor-arg ref="jobDefinitionRepository"/>
-    <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="bbb"/>
-    <constructor-arg value="${timeout}"/>
-  </bean>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bar" scope="step">
-    <constructor-arg ref="messageBus"/>
-    <constructor-arg ref="jobDefinitionRepository"/>
-    <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="bar"/>
     <constructor-arg value="${timeout}"/>
   </bean>
 </beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit.xml
@@ -4,7 +4,8 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="AA">
       <tasklet ref="jobRunner-AA"/>
-      <next on="*" to="split1"/>
+      <next on="COMPLETED" to="split1"/>
+      <fail on="*"/>
     </step>
     <split id="split1" task-executor="taskExecutor">
       <flow>
@@ -17,7 +18,8 @@
           <tasklet ref="jobRunner-CC"/>
         </step>
       </flow>
-      <next on="*" to="DD"/>
+      <next on="COMPLETED" to="DD"/>
+      <fail on="*"/>
     </split>
     <step id="DD">
       <tasklet ref="jobRunner-DD"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplit2.xml
@@ -4,13 +4,15 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="AA">
       <tasklet ref="jobRunner-AA"/>
-      <next on="*" to="split1"/>
+      <next on="COMPLETED" to="split1"/>
+      <fail on="*"/>
     </step>
     <split id="split1" task-executor="taskExecutor">
       <flow>
         <step id="BB">
           <tasklet ref="jobRunner-BB"/>
-          <next on="*" to="CC"/>
+          <next on="COMPLETED" to="CC"/>
+          <fail on="*"/>
         </step>
         <step id="CC">
           <tasklet ref="jobRunner-CC"/>
@@ -21,7 +23,8 @@
           <tasklet ref="jobRunner-DD"/>
         </step>
       </flow>
-      <next on="*" to="EE"/>
+      <next on="COMPLETED" to="EE"/>
+      <fail on="*"/>
     </split>
     <step id="EE">
       <tasklet ref="jobRunner-EE"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplitDupModule.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/flowSplitDupModule.xml
@@ -4,7 +4,8 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="split1"/>
+      <next on="COMPLETED" to="split1"/>
+      <fail on="*"/>
     </step>
     <split id="split1" task-executor="taskExecutor">
       <flow>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/lotsOfTransitions.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/lotsOfTransitions.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+  <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
+  <batch:job xmlns="http://www.springframework.org/schema/batch" id="lotsOfTransitions">
+    <step id="aaa">
+      <tasklet ref="jobRunner-aaa"/>
+      <next on="FAILED" to="iii"/>
+      <next on="COMPLETED" to="split1"/>
+      <fail on="*"/>
+    </step>
+    <split id="split1" task-executor="taskExecutor">
+      <flow>
+        <step id="bbb">
+          <tasklet ref="jobRunner-bbb"/>
+          <next on="FAILED" to="iii1"/>
+          <fail on="*"/>
+        </step>
+        <step id="iii1">
+          <tasklet ref="jobRunner-iii"/>
+        </step>
+      </flow>
+      <flow>
+        <step id="ccc">
+          <tasklet ref="jobRunner-ccc"/>
+          <next on="FAILED" to="jjj"/>
+          <fail on="*"/>
+        </step>
+        <step id="jjj">
+          <tasklet ref="jobRunner-jjj"/>
+        </step>
+      </flow>
+      <next on="COMPLETED" to="ddd"/>
+      <fail on="*"/>
+    </split>
+    <step id="ddd">
+      <tasklet ref="jobRunner-ddd"/>
+      <next on="FAILED" to="iii"/>
+      <next on="COMPLETED" to="eee"/>
+      <fail on="*"/>
+    </step>
+    <step id="eee">
+      <tasklet ref="jobRunner-eee"/>
+      <next on="FAILED" to="iii"/>
+      <next on="COMPLETED" to="fff"/>
+      <fail on="*"/>
+    </step>
+    <step id="fff">
+      <tasklet ref="jobRunner-fff"/>
+      <next on="FAILED" to="iii"/>
+      <next on="COMPLETED" to="split2"/>
+      <fail on="*"/>
+    </step>
+    <split id="split2" task-executor="taskExecutor">
+      <flow>
+        <step id="ggg">
+          <tasklet ref="jobRunner-ggg"/>
+          <next on="FAILED" to="kkk"/>
+          <fail on="*"/>
+        </step>
+        <step id="kkk">
+          <tasklet ref="jobRunner-kkk"/>
+        </step>
+      </flow>
+      <flow>
+        <step id="hhh">
+          <tasklet ref="jobRunner-hhh"/>
+          <next on="FAILED" to="kkk1"/>
+          <fail on="*"/>
+        </step>
+        <step id="kkk1">
+          <tasklet ref="jobRunner-kkk"/>
+        </step>
+      </flow>
+    </split>
+    <step id="iii">
+      <tasklet ref="jobRunner-iii"/>
+    </step>
+  </batch:job>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-aaa" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="aaa"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-iii" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="iii"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="bbb"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ccc" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="ccc"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-jjj" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="jjj"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ddd" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="ddd"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-eee" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="eee"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-fff" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="fff"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ggg" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="ggg"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-kkk" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="kkk"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-hhh" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="hhh"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+</beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/lotsOfTransitions2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/lotsOfTransitions2.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+  <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
+  <batch:job xmlns="http://www.springframework.org/schema/batch" id="lotsOfTransitions2">
+    <step id="aaa">
+      <tasklet ref="jobRunner-aaa"/>
+      <next on="FAILED" to="iii"/>
+      <next on="COMPLETED" to="split1"/>
+      <fail on="*"/>
+    </step>
+    <split id="split1" task-executor="taskExecutor">
+      <flow>
+        <step id="bbb">
+          <tasklet ref="jobRunner-bbb"/>
+          <next on="FAILED" to="iii1"/>
+          <next on="COMPLETED" to="zzz"/>
+          <fail on="*"/>
+        </step>
+        <step id="zzz">
+          <tasklet ref="jobRunner-zzz"/>
+        </step>
+        <step id="iii1">
+          <tasklet ref="jobRunner-iii"/>
+        </step>
+      </flow>
+      <flow>
+        <step id="ccc">
+          <tasklet ref="jobRunner-ccc"/>
+          <next on="FAILED" to="jjj"/>
+          <fail on="*"/>
+        </step>
+        <step id="jjj">
+          <tasklet ref="jobRunner-jjj"/>
+        </step>
+      </flow>
+      <next on="COMPLETED" to="ddd"/>
+      <fail on="*"/>
+    </split>
+    <step id="ddd">
+      <tasklet ref="jobRunner-ddd"/>
+      <next on="FAILED" to="iii"/>
+      <next on="COMPLETED" to="eee"/>
+      <fail on="*"/>
+    </step>
+    <step id="eee">
+      <tasklet ref="jobRunner-eee"/>
+      <next on="FAILED" to="iii"/>
+      <next on="COMPLETED" to="fff"/>
+      <fail on="*"/>
+    </step>
+    <step id="fff">
+      <tasklet ref="jobRunner-fff"/>
+      <next on="FAILED" to="iii"/>
+      <next on="COMPLETED" to="split2"/>
+      <fail on="*"/>
+    </step>
+    <split id="split2" task-executor="taskExecutor">
+      <flow>
+        <step id="ggg">
+          <tasklet ref="jobRunner-ggg"/>
+          <next on="FAILED" to="kkk"/>
+          <fail on="*"/>
+        </step>
+        <step id="kkk">
+          <tasklet ref="jobRunner-kkk"/>
+        </step>
+      </flow>
+      <flow>
+        <step id="hhh">
+          <tasklet ref="jobRunner-hhh"/>
+          <next on="FAILED" to="kkk1"/>
+          <fail on="*"/>
+        </step>
+        <step id="kkk1">
+          <tasklet ref="jobRunner-kkk"/>
+        </step>
+      </flow>
+    </split>
+    <step id="iii">
+      <tasklet ref="jobRunner-iii"/>
+    </step>
+  </batch:job>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-aaa" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="aaa"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-iii" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="iii"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="bbb"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-zzz" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="zzz"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ccc" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="ccc"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-jjj" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="jjj"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ddd" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="ddd"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-eee" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="eee"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-fff" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="fff"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ggg" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="ggg"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-kkk" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="kkk"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-hhh" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="hhh"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+</beans>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlow.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlow.xml
@@ -4,7 +4,8 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="bar"/>
+      <next on="COMPLETED" to="bar"/>
+      <fail on="*"/>
     </step>
     <step id="bar">
       <tasklet ref="jobRunner-bar"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowDupModule.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowDupModule.xml
@@ -4,7 +4,8 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="foo1"/>
+      <next on="COMPLETED" to="foo1"/>
+      <fail on="*"/>
     </step>
     <step id="foo1">
       <tasklet ref="jobRunner-foo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowDupModule2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowDupModule2.xml
@@ -4,15 +4,18 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="bar"/>
+      <next on="COMPLETED" to="bar"/>
+      <fail on="*"/>
     </step>
     <step id="bar">
       <tasklet ref="jobRunner-bar"/>
-      <next on="*" to="foo1"/>
+      <next on="COMPLETED" to="foo1"/>
+      <fail on="*"/>
     </step>
     <step id="foo1">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="split1"/>
+      <next on="COMPLETED" to="split1"/>
+      <fail on="*"/>
     </step>
     <split id="split1" task-executor="taskExecutor">
       <flow>
@@ -25,7 +28,8 @@
           <tasklet ref="jobRunner-foo"/>
         </step>
       </flow>
-      <next on="*" to="foo3"/>
+      <next on="COMPLETED" to="foo3"/>
+      <fail on="*"/>
     </split>
     <step id="foo3">
       <tasklet ref="jobRunner-foo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowOptions.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowOptions.xml
@@ -4,11 +4,13 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="bar"/>
+      <next on="COMPLETED" to="bar"/>
+      <fail on="*"/>
     </step>
     <step id="bar">
       <tasklet ref="jobRunner-bar"/>
-      <next on="*" to="boo"/>
+      <next on="COMPLETED" to="boo"/>
+      <fail on="*"/>
     </step>
     <step id="boo">
       <tasklet ref="jobRunner-boo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowOptions2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowOptions2.xml
@@ -4,11 +4,13 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="bar"/>
+      <next on="COMPLETED" to="bar"/>
+      <fail on="*"/>
     </step>
     <step id="bar">
       <tasklet ref="jobRunner-bar"/>
-      <next on="*" to="boo"/>
+      <next on="COMPLETED" to="boo"/>
+      <fail on="*"/>
     </step>
     <step id="boo">
       <tasklet ref="jobRunner-boo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowOptions3.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowOptions3.xml
@@ -4,11 +4,13 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="bar"/>
+      <next on="COMPLETED" to="bar"/>
+      <fail on="*"/>
     </step>
     <step id="bar">
       <tasklet ref="jobRunner-bar"/>
-      <next on="*" to="boo"/>
+      <next on="COMPLETED" to="boo"/>
+      <fail on="*"/>
     </step>
     <step id="boo">
       <tasklet ref="jobRunner-boo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowWithTransition.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowWithTransition.xml
@@ -4,11 +4,13 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="bar"/>
+      <next on="COMPLETED" to="bar"/>
+      <fail on="*"/>
     </step>
     <step id="bar">
       <tasklet ref="jobRunner-bar"/>
       <next on="failed" to="goo"/>
+      <fail on="*"/>
     </step>
     <step id="goo">
       <tasklet ref="jobRunner-goo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowWithTransition2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowWithTransition2.xml
@@ -5,11 +5,13 @@
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
       <next on="failed" to="bbb"/>
-      <next on="*" to="bar"/>
+      <next on="COMPLETED" to="bar"/>
+      <fail on="*"/>
     </step>
     <step id="bar">
       <tasklet ref="jobRunner-bar"/>
       <next on="failed" to="bbb"/>
+      <fail on="*"/>
     </step>
     <step id="bbb">
       <tasklet ref="jobRunner-bbb"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowWithTransition4.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleFlowWithTransition4.xml
@@ -6,11 +6,13 @@
       <tasklet ref="jobRunner-foo"/>
       <next on="failed" to="bbb"/>
       <next on="error" to="boo"/>
-      <next on="*" to="bar"/>
+      <next on="COMPLETED" to="bar"/>
+      <fail on="*"/>
     </step>
     <step id="bar">
       <tasklet ref="jobRunner-bar"/>
       <next on="failed" to="bbb"/>
+      <fail on="*"/>
     </step>
     <step id="bbb">
       <tasklet ref="jobRunner-bbb"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplitWithTransition.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplitWithTransition.xml
@@ -7,6 +7,7 @@
         <step id="foo">
           <tasklet ref="jobRunner-foo"/>
           <next on="failed" to="boo"/>
+          <fail on="*"/>
         </step>
         <step id="boo">
           <tasklet ref="jobRunner-boo"/>
@@ -16,6 +17,7 @@
         <step id="bar">
           <tasklet ref="jobRunner-bar"/>
           <next on="failed" to="goo"/>
+          <fail on="*"/>
         </step>
         <step id="goo">
           <tasklet ref="jobRunner-goo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplitWithTransition2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplitWithTransition2.xml
@@ -7,6 +7,7 @@
         <step id="foo">
           <tasklet ref="jobRunner-foo"/>
           <next on="failed" to="boo"/>
+          <fail on="*"/>
         </step>
         <step id="boo">
           <tasklet ref="jobRunner-boo"/>
@@ -16,6 +17,7 @@
         <step id="bar">
           <tasklet ref="jobRunner-bar"/>
           <next on="failed" to="boo1"/>
+          <fail on="*"/>
         </step>
         <step id="boo1">
           <tasklet ref="jobRunner-boo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplitWithTransition3.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplitWithTransition3.xml
@@ -8,6 +8,7 @@
           <tasklet ref="jobRunner-foo"/>
           <next on="failed" to="boo"/>
           <next on="error" to="boo"/>
+          <fail on="*"/>
         </step>
         <step id="boo">
           <tasklet ref="jobRunner-boo"/>
@@ -17,6 +18,7 @@
         <step id="bar">
           <tasklet ref="jobRunner-bar"/>
           <next on="failed" to="boo1"/>
+          <fail on="*"/>
         </step>
         <step id="boo1">
           <tasklet ref="jobRunner-boo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplitWithTransition4.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/simpleSplitWithTransition4.xml
@@ -8,7 +8,8 @@
           <tasklet ref="jobRunner-foo"/>
           <next on="failed" to="boo"/>
           <next on="error" to="boo"/>
-          <next on="*" to="goo"/>
+          <next on="COMPLETED" to="goo"/>
+          <fail on="*"/>
         </step>
         <step id="goo">
           <tasklet ref="jobRunner-goo"/>
@@ -21,6 +22,7 @@
         <step id="bar">
           <tasklet ref="jobRunner-bar"/>
           <next on="failed" to="boo1"/>
+          <fail on="*"/>
         </step>
         <step id="boo1">
           <tasklet ref="jobRunner-boo"/>

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/xml1.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/xml1.xml
@@ -1,20 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
-  <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
+  <batch:job xmlns="http://www.springframework.org/schema/batch" id="foo_COMPOSED">
     <step id="aaa">
       <tasklet ref="jobRunner-aaa"/>
-      <next on="failed" to="ccc"/>
-      <next on="COMPLETED" to="bbb"/>
+      <next on="COMPLETED" to="split1"/>
       <fail on="*"/>
     </step>
-    <step id="bbb">
-      <tasklet ref="jobRunner-bbb"/>
-      <next on="COMPLETED" to="ccc"/>
+    <split id="split1" task-executor="taskExecutor">
+      <flow>
+        <step id="bbb">
+          <tasklet ref="jobRunner-bbb"/>
+        </step>
+      </flow>
+      <flow>
+        <step id="ccc">
+          <tasklet ref="jobRunner-ccc"/>
+        </step>
+      </flow>
+      <next on="COMPLETED" to="farg"/>
       <fail on="*"/>
-    </step>
-    <step id="ccc">
-      <tasklet ref="jobRunner-ccc"/>
+    </split>
+    <step id="farg">
+      <tasklet ref="jobRunner-farg"/>
       <next on="COMPLETED" to="ddd"/>
       <fail on="*"/>
     </step>
@@ -29,6 +37,13 @@
     <constructor-arg value="aaa"/>
     <constructor-arg value="${timeout}"/>
   </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="bbb"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ccc" scope="step">
     <constructor-arg ref="messageBus"/>
     <constructor-arg ref="jobDefinitionRepository"/>
@@ -36,11 +51,11 @@
     <constructor-arg value="ccc"/>
     <constructor-arg value="${timeout}"/>
   </bean>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-farg" scope="step">
     <constructor-arg ref="messageBus"/>
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="bbb"/>
+    <constructor-arg value="farg"/>
     <constructor-arg value="${timeout}"/>
   </bean>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ddd" scope="step">

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/xml2.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/xml2.xml
@@ -1,25 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:batch="http://www.springframework.org/schema/batch" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
   <bean class="org.springframework.core.task.SimpleAsyncTaskExecutor" id="taskExecutor"/>
-  <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
+  <batch:job xmlns="http://www.springframework.org/schema/batch" id="foo_COMPOSED">
     <step id="aaa">
       <tasklet ref="jobRunner-aaa"/>
-      <next on="failed" to="ccc"/>
       <next on="COMPLETED" to="bbb"/>
       <fail on="*"/>
     </step>
     <step id="bbb">
       <tasklet ref="jobRunner-bbb"/>
-      <next on="COMPLETED" to="ccc"/>
+      <next on="COMPLETED" to="farg"/>
       <fail on="*"/>
     </step>
-    <step id="ccc">
-      <tasklet ref="jobRunner-ccc"/>
+    <step id="farg">
+      <tasklet ref="jobRunner-farg"/>
+      <next on="FAILED" to="ccc"/>
       <next on="COMPLETED" to="ddd"/>
       <fail on="*"/>
     </step>
     <step id="ddd">
       <tasklet ref="jobRunner-ddd"/>
+    </step>
+    <step id="ccc">
+      <tasklet ref="jobRunner-ccc"/>
     </step>
   </batch:job>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-aaa" scope="step">
@@ -29,18 +32,25 @@
     <constructor-arg value="aaa"/>
     <constructor-arg value="${timeout}"/>
   </bean>
-  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ccc" scope="step">
-    <constructor-arg ref="messageBus"/>
-    <constructor-arg ref="jobDefinitionRepository"/>
-    <constructor-arg ref="xdJobRepository"/>
-    <constructor-arg value="ccc"/>
-    <constructor-arg value="${timeout}"/>
-  </bean>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-bbb" scope="step">
     <constructor-arg ref="messageBus"/>
     <constructor-arg ref="jobDefinitionRepository"/>
     <constructor-arg ref="xdJobRepository"/>
     <constructor-arg value="bbb"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-farg" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="farg"/>
+    <constructor-arg value="${timeout}"/>
+  </bean>
+  <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ccc" scope="step">
+    <constructor-arg ref="messageBus"/>
+    <constructor-arg ref="jobDefinitionRepository"/>
+    <constructor-arg ref="xdJobRepository"/>
+    <constructor-arg value="ccc"/>
     <constructor-arg value="${timeout}"/>
   </bean>
   <bean class="org.springframework.xd.dirt.batch.tasklet.JobLaunchingTasklet" id="jobRunner-ddd" scope="step">

--- a/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/xmlFlowDup.xml
+++ b/spring-xd-dirt/src/test/resources/org/springframework/xd/dirt/job/dsl/xmlFlowDup.xml
@@ -4,7 +4,8 @@
   <batch:job xmlns="http://www.springframework.org/schema/batch" id="test1">
     <step id="foo">
       <tasklet ref="jobRunner-foo"/>
-      <next on="*" to="foo1"/>
+      <next on="COMPLETED" to="foo1"/>
+      <fail on="*"/>
     </step>
     <step id="foo1">
       <tasklet ref="jobRunner-foo"/>


### PR DESCRIPTION
Includes the changes to reflect the 'current thinking' around DSL > XML.  Also updated graph generation to match and graph to DSL text conversion. Includes support for $END and $FAIL transition targets.