### PR TITLE
XD-3716: Rabbit Bus - Configurable longStringLimit

### DIFF
--- a/config/servers.yml
+++ b/config/servers.yml
@@ -25,6 +25,9 @@
 #      compressionLevel:            1
             # bus-level property, applies only when 'compress=true' for a stream module
             # See java.util.zip.Deflater; 1=BEST_SPEED, 9=BEST_COMPRESSION, ...
+#      longStringLimit:             8192
+#            # Headers longer than this will not be converted to String and will be a
+#            # DataInputStream - such headers will NOT be properly converted back on output.
 #      default:
 #        ackMode:                   AUTO
             # Valid: AUTO (container acks), NONE (broker acks), MANUAL (consumer acks).

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -109,6 +109,9 @@ xd:
       compressionLevel:            1
             # bus-level property, applies only when 'compress=true' for a stream module
             # See java.util.zip.Deflater; 1=BEST_SPEED, 9=BEST_COMPRESSION, ...
+      longStringLimit:             8192
+            # Headers longer than this will not be converted to String and will be a
+            # DataInputStream - such headers will NOT be properly converted back on output.
       default:
         ackMode:                   AUTO
             # Valid: AUTO (container acks), NONE (broker acks), MANUAL (consumer acks).
@@ -314,7 +317,7 @@ security:
 
 
 # Profile specific documents below
---- 
+---
 spring:
   profiles: rabbit
 transport: rabbit

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitTestMessageBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@
 
 package org.springframework.xd.dirt.integration.bus.rabbit;
 
+import static org.junit.Assert.assertEquals;
+
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.integration.codec.Codec;
 import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.xd.dirt.integration.bus.AbstractTestMessageBus;
 import org.springframework.xd.dirt.integration.rabbit.RabbitMessageBus;
@@ -49,7 +52,9 @@ public class RabbitTestMessageBus extends AbstractTestMessageBus<RabbitMessageBu
 		context.getBeanFactory().registerSingleton(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, scheduler);
 		context.refresh();
 		messageBus.setApplicationContext(context);
+		messageBus.setLongStringLimit(8193);
 		this.setMessageBus(messageBus);
+		assertEquals(8193, TestUtils.getPropertyValue(messageBus, "inboundMessagePropertiesConverter.longStringLimit"));
 		this.rabbitAdmin = new RabbitAdmin(connectionFactory);
 	}
 

--- a/spring-xd-messagebus-rabbit/src/main/resources/META-INF/spring-xd/bus/rabbit-bus.xml
+++ b/spring-xd-messagebus-rabbit/src/main/resources/META-INF/spring-xd/bus/rabbit-bus.xml
@@ -51,6 +51,7 @@
 		<property name="vhost" value="${spring.rabbitmq.virtual_host:}" />
 		<property name="useSSL" value="${spring.rabbitmq.useSSL:false}" />
 		<property name="sslPropertiesLocation" value="${spring.rabbitmq.sslProperties:}" />
+		<property name="longStringLimit" value="${xd.messagebus.rabbit.longStringLimit}" />
 	</bean>
 
 </beans>

