### PR TITLE
XD-3684: Updated job repository configuration to be consistent

### DIFF
--- a/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HSQLServerBean.java
+++ b/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HSQLServerBean.java
@@ -21,16 +21,15 @@ import java.lang.management.OperatingSystemMXBean;
 import java.net.SocketException;
 import java.util.Properties;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.sun.management.UnixOperatingSystemMXBean;
 import org.hsqldb.persist.HsqlProperties;
 import org.hsqldb.server.ServerConfiguration;
 import org.hsqldb.server.ServerConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-
-import com.sun.management.UnixOperatingSystemMXBean;
 
 
 /**

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryFactoryBean.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryFactoryBean.java
@@ -38,7 +38,7 @@ import org.springframework.util.Assert;
 public class JobLaunchingJobRepositoryFactoryBean extends JobRepositoryFactoryBean {
 
 	private PlatformTransactionManager transactionManager;
-	private static final String DEFAULT_ISOLATION_LEVEL = "ISOLATION_SERIALIZABLE";
+	private static final String DEFAULT_ISOLATION_LEVEL = "ISOLATION_READ_COMMITTED";
 	private String isolationLevelForCreate = DEFAULT_ISOLATION_LEVEL;
 	private boolean validateTransactionState = true;
 	private ProxyFactory proxyFactory;

--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/batch.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/batch/batch.xml
@@ -11,12 +11,25 @@
 		class="org.springframework.xd.dirt.plugins.job.DistributedJobLocator">
 		<property name="jdbcTemplate" ref="jdbcTemplate" />
 	</bean>
-	
+
+	<beans profile="container">
+		<bean id="containerBatchConfigurer"
+			  class="org.springframework.xd.dirt.batch.RuntimeBatchConfigurer">
+			<constructor-arg ref="dataSource" />
+			<property name="isolationLevel" value="${spring.batch.isolationLevel:#{T(org.springframework.xd.dirt.batch.RuntimeBatchConfigurer).DEFAULT_ISOLATION_LEVEL}}" />
+			<property name="clobType" value="${spring.batch.clobType:#{null}}" />
+			<property name="dbType" value="${spring.batch.dbType:#{null}}" />
+			<property name="maxVarCharLength" value="${spring.batch.maxVarcharLength:#{T(org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao).DEFAULT_EXIT_MESSAGE_LENGTH}}" />
+			<property name="tablePrefix" value="${spring.batch.tablePrefix:#{T(org.springframework.batch.core.repository.dao.AbstractJdbcBatchMetadataDao).DEFAULT_TABLE_PREFIX}}" />
+			<property name="validateTransactionState" value="${spring.batch.validateTransactionState:true}" />
+		</bean>
+	</beans>
+
 	<beans profile="admin">
 		<import resource="classpath:/org/springframework/xd/batch/hsql-datasource.xml" />
 
-		<bean id="batchConfigurer"
-			class="org.springframework.xd.dirt.batch.RuntimeBatchConfigurer">
+		<bean id="adminBatchConfigurer"
+			  class="org.springframework.xd.dirt.batch.RuntimeBatchConfigurer">
 			<constructor-arg ref="dataSource" />
 			<property name="isolationLevel" value="${spring.batch.isolationLevel:#{T(org.springframework.xd.dirt.batch.RuntimeBatchConfigurer).DEFAULT_ISOLATION_LEVEL}}" />
 			<property name="clobType" value="${spring.batch.clobType:#{null}}" />


### PR DESCRIPTION
This commit causes the database configuration to be consistent across the container and admin nodes.