### PR TITLE
[Sprint 62] XD-3216-3610 Offset management and header propagation issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ allprojects {
 		mavenCentral()
 		maven { url 'http://repo.spring.io/milestone' }
 		maven { url 'http://repo.spring.io/libs-milestone' }
+		maven { url 'http://repo.spring.io/libs-staging-local' }
 		maven { url 'http://repo.spring.io/plugins-release' }
 		maven { url 'https://repo.eclipse.org/content/repositories/paho-releases' }
 	}
@@ -140,8 +141,8 @@ ext {
 	splunkVersion = '1.3.0'
 	springBatchAdminMgrVersion = '1.3.0.RELEASE'
 	springIntegrationSplunkVersion = '1.1.0.RELEASE'
-	springIntegrationKafkaVersion = '1.2.1.RELEASE'
-	kafkaVersion = '0.8.2.1'
+	springIntegrationKafkaVersion = '1.3.0.RELEASE'
+	kafkaVersion = '0.8.2.2'
 	springShellVersion = '1.1.0.RELEASE'
 	zookeeperVersion = '3.4.6'
 	sparkVersion = '1.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,6 @@ allprojects {
 		mavenCentral()
 		maven { url 'http://repo.spring.io/milestone' }
 		maven { url 'http://repo.spring.io/libs-milestone' }
-		maven { url 'http://repo.spring.io/libs-staging-local' }
 		maven { url 'http://repo.spring.io/plugins-release' }
 		maven { url 'https://repo.eclipse.org/content/repositories/paho-releases' }
 	}

--- a/config/servers.yml
+++ b/config/servers.yml
@@ -71,6 +71,7 @@
 #      brokers:                                 localhost:9092
 #      zkAddress:                               localhost:2181
 #      mode:                                    embeddedHeaders
+#      offsetManagement:                        kafkaNative
 #      headers:
             # comma-delimited list of additional header names to transport
 #      socketBufferSize:                        2097152

--- a/config/servers.yml
+++ b/config/servers.yml
@@ -71,7 +71,7 @@
 #      brokers:                                 localhost:9092
 #      zkAddress:                               localhost:2181
 #      mode:                                    embeddedHeaders
-#      offsetManagement:                        kafkaNative
+#      offsetManagement:                        kafkaTopic
 #      headers:
             # comma-delimited list of additional header names to transport
 #      socketBufferSize:                        2097152

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
@@ -44,7 +44,7 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
 	private String initialOffsets = "";
 
-	private OffsetStorageStrategy offsetStorage = OffsetStorageStrategy.kafka_native;
+	private OffsetStorageStrategy offsetStorage = OffsetStorageStrategy.kafkaNative;
 
 	private int streams = 1;
 
@@ -176,7 +176,7 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 		inmemory,
 		redis,
 		kafka,
-		kafka_native
+		kafkaNative
 	}
 
 	@AssertTrue(message = "the options topic and topics are mutually exclusive")

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
@@ -44,7 +44,7 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
 	private String initialOffsets = "";
 
-	private OffsetStorageStrategy offsetStorage = OffsetStorageStrategy.kafkaNative;
+	private OffsetStorageStrategy offsetStorage = OffsetStorageStrategy.kafka;
 
 	private int streams = 1;
 

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
@@ -44,7 +44,7 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 
 	private String initialOffsets = "";
 
-	private OffsetStorageStrategy offsetStorage = OffsetStorageStrategy.kafka;
+	private OffsetStorageStrategy offsetStorage = OffsetStorageStrategy.kafka_native;
 
 	private int streams = 1;
 
