### PR TITLE
XD-3739: Fix and Configure Script Refresh

### DIFF
--- a/modules/processor/filter/config/filter.xml
+++ b/modules/processor/filter/config/filter.xml
@@ -22,7 +22,8 @@
 	<filter input-channel="to.spel" expression="${expression:true}" output-channel="output"/>
 
 	<filter input-channel="to.script" output-channel="output">
-		<int-groovy:script location="${script:filter.groovy}" script-variable-generator="variableGenerator" refresh-check-delay="60"/>
+		<int-groovy:script location="${script:filter.groovy}" script-variable-generator="variableGenerator"
+						refresh-check-delay="${refreshDelay}"/>
 	</filter>
 
 	<channel id="output"/>

--- a/modules/processor/script/config/script.xml
+++ b/modules/processor/script/config/script.xml
@@ -15,7 +15,8 @@
 	<channel id="input" />
 
 	<service-activator output-channel="output" input-channel="input">
-		<int-groovy:script location="${script}" script-variable-generator="variableGenerator" refresh-check-delay="60"/>
+		<int-groovy:script location="${script}" script-variable-generator="variableGenerator"
+								refresh-check-delay="${refreshDelay}"/>
 	</service-activator>
 
 	<channel id="output" />

--- a/modules/processor/transform/config/transform.xml
+++ b/modules/processor/transform/config/transform.xml
@@ -23,7 +23,7 @@
 		<beans:import resource="../../../common/script-variable-generator.xml" />
 		<transformer input-channel="input" output-channel="output">
 			<int-groovy:script location="${script}"
-				script-variable-generator="variableGenerator" refresh-check-delay="60" />
+				script-variable-generator="variableGenerator" refresh-check-delay="${refreshDelay}" />
 		</transformer>
 	</beans:beans>
 

--- a/modules/sink/router/config/router.xml
+++ b/modules/sink/router/config/router.xml
@@ -22,7 +22,8 @@
 	<beans:beans profile="use-script">
 		<beans:import resource="../../../common/script-variable-generator.xml"/>
 		<router input-channel="input" resolution-required="false" default-output-channel="nullChannel">
-			<int-groovy:script location="${script}" script-variable-generator="variableGenerator" refresh-check-delay="60"/>
+			<int-groovy:script location="${script}" script-variable-generator="variableGenerator"
+						refresh-check-delay="${refreshDelay}"/>
 		</router>
 	</beans:beans>
 

--- a/modules/source/tcp-client/config/tcp-client.xml
+++ b/modules/source/tcp-client/config/tcp-client.xml
@@ -12,7 +12,7 @@
 		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
 	<import resource="../../../common/tcp-encdec.xml"/>
-	
+
 	<int-ip:tcp-connection-factory id="connectionFactory"
 		type="client"
 		host="${host}"
@@ -34,7 +34,7 @@
 	<int:inbound-channel-adapter channel="commandsTrigger" expression="@counter.incrementAndGet()" auto-startup="false">
 		<int:poller fixed-delay="${fixedDelay}" time-unit="SECONDS" max-messages-per-poll="${maxMessages}" />
 	</int:inbound-channel-adapter>
-	
+
 
 	<int:channel id="commands" />
 
@@ -44,11 +44,12 @@
 		connection-factory="connectionFactory" client-mode="true" channel="output" />
 
 	<int:channel id="output"/>
-	
+
 	<beans profile="use-script">
 		<import resource="../../../common/script-variable-generator.xml" />
 		<int:transformer input-channel="commandsTrigger" output-channel="commands">
-			<int-groovy:script location="${script}" script-variable-generator="variableGenerator" refresh-check-delay="60"/>
+			<int-groovy:script location="${script}" script-variable-generator="variableGenerator"
+							refresh-check-delay="${refreshDelay}"/>
 		</int:transformer>
 	</beans>
 	<beans profile="use-expression">

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/ScriptMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/ScriptMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * </ul>
  *
  * @author David Turanski
