### PR TITLE
[Sprint: 61] XD-3683 Supports single job composition

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ComposedJobUtil.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ComposedJobUtil.java
@@ -59,11 +59,11 @@ public class ComposedJobUtil {
 			//Check for single instanceof job with a transition
 			if (jobSpecification.getJobReferences().size() == 1){
 				JobReference reference = jobSpecification.getJobReferences().get(0);
-				if( reference.transitions.size() > 0){
+				if( reference.transitions != null && reference.transitions.size() > 0){
 					result = true;
 				}
 			}
-		} catch (Exception e) {
+		} catch (JobSpecificationException e) {
 			result = false; //failed to parse, could be a stream.
 		}
 		return result;
@@ -79,7 +79,7 @@ public class ComposedJobUtil {
 		try {
 			JobParser parser = new JobParser();
 			jobSpecification = parser.parse(definition);
-		} catch (Exception e) {
+		} catch (JobSpecificationException e) {
 			return; //failed to parse.
 		}
 		if (jobSpecification.getJobReferences().size() == 1) {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ComposedJobUtil.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ComposedJobUtil.java
@@ -29,8 +29,15 @@ public class ComposedJobUtil {
 
 	public static final String MODULE_SUFFIX = "_COMPOSED";
 
+	private static String orchestrationPatternString = "(\\|\\|" +//search for || in the definition
+						"(?=([^\\\"']*[\\\"'][^\\\"']*[\\\"'])*[^\\\"']*$))" + //make sure its not in quotes
+						"|(\\&" + //or find a & in the definition
+						"(?=([^\\\"']*[\\\"'][^\\\"']*[\\\"'])*[^\\\"']*$))";// make sure its not in quotes
+
 	private static String parameterPatternString = "(--" +//search for -- in the definition
 			"(?=([^\\\"']*[\\\"'][^\\\"']*[\\\"'])*[^\\\"']*$))"; //make sure its not in quotes
+
+	private static Pattern orchestrationPattern = Pattern.compile(orchestrationPatternString);
 
 	private static Pattern parameterPattern = Pattern.compile(parameterPatternString);
 
@@ -64,7 +71,10 @@ public class ComposedJobUtil {
 				}
 			}
 		} catch (JobSpecificationException e) {
-			result = false; //failed to parse, could be a stream.
+			//failed to parse, could still be a composed job.  Look for basic components
+			// such as || or & if found return true.
+			Matcher matcher = orchestrationPattern.matcher(definition);
+			result = matcher.find();
 		}
 		return result;
 	}

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
@@ -78,8 +78,11 @@ public class JobsController extends
 		if (distributedJobLocator.getJobNames().contains(name)) {
 			throw new BatchJobAlreadyExistsException(name);
 		}
-		if(ComposedJobUtil.isComposedJobDefinition(definition)){
-			moduleDefinitionService.compose(ComposedJobUtil.getComposedJobModuleName(name), ModuleType.job,definition, false);
+		if(ComposedJobUtil.isComposedJobDefinition(definition)) {
+			moduleDefinitionService.compose(ComposedJobUtil.getComposedJobModuleName(name), ModuleType.job, definition, false);
+		}
+		else {
+			ComposedJobUtil.validateNotSingleJobInstance(definition, distributedJobLocator.getJobNames());
 		}
 		super.save(name, definition, deploy);
 	}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
@@ -122,7 +122,7 @@ public class JobsControllerIntegrationTests extends AbstractControllerIntegratio
 	public void testComposedJobCreationBadDSL() throws Exception {
 		mockMvc.perform(
 				post("/jobs/definitions").param("name", "job1").param("definition", "A || B >").accept(
-						MediaType.APPLICATION_JSON)).andExpect(status().is4xxClientError());
+						MediaType.APPLICATION_JSON)).andExpect(status().isInternalServerError());
 	}
 	
 	@Test

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
@@ -122,7 +122,7 @@ public class JobsControllerIntegrationTests extends AbstractControllerIntegratio
 	public void testComposedJobCreationBadDSL() throws Exception {
 		mockMvc.perform(
 				post("/jobs/definitions").param("name", "job1").param("definition", "A || B >").accept(
-						MediaType.APPLICATION_JSON)).andExpect(status().isInternalServerError());
+						MediaType.APPLICATION_JSON)).andExpect(status().is4xxClientError());
 	}
 	
 	@Test


### PR DESCRIPTION
If a user decides to create a single job composition they can do so but it requires them to use transitions
i.e. job create --definition "aaa |FOO=ccc |'*'=$END"

If a user creates a job composition with job instance without transitions the following exception will be thrown.
Command failed org.springframework.xd.rest.client.impl.SpringXDException: Job Instance specified  aaa must use transitions.  Or just launch the job instance directly

If a user selects a job that is neither an instance nor a module, they will get the traditional message
Could not find module with name 'aaa' and type 'job