@@ -175,7 +175,8 @@ public class KafkaSourceModuleOptionsMetadata implements ProfileNamesProvider {
 	public enum OffsetStorageStrategy {
 		inmemory,
 		redis,
-		kafka
+		kafka,
+		kafka_native
 	}
 
 	@AssertTrue(message = "the options topic and topics are mutually exclusive")

--- a/modules/sink/kafka/config/kafka.xml
+++ b/modules/sink/kafka/config/kafka.xml
@@ -8,8 +8,8 @@
 
 	<int:channel id="input" />
 
-	<int-kafka:outbound-channel-adapter
-		kafka-producer-context-ref="kafkaProducerContext" topic="${topic}" auto-startup="false" channel="input">
+	<int-kafka:outbound-channel-adapter kafka-producer-context-ref="kafkaProducerContext" topic="${topic}"
+		auto-startup="false" channel="input" enable-header-routing="false">
 	</int-kafka:outbound-channel-adapter>
 
 	<bean id="producerProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">

--- a/modules/source/kafka/config/kafka.xml
+++ b/modules/source/kafka/config/kafka.xml
@@ -127,4 +127,14 @@
 		</bean>
 	</beans>
 
+	<beans profile="kafka_native-offset-manager">
+		<bean id="offsetManager" class="org.springframework.integration.kafka.listener.KafkaNativeOffsetManager">
+			<constructor-arg index="0" ref="connectionFactory"/>
+ 			<constructor-arg index="1" ref="kafkaSourceZookeeperConnect"/>
+			<constructor-arg index="2" ref="initialOffsetsMap"/>
+			<property name="consumerId" value="${groupId}"/>
+			<property name="referenceTimestamp" value="${autoOffsetResetValue}"/>
+		</bean>
+	</beans>
+
 </beans>

--- a/modules/source/kafka/config/kafka.xml
+++ b/modules/source/kafka/config/kafka.xml
@@ -127,7 +127,7 @@
 		</bean>
 	</beans>
 
-	<beans profile="kafka_native-offset-manager">
+	<beans profile="kafkaNative-offset-manager">
 		<bean id="offsetManager" class="org.springframework.integration.kafka.listener.KafkaNativeOffsetManager">
 			<constructor-arg index="0" ref="connectionFactory"/>
  			<constructor-arg index="1" ref="kafkaSourceZookeeperConnect"/>

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -154,7 +154,7 @@ xd:
       brokers:                                 localhost:9092
       zkAddress:                               localhost:2181
       mode:                                    embeddedHeaders
-      offsetManagement:                        kafkaNative
+      offsetManagement:                        kafkaTopic
       headers:
             # comma-delimited list of additional header names to transport
       socketBufferSize:                        2097152

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -154,6 +154,7 @@ xd:
       brokers:                                 localhost:9092
       zkAddress:                               localhost:2181
       mode:                                    embeddedHeaders
+      offsetManagement:                        kafkaNative
       headers:
             # comma-delimited list of additional header names to transport
       socketBufferSize:                        2097152

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
@@ -64,6 +64,29 @@ public class KafkaTestMessageBus extends AbstractTestMessageBus<KafkaMessageBus>
 		}
 	}
 