+ * @author Gary Russell
  */
 public class ScriptMixin {
 
@@ -40,6 +41,8 @@ public class ScriptMixin {
 	private String propertiesLocation;
 
 	private String variables;
+
+	private long refreshDelay = 60000;
 
 	public String getVariables() {
 		return variables;
@@ -68,12 +71,22 @@ public class ScriptMixin {
 		this.variables = variables;
 	}
 
+
+	public long getRefreshDelay() {
+		return refreshDelay;
+	}
+
+	@ModuleOption("how often to check (in milliseconds) whether the script has changed; -1 for never")
+	public void setRefreshDelay(long refreshDelay) {
+		this.refreshDelay = refreshDelay;
+	}
+
 	/**
 	 *
 	 * Validates the configuration meets expected conditions. Subclasses may override validation rules.
 	 * @return true if configuration is valid.
 	 */
-	@AssertTrue(message="'script' cannot be null or empty") //Allows subclasses to override 'script' is required.
+	@AssertTrue(message = "'script' cannot be null or empty") //Allows subclasses to override 'script' is required.
 	public boolean isValid() {
 		return StringUtils.hasText(script);
 	}

--- a/src/docs/asciidoc/Processors.asciidoc
+++ b/src/docs/asciidoc/Processors.asciidoc
@@ -76,6 +76,7 @@ The **$$filter$$** $$processor$$ has the following options:
 
 $$expression$$:: $$a SpEL expression used to transform messages$$ *($$String$$, default: `payload.toString()`)*
 $$propertiesLocation$$:: $$the path of a properties file containing custom script variable bindings$$ *($$String$$, no default)*
+$$refreshDelay$$:: $$how often to check (in milliseconds) whether the script has changed; -1 for never$$ *($$long$$, default: `60000`)*
 $$script$$:: $$reference to a script used to process messages$$ *($$String$$, no default)*
 $$variables$$:: $$variable bindings as a comma delimited string of name-value pairs, e.g., 'foo=bar,baz=car'$$ *($$String$$, no default)*
 //$processor.filter
@@ -164,7 +165,9 @@ Created and deployed new stream 'groovyfiltertest2'
 
 Note the last example demonstrates that values specified in _variables_ override values from _propertiesLocation_
 
-TIP: The script is checked for updates every 60 seconds, so it may be replaced in a running system.
+TIP: The script file's modified timestamp is checked for changes every 60 seconds by default; this can be changed with
+the `refreshDelay` deployment property: `--refreshDelay=30000` (every 30 seconds or 30,000ms), `--refreshDelay=-1` to
+disable refresh.
 
 [[header-enricher]]
 === Header Enricher (`header-enricher`)
@@ -179,11 +182,11 @@ A Simple SpEL expression
 ----
 xd:>stream create t1 --definition "http | header-enricher --headers={\"foo\":\"payload.toUpperCase()\"} | log --expression=headers" --deploy
 xd:>http post --data hello --target http://localhost:9000
----- 
-  
+----
+
 You should see the message headers, including **foo=HELLO** in the container console log:
 
-----  
+----
 2015-05-24T11:40:40-0400 1.2.0.SNAP INFO pool-12-thread-4 sink.t1 - {requestMethod=POST, foo=HELLO, User-Agent=Java/1.8.0_25, Host=localhost:9000, id=f6b2c420-cd12-2d5e-e0cb-675f60fb9a63, Content-Length=5, contentType=text/plain;Charset=UTF-8, requestPath=/, timestamp=1432482040939}
 ----
 
@@ -192,28 +195,28 @@ Multiple Headers: This will add 2 headers, **foo** and **bar**
 ----
 xd:> stream create t2 --definition "http | header-enricher --headers={\"foo\":\"payload.toUpperCase()\",\"bar\":\"payload+',world'\"} | log --expression=headers" --deploy
 xd:>http post --data hello --target http://localhost:9000
-----    
+----
 
 The result:
 
 ----
 2015-05-24T11:49:19-0400 1.2.0.SNAP INFO pool-27-thread-4 sink.t2 - {bar=hello,world, requestMethod=POST, foo=HELLO, User-Agent=Java/1.8.0_25, Host=localhost:9000, id=c9220992-f71c-db3f-0f22-b5ab262d4aee, Content-Length=5, contentType=text/plain;Charset=UTF-8, requestPath=/, timestamp=1432482559740}
-----    
+----
 
 JSON Path expressions: This example uses a JSON Path expression to extract a field value in a JSON Payload:
 
 ----
 xd:>stream create t3 --definition "http | header-enricher --headers={\"foo\":\"#jsonPath(payload,'$.duration')\"} | log --expression=headers" --deploy
-xd:>http post --data {"duration":123.45} --target http://localhost:9000		
+xd:>http post --data {"duration":123.45} --target http://localhost:9000
 ----
-		
+
 **foo=123.45** !!
 
 ----
 2015-05-24T11:45:16-0400 1.2.0.SNAP INFO pool-23-thread-4 sink.t3 - {requestMethod=POST, foo=123.45, User-Agent=Java/1.8.0_25, Host=localhost:9000, id=87d229b9-a434-31c2-eb35-b42ca3f8352a, Content-Length=19, contentType=text/plain;Charset=UTF-8, requestPath=/, timestamp=1432482316080}
 ----
 
-Literal Strings with Embedded Spaces: SpEL expects literals to be enclosed in single quotes. This is straight forward when the literal does not contain embedded spaces as in the `Multple Headers` example above. Using embedded spaces requires either 
+Literal Strings with Embedded Spaces: SpEL expects literals to be enclosed in single quotes. This is straight forward when the literal does not contain embedded spaces as in the `Multple Headers` example above. Using embedded spaces requires either
 wrapping the `headers` value in single quotes and escaping the single quote for the literal string
 
 ----
@@ -228,7 +231,7 @@ xd:>stream create t4 --definition "http | header-enricher --headers={\"foo\":\"'
 
 the result:
 
-----    
+----
 2015-05-24T12:26:32-0400 1.2.0.SNAP INFO pool-31-thread-4 sink.t4 - {requestMethod=POST, foo=this is a literal string, User-Agent=Java/1.8.0_25, Host=localhost:9000, id=b8892a1b-57b1-de6e-71de-e30f84cd199a, Content-Length=5, contentType=text/plain;Charset=UTF-8, requestPath=/, timestamp=1432484792949}
 ----
 
@@ -330,6 +333,7 @@ The script processor contains a _Service Activator_ that invokes a specified Gro
 The **$$script$$** $$processor$$ has the following options:
 
 $$propertiesLocation$$:: $$the path of a properties file containing custom script variable bindings$$ *($$String$$, no default)*
+$$refreshDelay$$:: $$how often to check (in milliseconds) whether the script has changed; -1 for never$$ *($$long$$, default: `60000`)*
 $$script$$:: $$reference to a script used to process messages$$ *($$String$$, no default)*
 $$variables$$:: $$variable bindings as a comma delimited string of name-value pairs, e.g., 'foo=bar,baz=car'$$ *($$String$$, no default)*
 //$processor.script
@@ -346,7 +350,9 @@ xd:> stream create --name groovyprocessortest --definition "http --port=9006 | s
 
 By default, Spring XD will search the classpath for _custom-processor.groovy_ and _custom-processor.properties_. You can place the script in _${xd.home}/modules/processor/scripts_ and the properties file in _${xd.home}/config_ to make them available on the classpath.  Alternatively, you can prefix the _location_ and _properties-location_ values with _file:_ to load from the file system.
 
-TIP: The script is checked for updates every 60 seconds, so it may be replaced in a running system.
+TIP: The script file's modified timestamp is checked for changes every 60 seconds by default; this can be changed with
+the `refreshDelay` deployment property: `--refreshDelay=30000` (every 30 seconds or 30,000ms), `--refreshDelay=-1` to
+disable refresh.
 
 [[shell]]
 === Shell
@@ -481,6 +487,7 @@ The **$$transform$$** $$processor$$ has the following options:
 
 $$expression$$:: $$a SpEL expression used to transform messages$$ *($$String$$, default: `payload.toString()`)*
 $$propertiesLocation$$:: $$the path of a properties file containing custom script variable bindings$$ *($$String$$, no default)*
+$$refreshDelay$$:: $$how often to check (in milliseconds) whether the script has changed; -1 for never$$ *($$long$$, default: `60000`)*
 $$script$$:: $$reference to a script used to process messages$$ *($$String$$, no default)*
 $$variables$$:: $$variable bindings as a comma delimited string of name-value pairs, e.g., 'foo=bar,baz=car'$$ *($$String$$, no default)*
 //$processor.transform
@@ -509,4 +516,6 @@ xd:> stream create --name groovytransformtest2 --definition "http --port=9004 | 
 
 By default, Spring XD will search the classpath for _custom-transform.groovy_ and _custom-transform.properties_. You can place the script in _${xd.home}/modules/processor/scripts_ and the properties file in _${xd.home}/config_ to make them available on the classpath.  Alternatively, you can prefix the _script_ and _properties-location_ values with _file:_ to load from the file system.
 
-TIP: The script is checked for updates every 60 seconds, so it may be replaced in a running system.
+TIP: The script file's modified timestamp is checked for changes every 60 seconds by default; this can be changed with
+the `refreshDelay` deployment property: `--refreshDelay=30000` (every 30 seconds or 30,000ms), `--refreshDelay=-1` to
+disable refresh.

--- a/src/docs/asciidoc/Sinks.asciidoc
+++ b/src/docs/asciidoc/Sinks.asciidoc
@@ -145,11 +145,14 @@ The **$$router$$** $$sink$$ has the following options:
 
 $$expression$$:: $$a SpEL expression used to transform messages$$ *($$String$$, default: `payload.toString()`)*
 $$propertiesLocation$$:: $$the path of a properties file containing custom script variable bindings$$ *($$String$$, no default)*
+$$refreshDelay$$:: $$how often to check (in milliseconds) whether the script has changed; -1 for never$$ *($$long$$, default: `60000`)*
 $$script$$:: $$reference to a script used to process messages$$ *($$String$$, no default)*
 $$variables$$:: $$variable bindings as a comma delimited string of name-value pairs, e.g., 'foo=bar,baz=car'$$ *($$String$$, no default)*
 //$sink.router
 
-TIP: If the `script` option is set, the script is checked for updates every 60 seconds.
+TIP: If the `script` option is set, the script file's modified timestamp is checked for changes every 60 seconds by
+default; this can be changed with the `refreshDelay` deployment property: `--refreshDelay=30000` (every 30 seconds or
+30,000ms), `--refreshDelay=-1` to disable refresh.
 
 [[file-sink]]
 === File Sink (`file`)
@@ -404,7 +407,7 @@ updated.
 [source,text]
 ----
 # select * from xdsink2;
- col1  | col2 | col3 
+ col1  | col2 | col3
 -------+------+------
  DATA3 | DATA | DATA
  DATA2 | DATA | DATA
@@ -433,7 +436,7 @@ updated.
 [source,text]
 ----
 # select * from xdsink2;
- col1  | col2  | col3  
+ col1  | col2  | col3
 -------+-------+-------
  DATA3 | DATA  | DATA
  DATA2 | DATA  | DATA
@@ -534,7 +537,7 @@ $$updateColumns$$:: $$update columns with update$$ *($$String$$, no default)*
 //$sink.gpfdist
 
 [[cassandra]]
-=== Cassandra 
+=== Cassandra
 
 The Cassandra sink write into a Cassandra table.  Here is a simple example
 

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -1129,6 +1129,7 @@ $$maxMessages$$:: $$the maximum messages per poll; -1 for unlimited$$ *($$long$$
 $$nio$$:: $$whether or not to use NIO$$ *($$boolean$$, default: `false`)*
 $$port$$:: $$the port on the remote host to connect to$$ *($$int$$, default: `1234`)*
 $$propertiesLocation$$:: $$the path of a properties file containing custom script variable bindings$$ *($$String$$, no default)*
+$$refreshDelay$$:: $$how often to check (in milliseconds) whether the script has changed; -1 for never$$ *($$long$$, default: `60000`)*
 $$reverseLookup$$:: $$perform a reverse DNS lookup on the remote IP Address$$ *($$boolean$$, default: `false`)*
 $$script$$:: $$reference to a script used to process messages$$ *($$String$$, no default)*
 $$socketTimeout$$:: $$the timeout (ms) before closing the socket when no data is received$$ *($$int$$, default: `120000`)*
@@ -1161,6 +1162,9 @@ else
 
 ----
 
+TIP: If the `script` option is set, the script file's modified timestamp is checked for changes every 60 seconds by
+default; this can be changed with the `refreshDelay` deployment property: `--refreshDelay=30000` (every 30 seconds or
+30,000ms), `--refreshDelay=-1` to disable refresh.
 
 [[time]]
 === Time


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-3739

Scripts were incorrectly checked for changes with a hard-wired 60ms interval
instead of 60 seconds as stated in the reference manual.

Change the default to 60 seconds and make it configurable; `-1` disables refresh.