### PR TITLE
[Sprint: 61] XD-3697: Fix Named Channel Kafka Partitions

### DIFF
--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -212,16 +212,17 @@ public class KafkaMessageBus extends MessageBusSupport {
 			.addAll(KAFKA_CONSUMER_PROPERTIES)
 			.build();
 
+	private static final Set<Object> KAFKA_PRODUCER_PROPERTIES = new SetBuilder()
+			.add(BusProperties.MIN_PARTITION_COUNT)
+			.build();
+
 	private static final Set<Object> SUPPORTED_NAMED_PRODUCER_PROPERTIES = new SetBuilder()
 			.addAll(PRODUCER_STANDARD_PROPERTIES)
 			.addAll(PRODUCER_BATCHING_BASIC_PROPERTIES)
 			.addAll(PRODUCER_COMPRESSION_PROPERTIES)
+			.addAll(KAFKA_PRODUCER_PROPERTIES)
 			.build();
 
-
-	private static final Set<Object> KAFKA_PRODUCER_PROPERTIES = new SetBuilder()
-			.add(BusProperties.MIN_PARTITION_COUNT)
-			.build();
 
 	/**
 	 * Partitioning + kafka producer properties.
@@ -482,7 +483,7 @@ public class KafkaMessageBus extends MessageBusSupport {
 
 		Assert.isInstanceOf(SubscribableChannel.class, moduleOutputChannel);
 		KafkaPropertiesAccessor producerPropertiesAccessor = new KafkaPropertiesAccessor(properties);
-		if (name.startsWith(P2P_NAMED_CHANNEL_TYPE_PREFIX)) {
+		if (name.startsWith(P2P_NAMED_CHANNEL_TYPE_PREFIX) || name.startsWith(PUBSUB_NAMED_CHANNEL_TYPE_PREFIX)) {
 			validateProducerProperties(name, properties, SUPPORTED_NAMED_PRODUCER_PROPERTIES);
 		}
 		else {

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
@@ -19,6 +19,14 @@ package org.springframework.xd.test.kafka;
 
 import java.util.Properties;
 
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.exception.ZkInterruptedException;
+import org.junit.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.xd.test.AbstractExternalResourceTestSupport;
+
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
 import kafka.utils.SystemTime$;
@@ -27,19 +35,13 @@ import kafka.utils.TestZKUtils;
 import kafka.utils.Utils;
 import kafka.utils.ZKStringSerializer$;
 import kafka.utils.ZkUtils;
-import org.I0Itec.zkclient.ZkClient;
-import org.I0Itec.zkclient.exception.ZkInterruptedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.junit.Rule;
-
-import org.springframework.xd.test.AbstractExternalResourceTestSupport;
 
 /**
  * JUnit {@link Rule} that starts an embedded Kafka server (with an associated Zookeeper)
  *
  * @author Ilayaperumal Gopinathan
  * @author Marius Bogoevici
+ * @author Gary Russell
  * @since 1.1
  */
 public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String> {
@@ -121,7 +123,7 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 			}
 		}
 		else {
-			this.zkClient = new ZkClient(DEFAULT_ZOOKEEPER_CONNECT, 5000, 5000, ZKStringSerializer$.MODULE$);
+			this.zkClient = new ZkClient(DEFAULT_ZOOKEEPER_CONNECT, 10000, 10000, ZKStringSerializer$.MODULE$);
 			if (ZkUtils.getAllBrokersInCluster(zkClient).size() == 0) {
 				throw new RuntimeException("Kafka server not available");
 			}


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-3697

Previously, a named channel (specifically `> queue:foo`) could not have a `minPartitionCount` deployment
property.

Also, a named pub sub channel (`> topic:foo`), incorrectly allowed bus partitioning properties.

__cherry-pick to 1.2.x__