+	public KafkaTestMessageBus(KafkaTestSupport kafkaTestSupport, Codec codec,
+			KafkaMessageBus.OffsetManagement offsetManagement) {
+
+		try {
+			ZookeeperConnect zookeeperConnect = new ZookeeperConnect();
+			zookeeperConnect.setZkConnect(kafkaTestSupport.getZkConnectString());
+			KafkaMessageBus messageBus = new KafkaMessageBus(zookeeperConnect,
+					kafkaTestSupport.getBrokerAddress(),
+					kafkaTestSupport.getZkConnectString(), codec);
+			messageBus.setOffsetManagement(offsetManagement);
+			messageBus.setDefaultBatchingEnabled(false);
+			messageBus.setMode(KafkaMessageBus.Mode.embeddedHeaders);
+			messageBus.afterPropertiesSet();
+			GenericApplicationContext context = new GenericApplicationContext();
+			context.refresh();
+			messageBus.setApplicationContext(context);
+			this.setMessageBus(messageBus);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
 	@Override
 	public void cleanup() {
 		// do nothing - the rule will take care of that

--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -307,7 +307,7 @@ public class KafkaMessageBus extends MessageBusSupport implements DisposableBean
 
 	private Mode mode = Mode.embeddedHeaders;
 
-	private OffsetManagement offsetManagement = OffsetManagement.kafkaNative;
+	private OffsetManagement offsetManagement = OffsetManagement.kafkaTopic;
 
 	private ZkClient zkClient;
 

--- a/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
+++ b/spring-xd-messagebus-kafka/src/main/resources/META-INF/spring-xd/bus/kafka-bus.xml
@@ -19,6 +19,7 @@
 		<constructor-arg value="${xd.messagebus.kafka.headers:}" />
 
 		<property name="mode" value="${xd.messagebus.kafka.mode}"/>
+		<property name="offsetManagement" value="${xd.messagebus.kafka.offsetManagement}"/>
 
 		<!-- Producer properties -->
 		<property name="defaultBatchSize" value="${xd.messagebus.kafka.default.batchSize}"/>

--- a/spring-xd-yarn/site/config/servers.yml
+++ b/spring-xd-yarn/site/config/servers.yml
@@ -179,6 +179,7 @@ xd:
 #      brokers:                                 localhost:9092
 #      zkAddress:                               localhost:2181
 #      mode:                                    embeddedHeaders
+#      offsetManagement:                        kafkaNative
 #      headers:
             # comma-delimited list of additional header names to transport
 #      socketBufferSize:                        2097152

--- a/spring-xd-yarn/site/config/servers.yml
+++ b/spring-xd-yarn/site/config/servers.yml
@@ -179,7 +179,7 @@ xd:
 #      brokers:                                 localhost:9092
 #      zkAddress:                               localhost:2181
 #      mode:                                    embeddedHeaders
-#      offsetManagement:                        kafkaNative
+#      offsetManagement:                        kafkaTopic
 #      headers:
             # comma-delimited list of additional header names to transport
 #      socketBufferSize:                        2097152

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -458,7 +458,7 @@ $$kafkaOffsetTopicName$$:: $$name of the offset topic, if Kafka offset strategy 
 $$kafkaOffsetTopicRequiredAcks$$:: $$required acks for writing to the Kafka offset topic, if Kafka offset strategy is chosen$$ *($$int$$, default: `1`)*
 $$kafkaOffsetTopicRetentionTime$$:: $$retention time for dead records (tombstones), if Kafka offset strategy is chosen$$ *($$int$$, default: `60000`)*
 $$kafkaOffsetTopicSegmentSize$$:: $$segment size of the offset topic, if Kafka offset strategy is chosen$$ *($$int$$, default: `262144000`)*
-$$offsetStorage$$:: $$strategy for persisting offset values$$ *($$OffsetStorageStrategy$$, default: `kafka`, possible values: `inmemory,redis,kafka`)*
+$$offsetStorage$$:: $$strategy for persisting offset values$$ *($$OffsetStorageStrategy$$, default: `kafka_native`, possible values: `inmemory,redis,kafka,kafka_native`)*
 $$offsetUpdateCount$$:: $$frequency, in number of messages, with which offsets are persisted, per concurrent processor, mutually exclusive with the time-based offset update option (use 0 to disable either)$$ *($$int$$, default: `0`)*
 $$offsetUpdateShutdownTimeout$$:: $$timeout for ensuring that all offsets have been written, on shutdown$$ *($$int$$, default: `2000`)*
 $$offsetUpdateTimeWindow$$:: $$frequency (in milliseconds) with which offsets are persisted mutually exclusive with the count-based offset update option (use 0 to disable either)$$ *($$int$$, default: `10000`)*

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -458,7 +458,7 @@ $$kafkaOffsetTopicName$$:: $$name of the offset topic, if Kafka offset strategy 
 $$kafkaOffsetTopicRequiredAcks$$:: $$required acks for writing to the Kafka offset topic, if Kafka offset strategy is chosen$$ *($$int$$, default: `1`)*
 $$kafkaOffsetTopicRetentionTime$$:: $$retention time for dead records (tombstones), if Kafka offset strategy is chosen$$ *($$int$$, default: `60000`)*
 $$kafkaOffsetTopicSegmentSize$$:: $$segment size of the offset topic, if Kafka offset strategy is chosen$$ *($$int$$, default: `262144000`)*
-$$offsetStorage$$:: $$strategy for persisting offset values$$ *($$OffsetStorageStrategy$$, default: `kafka_native`, possible values: `inmemory,redis,kafka,kafka_native`)*
+$$offsetStorage$$:: $$strategy for persisting offset values$$ *($$OffsetStorageStrategy$$, default: `kafkaNative`, possible values: `inmemory,redis,kafka,kafkaNative`)*
 $$offsetUpdateCount$$:: $$frequency, in number of messages, with which offsets are persisted, per concurrent processor, mutually exclusive with the time-based offset update option (use 0 to disable either)$$ *($$int$$, default: `0`)*
 $$offsetUpdateShutdownTimeout$$:: $$timeout for ensuring that all offsets have been written, on shutdown$$ *($$int$$, default: `2000`)*
 $$offsetUpdateTimeWindow$$:: $$frequency (in milliseconds) with which offsets are persisted mutually exclusive with the count-based offset update option (use 0 to disable either)$$ *($$int$$, default: `10000`)*


### PR DESCRIPTION
* Upgrade to Spring Integration Kafka 1.3.0.RELEASE and Kafka 0.8.2.2
* Add an option for native offset management for Kafka sources and make it the default
* Add native offset management support to Kafka message bus, make it configurable and default