--- a/src/docs/asciidoc/Application-Configuration.asciidoc
+++ b/src/docs/asciidoc/Application-Configuration.asciidoc
@@ -45,7 +45,7 @@ You may also put multiple profile specific configuration in a single `servers.ym
 
 Spring XD saves the state of the batch job workflows in a relational database.  When running `xd-singlenode` an embedded HSQLDB database instance is started automatically. When running in distributed mode a standalone HSQLDB instance can be used. A startup script `hsqldb-server` is provided in the installation directory under the folder `hsqldb/bin`.  It is recommended to use HSQLDB only for development and learning.
 
-When deploying in a production environment, you will need to select another database.  Spring XD is primarily tested on HSQLDB, MySql and Postgres but Apache Derby and Oracle are supported as well. All batch workflow tables are automatically created, if they do not exist, when you use HSQLDB, MySQL, Postgres, Apache Derby or Oracle.  The JDBC driver jars for HSQLDB and Postgres are already on the XD classpath. If you use MySQL, Apache Derby or Oracle for your batch repository database, then you would need to copy the corresponding JDBC jar into the `lib` directory under `$XD_HOME` (`$XD_HOME/lib`) before starting Spring XD. 
+When deploying in a production environment, you will need to select another database.  Spring XD is primarily tested on HSQLDB, MySql and Postgres but Apache Derby and Oracle are supported as well. All batch workflow tables are automatically created, if they do not exist, when you use HSQLDB, MySQL, Postgres, Apache Derby or Oracle.  The JDBC driver jars for HSQLDB and Postgres are already on the XD classpath. If you use MySQL, Apache Derby or Oracle for your batch repository database, then you would need to copy the corresponding JDBC jar into the `lib` directory under `$XD_HOME` (`$XD_HOME/lib`) before starting Spring XD.
 
 NOTE: If you access any database other than HSQLDB or Postgres in a stream module then the JDBC driver jar for that database needs to be present in the `$XD_HOME/lib` directory.
 
@@ -232,77 +232,83 @@ In addition, the following default settings for the rabbit message bus can be mo
 ----
   messagebus:
     rabbit:
-      compressionLevel             1     # <1>
+      compressionLevel:            1     # <1>
+      longStringLimit:             8192  # <2>
       default:
-        ackMode:                   AUTO  # <2>
-        autoBindDLQ:               false # <3>
-        backOffInitialInterval:    1000  # <4>
-        backOffMaxInterval:        10000 # <5>
-        backOffMultiplier:         2.0   # <6>
-        batchBufferLimit:          10000 # <7>
-        batchingEnabled:           false # <8>
-        batchSize:                 100   # <9>
-        batchTimeout:              5000  # <10>
-        compress:                  false # <11>
-        concurrency:               1     # <12>
-        durableSubscription:       false # <13>
-        maxAttempts:               3     # <14>
-        maxConcurrency:            1     # <15>
-        prefix:                    xdbus. # <16>
-        prefetch:                  1     # <17>
-        replyHeaderPatterns:       STANDARD_REPLY_HEADERS,*   # <18>
-        republishToDLQ             false # <19>
-        requestHeaderPatterns:     STANDARD_REQUEST_HEADERS,* # <20>
-        requeue:                   true  # <21>
-        transacted:                false # <22>
-        txSize:                    1     # <23>
+        ackMode:                   AUTO  # <3>
+        autoBindDLQ:               false # <4>
+        backOffInitialInterval:    1000  # <5>
+        backOffMaxInterval:        10000 # <6>
+        backOffMultiplier:         2.0   # <7>
+        batchBufferLimit:          10000 # <8>
+        batchingEnabled:           false # <9>
+        batchSize:                 100   # <10>
+        batchTimeout:              5000  # <11>
+        compress:                  false # <12>
+        concurrency:               1     # <13>
+        durableSubscription:       false # <14>
+        maxAttempts:               3     # <15>
+        maxConcurrency:            1     # <16>
+        prefix:                    xdbus. # <17>
+        prefetch:                  1     # <18>
+        replyHeaderPatterns:       STANDARD_REPLY_HEADERS,*   # <19>
+        republishToDLQ:            false # <20>
+        requestHeaderPatterns:     STANDARD_REQUEST_HEADERS,* # <21>
+        requeue:                   true  # <22>
+        transacted:                false # <23>
+        txSize:                    1     # <24>
 ----
 <1> When the bus (or a stream module deployment) is configured to compress messages, specifies the compression level. See _java.uti.zip.Deflater_ for available values; defaults to 1 (BEST_SPEED)
 
-<2> AUTO (container acks), NONE (broker acks), MANUAL (consumer acks). Upper case only. Note: MANUAL requires specialized code in the consuming module and is unlikely to be used in an XD application. For more information, see http://docs.spring.io/spring-integration/reference/html/amqp.html#amqp-inbound-ack
+<2> RabbitMQ headers longer than this value are not converted to `String`; instead they are made available as a
+`DataInputStream`; these are currently not properly re-converted during output conversion.
+If you expect headers longer than this, increase this setting appropriately if you wish them to pass to downstream
+modules.
 
-<3> When true, the bus will automatically declare dead letter queues and binding for each bus queue. The user is responsible for setting a policy on the broker to enable dead-lettering; see xref:MessageBus#error-handling-message-delivery-failures[Message Bus Configuration] for more information. The bus will configure a dead-letter-exchange (`<prefix>DLX`) and bind a queue with the name `<original queue name>.dlq` and route using the original queue name
+<3> AUTO (container acks), NONE (broker acks), MANUAL (consumer acks). Upper case only. Note: MANUAL requires specialized code in the consuming module and is unlikely to be used in an XD application. For more information, see http://docs.spring.io/spring-integration/reference/html/amqp.html#amqp-inbound-ack
 
-<4> The time in milliseconds before retrying a failed message delivery
+<4> When true, the bus will automatically declare dead letter queues and binding for each bus queue. The user is responsible for setting a policy on the broker to enable dead-lettering; see xref:MessageBus#error-handling-message-delivery-failures[Message Bus Configuration] for more information. The bus will configure a dead-letter-exchange (`<prefix>DLX`) and bind a queue with the name `<original queue name>.dlq` and route using the original queue name
 
-<5> The maximum time (ms) to wait between retries
+<5> The time in milliseconds before retrying a failed message delivery
 
-<6> The back off multiplier (previous interval x multiplier = next interval)
+<6> The maximum time (ms) to wait between retries
 
-<7> When batching is enabled, the size of the buffer that will cause a batch to be released (overrides _batchSize_)
+<7> The back off multiplier (previous interval x multiplier = next interval)
 
-<8> True to enable message batching by producers
+<8> When batching is enabled, the size of the buffer that will cause a batch to be released (overrides _batchSize_)
 
-<9> The number of messages in a batch (may be preempted by _batchBufferLimit_ or _batchTimeout_)
+<9> True to enable message batching by producers
 
-<10> The idle time to wait before sending a partial batch
+<10> The number of messages in a batch (may be preempted by _batchBufferLimit_ or _batchTimeout_)
 
-<11> True to enable message compression - also see (1. bus _compressionLevel_)
+<11> The idle time to wait before sending a partial batch
 
-<12> The minimum number of consumer threads receiving messages for a module
+<12> True to enable message compression - also see (1. bus _compressionLevel_)
 
-<13> When `true` queues for subscriptions to publish/subscribe named channels (`tap:`, `topic:`) will be declared as durable and are eligible for dead-letter configuration according to the `autoBindDLQ` setting.
+<13> The minimum number of consumer threads receiving messages for a module
 
-<14> The maximum number of delivery attempts. Setting this to `1` disables the retry mechanism and `requeue` must be set to false if you wish failed messages to be rejected or routed to a DLQ. Otherwise deliveries
+<14> When `true` queues for subscriptions to publish/subscribe named channels (`tap:`, `topic:`) will be declared as durable and are eligible for dead-letter configuration according to the `autoBindDLQ` setting.
+
+<15> The maximum number of delivery attempts. Setting this to `1` disables the retry mechanism and `requeue` must be set to false if you wish failed messages to be rejected or routed to a DLQ. Otherwise deliveries
 will be attempted repeatedly, with no termination. Also see `republishToDLQ`
 
-<15> The maximum number of consumer threads receiving messages for a module
+<16> The maximum number of consumer threads receiving messages for a module
 
-<16> A prefix applied to all queues, exchanges so that policies (HA etc) can be applied
+<17> A prefix applied to all queues, exchanges so that policies (HA etc) can be applied
 
-<17> The number of messages to prefetch for each consumer
+<18> The number of messages to prefetch for each consumer
 
-<18> Determines which reply headers will be transported
+<19> Determines which reply headers will be transported
 
-<19> By default, failed messages after retries are exhausted are rejected. If a dead-letter queue (DLQ) is configured, rabbitmq will route the failed message (unchanged) to the DLQ. Setting this property to `true` instructs the bus to republish failed messages to the DLQ, with additional headers, including the exception message and stack trace from the cause of the final failure. Note that the republish will occur even if `maxAttempts` is only set to `1`. Also see `autoBindDLQ`
+<20> By default, failed messages after retries are exhausted are rejected. If a dead-letter queue (DLQ) is configured, rabbitmq will route the failed message (unchanged) to the DLQ. Setting this property to `true` instructs the bus to republish failed messages to the DLQ, with additional headers, including the exception message and stack trace from the cause of the final failure. Note that the republish will occur even if `maxAttempts` is only set to `1`. Also see `autoBindDLQ`
 
-<20> Determines which request headers will be transported
+<21> Determines which request headers will be transported
 
-<21> Whether rejected messages will be requeued by default
+<22> Whether rejected messages will be requeued by default
 
-<22> Whether the channel is to be transacted
+<23> Whether the channel is to be transacted
 
-<23> The number of messages to process between acks (when ack mode is AUTO).
+<24> The number of messages to process between acks (when ack mode is AUTO).
 
 [[kafka-configuration]]
 ==== Kafka


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-3716

The `longStringLimit` property determines when long
headers are converted to `String` Vs. `DataInputStream`.

The latter is not (currently) property converted on output.

https://jira.spring.io/browse/AMQP-568