### PR TITLE
[Sprint: 61] XD-3673 Propagate sequence and count to modules with named channel input

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -95,6 +95,7 @@
 #        maxWait:                   100
 #        fetchSize:                 1048576
 #        minPartitionCount:         1
+#        durableSubscription:       false
 
 #Disable batch database initialization
 #spring:

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -179,6 +179,7 @@ xd:
         maxWait:                   100
         fetchSize:                 1048576
         minPartitionCount:         1
+        durableSubscription:       false
   security:
     authorization:
       rules:

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/BrokerBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/BrokerBusTests.java
@@ -39,8 +39,7 @@ import org.springframework.messaging.support.GenericMessage;
  *
  * @author Gary Russell
  */
-public abstract class BrokerBusTests extends
-AbstractMessageBusTests {
+public abstract class BrokerBusTests extends AbstractMessageBusTests {
 
 	@Test
 	public void testDirectBinding() throws Exception {

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
@@ -18,6 +18,8 @@ package org.springframework.xd.dirt.integration.bus.kafka;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -25,13 +27,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
-
+import org.hamcrest.CoreMatchers;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.DirectChannel;
@@ -47,6 +45,11 @@ import org.springframework.xd.dirt.integration.bus.BusProperties;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.XdHeaders;
 import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
 
 /**
  * @author Marius Bogoevici
@@ -333,4 +336,68 @@ public class RawModeKafkaMessageBusTests extends KafkaMessageBusTests {
 		assertTrue(getBindings(messageBus).isEmpty());
 	}
 
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSendAndReceivePubSubWithMultipleConsumers() throws Exception {
+		MessageBus messageBus = getMessageBus();
+		DirectChannel quuxUpstreamModuleOutputChannel = new DirectChannel();
+		// Test pub/sub by emulating how StreamPlugin handles taps
+		DirectChannel tapChannel = new DirectChannel();
+		QueueChannel basDownstreamModuleInputChannel = new QueueChannel();
+		QueueChannel fooTapDownstreamInputChannel = new QueueChannel();
+		QueueChannel barTapDowstreamInput1Channel = new QueueChannel();
+		QueueChannel barTapDowstreamInput2Channel = new QueueChannel();
+		String originalTopic = "quux.0";
+		messageBus.bindProducer(originalTopic, quuxUpstreamModuleOutputChannel, null);
+		messageBus.bindConsumer(originalTopic, basDownstreamModuleInputChannel, null);
+		quuxUpstreamModuleOutputChannel.addInterceptor(new WireTap(tapChannel));
+		Properties quuxTapProducerProperties = new Properties();
+		// set the partition count to two, so that the tap has two partitions as well
+		// this will be necessary to robin messages across the competing consumers
+		quuxTapProducerProperties.setProperty(BusProperties.MIN_PARTITION_COUNT, "2");
+		messageBus.bindPubSubProducer("tap:quux.http", tapChannel, quuxTapProducerProperties);
+		// A new module is using the tap as an input channel
+		String fooTapName = messageBus.isCapable(MessageBus.Capability.DURABLE_PUBSUB) ? "foo.tap:quux.http" : "tap:quux.http";
+		messageBus.bindPubSubConsumer(fooTapName, fooTapDownstreamInputChannel, null);
+		// Another new module is using tap as an input channel
+		String barTapName = messageBus.isCapable(MessageBus.Capability.DURABLE_PUBSUB) ? "bar.tap:quux.http" : "tap:quux.http";
+		Properties barTap1Properties = new Properties();
+		barTap1Properties.setProperty(BusProperties.COUNT, "2");
+		barTap1Properties.setProperty(BusProperties.SEQUENCE, "1");
+		messageBus.bindPubSubConsumer(barTapName, barTapDowstreamInput1Channel, barTap1Properties);
+		Properties barTap2Properties = new Properties();
+		barTap2Properties.setProperty(BusProperties.COUNT, "2");
+		barTap2Properties.setProperty(BusProperties.SEQUENCE, "2");
+		messageBus.bindPubSubConsumer(barTapName, barTapDowstreamInput2Channel, barTap2Properties);
+		Message<?> message1 = MessageBuilder.withPayload("foo1".getBytes()).build();
+		Message<?> message2 = MessageBuilder.withPayload("foo2".getBytes()).build();
+
+		quuxUpstreamModuleOutputChannel.send(message1);
+		quuxUpstreamModuleOutputChannel.send(message2);
+		Message<byte[]> inbound = (Message<byte[]>) basDownstreamModuleInputChannel.receive(5000);
+		assertNotNull(inbound);
+		assertEquals("foo1", new String(inbound.getPayload()));
+		inbound = (Message<byte[]>) basDownstreamModuleInputChannel.receive(5000);
+		assertNotNull(inbound);
+		assertEquals("foo2", new String(inbound.getPayload()));
+		List<Message<?>> tappedFoo = new ArrayList<>();
+		tappedFoo.add(fooTapDownstreamInputChannel.receive(5000));
+		tappedFoo.add(fooTapDownstreamInputChannel.receive(5000));
+		Message<byte[]> tappedBar1 = (Message<byte[]>) barTapDowstreamInput1Channel.receive(5000);
+		Message<byte[]> tappedBar2 = (Message<byte[]>) barTapDowstreamInput2Channel.receive(5000);
+		assertThat(tappedFoo,
+				CoreMatchers.<Message<?>>hasItems(hasProperty("payload", equalTo("foo1".getBytes())),
+						hasProperty("payload", equalTo("foo2".getBytes()))));
+		assertEquals("foo1", new String(tappedBar1.getPayload()));
+		assertEquals("foo2", new String(tappedBar2.getPayload()));
+
+		// when other tap stream is deleted
+		messageBus.unbindConsumers(fooTapName);
+		// Clean up as StreamPlugin would
+		messageBus.unbindConsumers(originalTopic);
+		messageBus.unbindProducers(originalTopic);
+		messageBus.unbindProducers("tap:quux.http");
+		messageBus.unbindConsumers(barTapName);
+		assertTrue(getBindings(messageBus).isEmpty());
+	}
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
@@ -13,25 +13,6 @@
 
 package org.springframework.xd.dirt.stream;
 
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.Type;
@@ -43,7 +24,6 @@ import org.junit.Test;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -58,6 +38,7 @@ import org.springframework.xd.dirt.core.DeploymentUnitStatus;
 import org.springframework.xd.dirt.core.ModuleDeploymentsPath;
 import org.springframework.xd.dirt.integration.bus.AbstractTestMessageBus;
 import org.springframework.xd.dirt.integration.bus.Binding;
+import org.springframework.xd.dirt.integration.bus.BusProperties;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.XdHeaders;
 import org.springframework.xd.dirt.integration.bus.local.LocalMessageBus;
@@ -72,6 +53,26 @@ import org.springframework.xd.dirt.zookeeper.Paths;
 import org.springframework.xd.dirt.zookeeper.ZooKeeperUtils;
 import org.springframework.xd.module.ModuleDeploymentProperties;
 import org.springframework.xd.module.core.Module;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 
 /**

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusUtils.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusUtils.java
@@ -62,6 +62,14 @@ public class BusUtils {
 		}
 	}
 
+	public static String getGroupFromPubSub(String name) {
+		if (PUBSUB_NAMED_CHANNEL_PATTERN.matcher(name).find()) {
+			return name.substring(0,name.indexOf("."));
+		}
+		else {
+			return name;
+		}
+	}
 	/**
 	 * Determine whether the provided channel name represents a pub/sub channel (i.e. topic or tap).
 	 * @param channelName name of the channel to check

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -80,6 +80,8 @@ public abstract class MessageBusSupport
 
 	protected static final String P2P_NAMED_CHANNEL_TYPE_PREFIX = "queue:";
 
+	protected static final String TAP_TYPE_PREFIX = "tap:";
+
 	protected static final String PUBSUB_NAMED_CHANNEL_TYPE_PREFIX = "topic:";
 
 	protected static final String JOB_CHANNEL_TYPE_PREFIX = "job:";

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
@@ -65,7 +65,8 @@ public class KafkaTestSupport extends AbstractExternalResourceTestSupport<String
 	private Properties brokerConfig = TestUtils.createBrokerConfig(0, TestUtils.choosePort(), false);
 
 	static {
-		embedded = "true".equals(System.getProperty(XD_KAFKA_TEST_EMBEDDED));
+		embedded = "true".equals(System.getProperty(XD_KAFKA_TEST_EMBEDDED))
+				|| "true".equals(System.getenv(XD_KAFKA_TEST_EMBEDDED));
 		log.info(String.format("Testing with %s Kafka broker", embedded ? "embedded" : "external"));
 	}
 

--- a/spring-xd-yarn/site/config/servers.yml
+++ b/spring-xd-yarn/site/config/servers.yml
@@ -203,6 +203,7 @@ xd:
 #        maxWait:                   100
 #        fetchSize:                 1048576
 #        minPartitionCount:         1
+#        durableSubscription:       false
 
 
 #Disable batch database initialization


### PR DESCRIPTION
* Allow modules with a named channel input to receive index and count, so that zero-indexed
modules that receive data off a tap or named channel can act as competing consumers in Kafka
* Propagate group name to consumers for establishing consumer groups for offset management with Kafka
* Ensure that there is no automatic repartitioning on shared destinations (topics and named channels) so
that modules do not interfere with each other