### PR TITLE
[Sprint 61] XD-3702 Allow partitioning with count=1 for Kafka

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/StreamRuntimePropertiesProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/StreamRuntimePropertiesProvider.java
@@ -16,17 +16,15 @@
 
 package org.springframework.xd.dirt.server.admin.deployment;
 
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.springframework.util.Assert;
 import org.springframework.xd.dirt.core.Stream;
 import org.springframework.xd.dirt.integration.bus.BusProperties;
 import org.springframework.xd.module.ModuleDeploymentProperties;
 import org.springframework.xd.module.ModuleDescriptor;
 import org.springframework.xd.module.RuntimeModuleDeploymentProperties;
+
+import java.util.List;
 
 
 /**
@@ -104,13 +102,7 @@ public class StreamRuntimePropertiesProvider extends RuntimeModuleDeploymentProp
 
 		// Partitioning
 		if (hasPartitionKeyProperty(properties)) {
-			// validate next module count if the stream is partitioned
-			try {
-				ModuleDeploymentProperties nextProperties =
-						deploymentPropertiesProvider.propertiesForDescriptor(streamModules.get(moduleIndex + 1));
-				validateCountPropertyForPartitioning(nextProperties.get(ModuleDeploymentProperties.COUNT_KEY), moduleDescriptor);
-			}
-			catch (IndexOutOfBoundsException e) {
+			if (moduleIndex == streamModules.size() && !isNamedChannelOutput(moduleDescriptor)) {
 				logger.warn("Module '{}' is a sink module which contains a property " +
 								"of '{}' used for data partitioning; this feature is only " +
 								"supported for modules that produce data", moduleDescriptor,
@@ -119,8 +111,8 @@ public class StreamRuntimePropertiesProvider extends RuntimeModuleDeploymentProp
 		}
 		else if (moduleIndex + 1 < streamModules.size()) {
 			// check for direct binding if the module is neither last nor partitioned
-			ModuleDeploymentProperties nextProperties
-					= deploymentPropertiesProvider.propertiesForDescriptor(streamModules.get(moduleIndex + 1));
+			ModuleDeploymentProperties nextProperties =
+					deploymentPropertiesProvider.propertiesForDescriptor(streamModules.get(moduleIndex + 1));
 			/*
 			 *  A direct binding is allowed if all of the following are true:
 			 *  1. the user did not explicitly disallow direct binding
@@ -157,6 +149,13 @@ public class StreamRuntimePropertiesProvider extends RuntimeModuleDeploymentProp
 					|| sourceChannelName.startsWith("queue:"));
 	}
 
+	private boolean isNamedChannelOutput(ModuleDescriptor moduleDescriptor) {
+		String sinkChannelName = moduleDescriptor.getSinkChannelName();
+		return sinkChannelName != null
+				&& (sinkChannelName.startsWith("topic:")
+				|| sinkChannelName.startsWith("queue:"));
+	}
+
 	/**
 	 * Return {@code true} if the provided properties include a property
 	 * used to extract a partition key.
@@ -168,32 +167,4 @@ public class StreamRuntimePropertiesProvider extends RuntimeModuleDeploymentProp
 		return (properties.containsKey("producer.partitionKeyExpression")
 				|| properties.containsKey("producer.partitionKeyExtractorClass"));
 	}
-
-	/**
-	 * Validate the value of {@code count} for the purposes of partitioning.
-	 * The value of the string must consist of an integer > 1.
-	 *
-	 * @param count       value to validate
-	 * @param descriptor  module descriptor this {@code count} property
-	 *                    is associated with
-	 *
-	 * @throws IllegalArgumentException if the value of the string
-	 *         does not consist of an integer > 1
-	 */
-	private void validateCountPropertyForPartitioning(String count, ModuleDescriptor descriptor) {
-		Assert.hasText(count, String.format("'count' property is required " +
-				"in properties for module '%s' in order to support partitioning", descriptor));
-
-		try {
-			Assert.isTrue(Integer.parseInt(count) > 1,
-					String.format("'count' property for module '%s' must contain an " +
-							"integer > 1, current value is '%s'", descriptor, count));
-		}
-		catch (NumberFormatException e) {
-			throw new IllegalArgumentException(String.format("'count' property for " +
-					"module %s does not contain a valid integer, current value is '%s'",
-					descriptor, count));
-		}
-	}
-
 }

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionCapableBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionCapableBusTests.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
@@ -244,6 +245,26 @@ abstract public class PartitionCapableBusTests extends BrokerBusTests {
 
 		bus.unbindConsumers("partJ.0");
 		bus.unbindProducers("partJ.0");
+	}
+
+
+	@Test
+	public void testPartitioningWithSingleReceiver() throws Exception {
+		MessageBus bus = getMessageBus();
+		Properties properties = new Properties();
+		properties.put("partitionKeyExtractorClass", "org.springframework.xd.dirt.integration.bus.PartitionTestSupport");
+		properties.put("partitionSelectorClass", "org.springframework.xd.dirt.integration.bus.PartitionTestSupport");
+		try {
+			DirectChannel output = new DirectChannel();
+			output.setBeanName("test.output");
+			bus.bindProducer("partK.0", output, properties);
+			fail();
+		}
+		catch (IllegalArgumentException e) {
+			assertThat(e.getMessage(), Matchers.equalTo(bus.getClass().getSimpleName().replace("Test", "")
+							+ " requires partitioned data to be sent to a module having 'count' > 1 for 'partK.0'"));
+		}
+
 	}
 
 	/**

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
@@ -19,6 +19,7 @@ package org.springframework.xd.dirt.integration.bus.kafka;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -27,21 +28,17 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
-
+import kafka.admin.AdminUtils$;
 import org.hamcrest.CoreMatchers;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.channel.interceptor.WireTap;
 import org.springframework.integration.endpoint.AbstractEndpoint;
+import org.springframework.integration.kafka.support.KafkaHeaders;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
@@ -51,6 +48,11 @@ import org.springframework.xd.dirt.integration.bus.BusProperties;
 import org.springframework.xd.dirt.integration.bus.MessageBus;
 import org.springframework.xd.dirt.integration.bus.XdHeaders;
 import org.springframework.xd.dirt.integration.kafka.KafkaMessageBus;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
 
 /**
  * @author Marius Bogoevici
@@ -182,6 +184,48 @@ public class RawModeKafkaMessageBusTests extends KafkaMessageBusTests {
 
 		bus.unbindConsumers("part.0");
 		bus.unbindProducers("part.0");
+	}
+
+	@Test
+	@Override
+	@SuppressWarnings("unchecked")
+	public void testPartitioningWithSingleReceiver() throws Exception {
+		MessageBus bus = getMessageBus();
+		String topicName = "foo" + System.currentTimeMillis() + ".0";
+		try {
+			byte partitionCount = 4;
+			Properties properties = new Properties();
+			properties.put("partitionKeyExpression", "payload[0]");
+			properties.put("partitionSelectorExpression", "hashCode()");
+			properties.put(BusProperties.MIN_PARTITION_COUNT, Integer.toString(partitionCount));
+			DirectChannel moduleOutputChannel = new DirectChannel();
+			QueueChannel moduleInputChannel = new QueueChannel();
+			bus.bindProducer(topicName, moduleOutputChannel, properties);
+			bus.bindConsumer(topicName, moduleInputChannel, null);
+			int totalSent = 0;
+			for (byte i = 0; i < partitionCount; i++) {
+				for (byte j = 0; j < partitionCount + 1; j++ ) {
+					// the distribution is uneven across partitions, so that we can verify that the bus doesn't round robin
+					moduleOutputChannel.send(new GenericMessage<>(new byte[] { (byte) (i * partitionCount + j) }));
+					totalSent ++;
+				}
+			}
+			List<Message<byte[]>> receivedMessages = new ArrayList<>();
+			for (int i = 0; i < totalSent; i++) {
+				assertTrue(receivedMessages.add((Message<byte[]>) moduleInputChannel.receive(2000)));
+			}
+
+			assertThat(receivedMessages, hasSize(totalSent));
+			for (Message<byte[]> receivedMessage : receivedMessages) {
+				int expectedPartition = receivedMessage.getPayload()[0] % partitionCount;
+				assertThat(expectedPartition, equalTo(receivedMessage.getHeaders().get(KafkaHeaders.PARTITION_ID)));
+			}
+		}
+		finally {
+			bus.unbindConsumers(topicName);
+			bus.unbindProducers(topicName);
+			AdminUtils$.MODULE$.deleteTopic(kafkaTestSupport.getZkClient(),topicName);
+		}
 	}
 
 	@Test

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitMessageBusTests.java
@@ -219,7 +219,7 @@ public class RabbitMessageBusTests extends PartitionCapableBusTests {
 		properties.put("partitionKeyExtractorClass", "foo");
 		properties.put("partitionSelectorExpression", "0");
 		properties.put("partitionSelectorClass", "foo");
-		properties.put(BusProperties.NEXT_MODULE_COUNT, "1");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "2");
 
 		bus.bindProducer("props.0", new DirectChannel(), properties);
 		assertEquals(1, bindings.size());

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
@@ -164,7 +164,7 @@ public class RedisMessageBusTests extends PartitionCapableBusTests {
 		properties.put("partitionKeyExtractorClass", "foo");
 		properties.put("partitionSelectorExpression", "0");
 		properties.put("partitionSelectorClass", "foo");
-		properties.put(BusProperties.NEXT_MODULE_COUNT, "1");
+		properties.put(BusProperties.NEXT_MODULE_COUNT, "2");
 
 		bus.bindProducer("props.0", new DirectChannel(), properties);
 		assertEquals(1, bindings.size());

--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -422,12 +422,12 @@ public class KafkaMessageBus extends MessageBusSupport implements DisposableBean
 	public boolean isCapable(Capability capability) {
 		switch (capability) {
 		case DURABLE_PUBSUB:
+		case NATIVE_PARTITIONING:
 			return true;
 		default:
 			return false;
 		}
 	}
-
 
 	/**
 	 * Allowed chars are ASCII alphanumerics, '.', '_' and '-'. '_' is used as escaped char in the form '_xx' where xx

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBus.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBus.java
@@ -151,8 +151,14 @@ public interface MessageBus {
 		 * When a bus supports durable subscriptions to a pub/sub channel, the stream
 		 * name will be included in the consumer name.
 		 */
-		DURABLE_PUBSUB
+		DURABLE_PUBSUB,
 
+		/**
+		 * When a bus supports partitioning natively, then a partitioning strategy can
+		 * be provided for any kind of producer, regardless on the count of downstream
+		 * consumers
+		 */
+		NATIVE_PARTITIONING
 	}
 
 }


### PR DESCRIPTION
* Move validation of partitioning and count properties from runtime
property population to the message bus;
* Introduce Capability for transports that support native partitioning
(i.e. Kafka)
* Allow partitioning for Kafka even for `count`=1 consumers and named queues
* Maintain restriction for Redis and Rabbit
* Add tests