### PR TITLE
Xd 3742 - Enable in line SSL properties as an alternative to external properties files.

### DIFF
--- a/config/modules/modules.yml
+++ b/config/modules/modules.yml
@@ -33,6 +33,9 @@
 #   - XD_HOME/xd/config/modules/source/rabbit/rabbit.properties
 #   - XD_HOME/xd/config/modules/sink/rabbit/rabbit.properties
 #
+#  NOTE: sslProperties is mutually exclusive with keyStore, keyStorePassphrase, trustStore, trustStorePassphrase.
+#  if you set inline properties, values in the properties file location given by 'sslProperties' will be ignored.
+#
 #rabbit:
 #  addresses: localhost:5672
 #  username: guest
@@ -40,6 +43,11 @@
 #  vhost: /
 #  useSSL: false
 #  sslProperties:
+#  ssl:
+#    keyStore:
+#    keyStorePassphrase:
+#    trustStore:
+#    trustStorePassphrase:
 
 ---
 

--- a/config/modules/sink/rabbit/rabbit.properties
+++ b/config/modules/sink/rabbit/rabbit.properties
@@ -4,7 +4,15 @@
 #password=${rabbit.password:}
 #vhost=${rabbit.vhost:}
 #useSSL=${rabbit.useSSL:}
+#
+#  NOTE: sslProperties is mutually exclusive with keyStore, keyStorePassphrase, trustStore, trustStorePassphrase.
+#  if you set inline properties, values in the properties file location given by 'sslProperties' will be ignored.
+#
 #sslProperties=${rabbit.sslProperties:}
+#keyStore=${rabbit.ssl.keyStore}
+#keyStorePassphrase=${rabbit.ssl.keyStorePassphrase}
+#trustStore=${rabbit.ssl.trustStore}
+#trustStorePassphrase=${rabbit.ssl.trustStorePassphrase}
 
 # Routing properties to send the messages into
 # Exchange name to use

--- a/config/modules/source/http/http.properties
+++ b/config/modules/source/http/http.properties
@@ -1,0 +1,12 @@
+# HTTP(S) source module properties. Requires https=true. Either provide properties inline or use sslPropertiesLocation
+# Note that external properties files cannot contain an encrypted passPhrase.
+#
+#https=true
+sslPropertiesLocation=classpath:httpSSL.properties
+#keyStore=file:/path/to/keystore
+#
+# NOTE: To maintain backward compatibilty, the property name 'keyStore.passPhrase' may be used if using an external properties file,
+# but will not work here.
+#
+#keyStorePassphrase=secret
+

--- a/config/modules/source/rabbit/rabbit.properties
+++ b/config/modules/source/rabbit/rabbit.properties
@@ -4,7 +4,15 @@
 #password=${rabbit.password:}
 #vhost=${rabbit.vhost:}
 #useSSL=${rabbit.useSSL:}
+#
+#  NOTE: sslProperties is mutually exclusive with keyStore, keyStorePassphrase, trustStore, trustStorePassphrase.
+#  if you set inline properties, values in the properties file location given by 'sslProperties' will be ignored.
+#
 #sslProperties=${rabbit.sslProperties:}
+#keyStore=${rabbit.ssl.keyStore}
+#keyStorePassphrase=${rabbit.ssl.keyStorePassphrase}
+#trustStore=${rabbit.ssl.trustStore}
+#trustStorePassphrase=${rabbit.ssl.trustStorePassphrase}
 
 # RabbitMQ queue names (as comma separated strings) that the messages are retrieved from
 #queues=

--- a/config/servers.yml
+++ b/config/servers.yml
@@ -285,6 +285,7 @@ endpoints:
 #  port: 9393
 
 ---
+#  Rabbit MQ Properties
 #
 #  NOTE: sslProperties is mutually exclusive with keyStore, keyStorePassphrase, trustStore, trustStorePassphrase.
 #  if you set inline properties, values in the properties file location given by 'sslProperties' will be ignored.

--- a/config/servers.yml
+++ b/config/servers.yml
@@ -285,7 +285,10 @@ endpoints:
 #  port: 9393
 
 ---
-# RabbitMQ properties
+#
+#  NOTE: sslProperties is mutually exclusive with keyStore, keyStorePassphrase, trustStore, trustStorePassphrase.
+#  if you set inline properties, values in the properties file location given by 'sslProperties' will be ignored.
+#
 #spring:
 #  rabbitmq:
 #   addresses: localhost:5672
@@ -296,6 +299,11 @@ endpoints:
 #   virtual_host: /
 #   useSSL: false
 #   sslProperties:
+#   ssl:
+#     keyStore:
+#     keyStorePassphrase:
+#     trustStore:
+#     trustStorePassphrase:
 
 
 ---

--- a/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
+++ b/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
@@ -82,6 +82,7 @@ import org.springframework.util.StringUtils;
  * @author Jennifer Hickey
  * @author Gary Russell
  * @author Marius Bogoevici
+ * @author David Turanski
  */
 public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 
@@ -110,6 +111,10 @@ public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 	private final int port;
 
 	private final boolean ssl;
+
+	private volatile String keyStore;
+
+	private volatile String keyStorePassphrase;
 
 	private volatile ServerBootstrap bootstrap;
 
@@ -172,6 +177,24 @@ public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 	}
 
 	/**
+	 * Set the keyStore location directly as an alternative to using
+	 * sslPropertiesLocation. If sslPropertiesLocation is set, this value will be ignored.
+	 * @param keyStore
+	 */
+	public void setKeyStore(String keyStore) {
+		this.keyStore = keyStore;
+	}
+
+	/**
+	 * Set the keyStore passphrase directly as an alternative to using
+	 * sslPropertiesLocation. If sslPropertiesLocation is set, this value will be ignored.
+	 * @param keyStorePassphrase
+	 */
+	public void setKeyStorePassphrase(String keyStorePassphrase) {
+		this.keyStorePassphrase = keyStorePassphrase;
+	}
+
+	/**
 	 * Set the max content length; default 1Mb.
 	 * @param maxContentLength the max content length.
 	 */
@@ -213,14 +236,38 @@ public class NettyHttpInboundChannelAdapter extends MessageProducerSupport {
 	}
 
 	private SSLContext initializeSSLContext() throws Exception {
-		Assert.state(this.sslPropertiesLocation != null, "KeyStore and pass phrase properties file required");
-		Properties sslProperties = new Properties();
-		sslProperties.load(this.sslPropertiesLocation.getInputStream());
-		PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
-		String keyStoreName = sslProperties.getProperty("keyStore");
+		Assert.state(this.sslPropertiesLocation != null || (StringUtils.hasText
+				(keyStore) && StringUtils.hasText(this.keyStorePassphrase))
+				,"either 'sslPropertiesLocation' or 'keyStore' and 'keyStorePassphrase' "
+						+ "must be set.");
+		Assert.state( this.sslPropertiesLocation == null || (StringUtils.isEmpty
+				(keyStore) && StringUtils.isEmpty(keyStorePassphrase)),
+				"either 'sslPropertiesLocation' or 'keyStore' and 'keyStorePassphrase' "
+						+ "must be set.");
+
+		String keyStoreName = this.keyStore;
+		String keyStorePassphrase = this.keyStorePassphrase;
+
+		if (this.sslPropertiesLocation != null) {
+			Properties sslProperties = new Properties();
+			sslProperties.load(this.sslPropertiesLocation.getInputStream());
+			keyStoreName = sslProperties.getProperty("keyStore");
+			//For consistency, respect new inline property name and fall back to original
+			keyStorePassphrase = sslProperties.getProperty("keyStorePassphrase");
+			if (StringUtils.isEmpty(keyStorePassphrase)) {
+				keyStorePassphrase = sslProperties.getProperty("keyStore.passPhrase");
+			}
+		}
+
+		return createSSLContext(keyStoreName, keyStorePassphrase);
+	}
+
+	private SSLContext createSSLContext(String keyStoreName, String keyStorePassPhrase)
+			throws Exception {
 		Assert.state(StringUtils.hasText(keyStoreName), "keyStore property cannot be null");
-		String keyStorePassPhrase = sslProperties.getProperty("keyStore.passPhrase");
-		Assert.state(StringUtils.hasText(keyStorePassPhrase), "keyStore.passPhrase property cannot be null");
+		Assert.state(StringUtils.hasText(keyStorePassPhrase),
+				"keyStorePassPhrase property cannot be null");
+		PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
 		Resource keyStore = resolver.getResource(keyStoreName);
 		SSLContext sslContext = SSLContext.getInstance("TLS");
 		KeyStore ks = KeyStore.getInstance("PKCS12");

--- a/modules/sink/rabbit/config/rabbit.xml
+++ b/modules/sink/rabbit/config/rabbit.xml
@@ -32,11 +32,11 @@
 
 	<bean id="connectionFactory" class="org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean">
 		<property name="useSSL" value="${useSSL}" />
-		<property name="sslPropertiesLocation" value="${sslPropertiesLocation}"/>
-		<property name="keyStore" value="${keyStore:}" />
-		<property name="keyStorePassphrase" value="${keyStorePassphrase:}" />
-		<property name="trustStore" value="${trustStore:}" />
-		<property name="trustStorePassphrase" value="${trustStorePassphrase:}" />
+		<property name="sslPropertiesLocation" value="${sslPropertiesLocation}" />
+		<property name="keyStore" value="#{'${keyStore}' == null || '${keyStore}'.length() == 0 ? null : '${keyStore}' }" />
+		<property name="keyStorePassphrase" value="#{'${keyStorePassphrase}' == null || '${keyStorePassphrase}'.length() == 0 ? null : '${keyStorePassphrase}' }" />
+		<property name="trustStore" value="#{'${trustStore}' == null || '${trustStore}'.length() == 0 ? null : '${trustStore}' }" />
+		<property name="trustStorePassphrase" value="#{'${trustStorePassphrase}' == null || '${trustStorePassphrase}'.length() == 0 ? null : '${trustStorePassphrase}' }" />
 	</bean>
 
 </beans>

--- a/modules/sink/rabbit/config/rabbit.xml
+++ b/modules/sink/rabbit/config/rabbit.xml
@@ -33,6 +33,10 @@
 	<bean id="connectionFactory" class="org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean">
 		<property name="useSSL" value="${useSSL}" />
 		<property name="sslPropertiesLocation" value="${sslPropertiesLocation}"/>
+		<property name="keyStore" value="${keyStore:}" />
+		<property name="keyStorePassphrase" value="${keyStorePassphrase:}" />
+		<property name="trustStore" value="${trustStore:}" />
+		<property name="trustStorePassphrase" value="${trustStorePassphrase:}" />
 	</bean>
 
 </beans>

--- a/modules/source/http/config/http.xml
+++ b/modules/source/http/config/http.xml
@@ -12,7 +12,9 @@
 		<beans:constructor-arg value="${https}"/>
 		<beans:property name="autoStartup" value="false"/>
 		<beans:property name="outputChannel" ref="output"/>
-		<beans:property name="sslPropertiesLocation" value="${sslPropertiesLocation}"/>
+		<beans:property name="sslPropertiesLocation" value="${sslPropertiesLocation:}"/>
+		<beans:property name="keyStore" value="${keyStore:}"/>
+		<beans:property name="keyStorePassphrase" value="${keyStorePassphrase:}"/>
 		<beans:property name="maxContentLength" value="${maxContentLength}"/>
 		<beans:property name="messageConverter" ref="converter"/>
 	</beans:bean>

--- a/modules/source/rabbit/config/rabbit.xml
+++ b/modules/source/rabbit/config/rabbit.xml
@@ -44,13 +44,19 @@
 		virtual-host="${vhost}"
 		username="${username}" password="${password}" />
 
+	<rabbit:connection-factory id="rabbitConnectionFactory"
+							   connection-factory="connectionFactory"
+							   addresses="${addresses}"
+							   virtual-host="${vhost}"
+							   username="${username}" password="${password}" />
+
 	<bean id="connectionFactory" class="org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean">
 		<property name="useSSL" value="${useSSL}" />
-		<property name="sslPropertiesLocation" value="${sslPropertiesLocation:}" />
-		<property name="keyStore" value="${keyStore:}" />
-		<property name="keyStorePassphrase" value="${keyStorePassphrase:}" />
-		<property name="trustStore" value="${trustStore:}" />
-		<property name="trustStorePassphrase" value="${trustStorePassphrase:}" />
+		<property name="sslPropertiesLocation" value="${sslPropertiesLocation}" />
+		<property name="keyStore" value="#{'${keyStore}' == null || '${keyStore}'.length() == 0 ? null : '${keyStore}' }" />
+		<property name="keyStorePassphrase" value="#{'${keyStorePassphrase}' == null || '${keyStorePassphrase}'.length() == 0 ? null : '${keyStorePassphrase}' }" />
+		<property name="trustStore" value="#{'${trustStore}' == null || '${trustStore}'.length() == 0 ? null : '${trustStore}' }" />
+		<property name="trustStorePassphrase" value="#{'${trustStorePassphrase}' == null || '${trustStorePassphrase}'.length() == 0 ? null : '${trustStorePassphrase}' }" />
 	</bean>
 
 	<beans profile="enable-retry">

--- a/modules/source/rabbit/config/rabbit.xml
+++ b/modules/source/rabbit/config/rabbit.xml
@@ -46,7 +46,11 @@
 
 	<bean id="connectionFactory" class="org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean">
 		<property name="useSSL" value="${useSSL}" />
-		<property name="sslPropertiesLocation" value="${sslPropertiesLocation}" />
+		<property name="sslPropertiesLocation" value="${sslPropertiesLocation:}" />
+		<property name="keyStore" value="${keyStore:}" />
+		<property name="keyStorePassphrase" value="${keyStorePassphrase:}" />
+		<property name="trustStore" value="${trustStore:}" />
+		<property name="trustStorePassphrase" value="${trustStorePassphrase:}" />
 	</bean>
 
 	<beans profile="enable-retry">

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
@@ -22,6 +22,7 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * Describes options to the {@code http} source module.
  *
  * @author Gary Russell
+ * @author David Turanski
  */
 public class HttpSourceOptionsMetadata {
 
@@ -29,7 +30,11 @@ public class HttpSourceOptionsMetadata {
 
 	private boolean https;
 
-	private String sslPropertiesLocation = "classpath:httpSSL.properties";
+	private String sslPropertiesLocation;
+
+	private String keyStore;
+
+	private String keyStorePassphrase;
 
 	private int maxContentLength = 1048576;
 
@@ -60,6 +65,20 @@ public class HttpSourceOptionsMetadata {
 	@ModuleOption("location (resource) of properties containing the location of the pkcs12 keyStore and pass phrase")
 	public void setSslPropertiesLocation(String sslProperties) {
 		this.sslPropertiesLocation = sslProperties;
+	}
+
+	public String getKeyStore() { return keyStore; }
+
+	@ModuleOption(value = "key store location (if sslPropertiesLocation not used)",
+			hidden = true)
+	public void setKeyStore(String keyStore) { this.keyStore = keyStore; }
+
+	public String getKeyStorePassphrase() { return keyStorePassphrase; }
+
+	@ModuleOption(value = "key store passphrase (if sslPropertiesLocation not used)",
+			hidden = true)
+	public void setKeyStorePassphrase(String keyStorePassphrase) {
+		this.keyStorePassphrase = keyStorePassphrase;
 	}
 
 	public int getMaxContentLength() {

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitConnectionMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitConnectionMixin.java
@@ -27,6 +27,7 @@ import org.springframework.xd.module.options.spi.ModuleOption;
  * @author Gary Russell
  * @author Glenn Renfro
  * @author Gary Russell
+ * @author David Turanski
  */
 public class RabbitConnectionMixin {
 
@@ -41,6 +42,14 @@ public class RabbitConnectionMixin {
 	private String useSSL = "${spring.rabbitmq.useSSL}";
 
 	private String sslPropertiesLocation = "${spring.rabbitmq.sslProperties}";
+
+	private String keyStore = "${spring.rabbitmq.ssl.keyStore}";
+
+	private String keyStorePassphrase = "${spring.rabbitmq.ssl.keyStorePassphrase}";
+
+	private String trustStore = "${spring.rabbitmq.ssl.trustStore}";
+
+	private String trustStorePassphrase = "${spring.rabbitmq.ssl.trustStorePassphrase}";
 
 	@NotBlank
 	public String getUsername() {
@@ -89,6 +98,7 @@ public class RabbitConnectionMixin {
 		this.useSSL = useSSL;
 	}
 
+
 	public String getSslPropertiesLocation() {
 		return sslPropertiesLocation;
 	}
@@ -98,4 +108,33 @@ public class RabbitConnectionMixin {
 		this.sslPropertiesLocation = sslPropertiesLocation;
 	}
 
+	public String getKeyStore() { return keyStore; }
+
+	@ModuleOption(value = "keyStore location (if not using SSL properties)", hidden =
+			true)
+	public void setKeyStore(String keyStore) { this.keyStore = keyStore; }
+
+	public String getKeyStorePassphrase() { return keyStorePassphrase; }
+
+	@ModuleOption(value = "keyStore passphrase (if not using SSL properties)", hidden =
+			true)
+	public void setKeyStorePassphrase(String keyStorePassphrase) {
+		this.keyStorePassphrase = keyStorePassphrase;
+	}
+
+	public String getTrustStore() { return trustStore; }
+
+	@ModuleOption(value = "trustStore location (if not using SSL properties)", hidden =
+			true)
+	public void setTrustStore(String trustStore) {
+		this.trustStore = trustStore;
+	}
+
+	public String getTrustStorePassphrase() { return trustStorePassphrase; }
+
+	@ModuleOption(value = "trustStore passphrase (if not using SSL properties)", hidden
+			= true)
+	public void setTrustStorePassphrase(String trustStorePassphrase) {
+		this.trustStorePassphrase = trustStorePassphrase;
+	}
 }

--- a/spring-xd-dirt/src/main/resources/application.yml
+++ b/spring-xd-dirt/src/main/resources/application.yml
@@ -27,6 +27,12 @@ spring:
    virtual_host: /
    useSSL: false
    sslProperties:
+   ssl:
+     keyStore:
+     keyStorePassphrase:
+     trustStore:
+     trustStorePassphrase:
+
 # HSQL database configuration
   datasource:
     url: jdbc:hsqldb:hsql://${hsql.server.host:localhost}:${hsql.server.port:9101}/${hsql.server.dbname:xdjob};sql.enforce_strict_size=true;hsqldb.tx=mvcc

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/ConnectionFactorySettings.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/ConnectionFactorySettings.java
@@ -94,10 +94,14 @@ public class ConnectionFactorySettings {
 		RabbitConnectionFactoryBean rabbitConnectionFactoryBean = new RabbitConnectionFactoryBean();
 		rabbitConnectionFactoryBean.setUseSSL(this.useSSL);
 		rabbitConnectionFactoryBean.setSslPropertiesLocation(this.sslPropertiesLocation);
-		rabbitConnectionFactoryBean.setKeyStore(this.keyStore);
-		rabbitConnectionFactoryBean.setKeyStorePassphrase(this.keyStorePassphrase);
-		rabbitConnectionFactoryBean.setTrustStore(this.trustStore);
-		rabbitConnectionFactoryBean.setTrustStorePassphrase(this.trustStorePassphrase);
+		rabbitConnectionFactoryBean.setKeyStore(StringUtils.hasText(this.keyStore) ?
+				this.keyStore : null);
+		rabbitConnectionFactoryBean.setKeyStorePassphrase(StringUtils.hasText(
+				this.keyStorePassphrase) ? this.keyStorePassphrase : null);
+		rabbitConnectionFactoryBean.setTrustStore(StringUtils.hasText(this.trustStore) ?
+				this.trustStore : null);
+		rabbitConnectionFactoryBean.setTrustStorePassphrase(StringUtils.hasText(
+				this.trustStorePassphrase) ? this.trustStorePassphrase : null);
 		return rabbitConnectionFactoryBean;
 	}
 

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/ConnectionFactorySettings.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/ConnectionFactorySettings.java
@@ -61,10 +61,8 @@ public class ConnectionFactorySettings {
 	@Bean
 	// TODO: Move to spring boot
 	public ConnectionFactory rabbitConnectionFactory(RabbitProperties config,
-			com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory)
-			throws Exception {
-		CachingConnectionFactory factory = new CachingConnectionFactory(
-				rabbitConnectionFactory);
+			com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory) throws Exception {
+		CachingConnectionFactory factory = new CachingConnectionFactory(rabbitConnectionFactory);
 		factory.setAddresses(config.getAddresses());
 		if (config.getHost() != null) {
 			factory.setHost(config.getHost());

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/ConnectionFactorySettings.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/ConnectionFactorySettings.java
@@ -28,12 +28,14 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
 
 /**
  * Configures the connection factory used by the rabbit message bus.
  *
  * @author Eric Bottard
  * @author Gary Russell
+ * @author David Turanski
  */
 @Configuration
 public class ConnectionFactorySettings {
@@ -44,11 +46,25 @@ public class ConnectionFactorySettings {
 	@Value("${spring.rabbitmq.sslProperties:}")
 	private Resource sslPropertiesLocation;
 
+	@Value("${spring.rabbitmq.ssl.keyStore:}")
+	private String keyStore;
+
+	@Value("${spring.rabbitmq.ssl.keyStorePassphrase:}")
+	private String keyStorePassphrase;
+
+	@Value("${spring.rabbitmq.ssl.trustStore:}")
+	private String trustStore;
+
+	@Value("${spring.rabbitmq.ssl.trustStorePassphrase:}")
+	private String trustStorePassphrase;
+
 	@Bean
 	// TODO: Move to spring boot
 	public ConnectionFactory rabbitConnectionFactory(RabbitProperties config,
-			com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory) throws Exception {
-		CachingConnectionFactory factory = new CachingConnectionFactory(rabbitConnectionFactory);
+			com.rabbitmq.client.ConnectionFactory rabbitConnectionFactory)
+			throws Exception {
+		CachingConnectionFactory factory = new CachingConnectionFactory(
+				rabbitConnectionFactory);
 		factory.setAddresses(config.getAddresses());
 		if (config.getHost() != null) {
 			factory.setHost(config.getHost());
@@ -78,6 +94,10 @@ public class ConnectionFactorySettings {
 		RabbitConnectionFactoryBean rabbitConnectionFactoryBean = new RabbitConnectionFactoryBean();
 		rabbitConnectionFactoryBean.setUseSSL(this.useSSL);
 		rabbitConnectionFactoryBean.setSslPropertiesLocation(this.sslPropertiesLocation);
+		rabbitConnectionFactoryBean.setKeyStore(this.keyStore);
+		rabbitConnectionFactoryBean.setKeyStorePassphrase(this.keyStorePassphrase);
+		rabbitConnectionFactoryBean.setTrustStore(this.trustStore);
+		rabbitConnectionFactoryBean.setTrustStorePassphrase(this.trustStorePassphrase);
 		return rabbitConnectionFactoryBean;
 	}
 

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactory.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactory.java
@@ -33,6 +33,7 @@ import org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean;
 import org.springframework.amqp.rabbit.connection.RoutingConnectionFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.xd.dirt.integration.bus.RabbitManagementUtils;
@@ -52,6 +53,7 @@ import org.springframework.xd.dirt.integration.bus.RabbitManagementUtils;
  * <p>All {@link ConnectionFactory} methods delegate to the default
  *
  * @author Gary Russell
+ * @author David Turanski
  * @since 1.2
  */
 public class LocalizedQueueConnectionFactory implements ConnectionFactory, RoutingConnectionFactory {
@@ -78,20 +80,38 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 
 	private final Resource sslPropertiesLocation;
 
+	private final String keyStore;
+
+	private final String keyStorePassphrase;
+
+	private final String trustStore;
+
+	private final String trustStorePassphrase;
+
 	/**
 	 *
 	 * @param defaultConnectionFactory the fallback connection factory to use if the queue can't be located.
 	 * @param addresses the rabbitmq server addresses (host:port, ...).
-	 * @param adminAddresses the rabbitmq admin addresses (http://host:port, ...) must be the same length
-	 * as addresses.
+	 * @param adminAddresses the rabbitmq admin addresses (http://host:port, ...) must
+	 * be the same length as addresses.
 	 * @param nodes the rabbitmq nodes corresponding to addresses (rabbit@server1, ...).
 	 * @param vhost the virtual host.
 	 * @param username the user name.
 	 * @param password the password.
+	 * @param useSSL flag to enable SSL.
+	 * @param sslPropertiesLocation location of SSL properties file. If this is set, the
+	 * following parameters are not used.
+	 * @param keyStore the key store location if not using properties file.
+	 * @param keyStorePassphrase the key store passphrase if not using properties file.
+	 * @param trustStore the trust store location if not using properties file.
+	 * @param truststorePassphrase the trust store passphrase if not using properties
+	 * file.
 	 */
 	public LocalizedQueueConnectionFactory(ConnectionFactory defaultConnectionFactory,
 			String[] addresses, String[] adminAddresses, String[] nodes, String vhost,
-			String username, String password, boolean useSSL, Resource sslPropertiesLocation) {
+			String username, String password, boolean useSSL,
+			Resource sslPropertiesLocation, String keyStore, String keyStorePassphrase,
+			String trustStore, String truststorePassphrase) {
 		Assert.isTrue(addresses.length == adminAddresses.length
 				&& addresses.length == nodes.length,
 				"'addresses', 'adminAddresses', and 'nodes' properties must have equal length");
@@ -104,6 +124,10 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 		this.password = password;
 		this.useSSL = useSSL;
 		this.sslPropertiesLocation = sslPropertiesLocation;
+		this.keyStore = keyStore;
+		this.keyStorePassphrase = keyStorePassphrase;
+		this.trustStore = trustStore;
+		this.trustStorePassphrase = truststorePassphrase;
 	}
 
 	@Override
@@ -220,6 +244,10 @@ public class LocalizedQueueConnectionFactory implements ConnectionFactory, Routi
 		RabbitConnectionFactoryBean rcfb = new RabbitConnectionFactoryBean();
 		rcfb.setUseSSL(this.useSSL);
 		rcfb.setSslPropertiesLocation(this.sslPropertiesLocation);
+		rcfb.setKeyStore(this.keyStore);
+		rcfb.setKeyStorePassphrase(this.keyStorePassphrase);
+		rcfb.setTrustStore(this.trustStore);
+		rcfb.setKeyStorePassphrase(this.trustStorePassphrase);
 		rcfb.afterPropertiesSet();
 		CachingConnectionFactory ccf = new CachingConnectionFactory(rcfb.getObject());
 		ccf.setAddresses(address);

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -314,6 +314,14 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 
 	private Resource sslPropertiesLocation;
 
+	private String keyStore;
+
+	private String keyStorePassphrase;
+
+	private String trustStore;
+
+	private String trustStorePassphrase;
+
 	private volatile boolean clustered;
 
 	public RabbitMessageBus(ConnectionFactory connectionFactory, Codec codec) {
@@ -437,6 +445,22 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 		this.sslPropertiesLocation = sslPropertiesLocation;
 	}
 
+	public void setKeyStore(String keyStore) {
+		this.keyStore = keyStore;
+	}
+
+	public void setKeyStorePassphrase(String keyStorePassphrase) {
+		this.keyStorePassphrase = keyStorePassphrase;
+	}
+
+	public void setTrustStore(String trustStore) {
+		this.trustStore = trustStore;
+	}
+
+	public void setTrustStorePassphrase(String trustStorePassphrase) {
+		this.trustStorePassphrase = this.trustStorePassphrase;
+	}
+
 	/**
 	 * Set the limit for the lengths of LongString headers. Headers greater than
 	 * this length are returned as a {@code DataInputStream} which requires user
@@ -457,7 +481,8 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 					"'addresses', 'adminAddresses', and 'nodes' properties must have equal length");
 			this.connectionFactory = new LocalizedQueueConnectionFactory(this.connectionFactory, this.addresses,
 					this.adminAddresses, this.nodes, this.vhost, this.username, this.password, this.useSSL,
-					this.sslPropertiesLocation);
+					this.sslPropertiesLocation, this.keyStore, this.keyStorePassphrase,
+					this.trustStore, this.trustStorePassphrase);
 		}
 		if (this.longStringLimit != null) {
 			this.inboundMessagePropertiesConverter = new DeliveryModeRemovingMessagePropertiesConverter(

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -481,8 +481,12 @@ public class RabbitMessageBus extends MessageBusSupport implements DisposableBea
 					"'addresses', 'adminAddresses', and 'nodes' properties must have equal length");
 			this.connectionFactory = new LocalizedQueueConnectionFactory(this.connectionFactory, this.addresses,
 					this.adminAddresses, this.nodes, this.vhost, this.username, this.password, this.useSSL,
-					this.sslPropertiesLocation, this.keyStore, this.keyStorePassphrase,
-					this.trustStore, this.trustStorePassphrase);
+					this.sslPropertiesLocation,
+					StringUtils.hasText(this.keyStore) ? this.keyStore : null,
+					StringUtils.hasText(this.keyStorePassphrase) ? this.keyStorePassphrase : null,
+					StringUtils.hasText(this.trustStore) ? this.trustStore : null,
+					StringUtils.hasText(this.trustStorePassphrase) ? this.trustStorePassphrase : null);
+
 		}
 		if (this.longStringLimit != null) {
 			this.inboundMessagePropertiesConverter = new DeliveryModeRemovingMessagePropertiesConverter(

--- a/spring-xd-messagebus-rabbit/src/main/resources/META-INF/spring-xd/bus/rabbit-bus.xml
+++ b/spring-xd-messagebus-rabbit/src/main/resources/META-INF/spring-xd/bus/rabbit-bus.xml
@@ -51,6 +51,10 @@
 		<property name="vhost" value="${spring.rabbitmq.virtual_host:}" />
 		<property name="useSSL" value="${spring.rabbitmq.useSSL:false}" />
 		<property name="sslPropertiesLocation" value="${spring.rabbitmq.sslProperties:}" />
+		<property name="keyStore" value="${spring.rabbitmq.ssl.keyStore:}" />
+		<property name="keyStorePassphrase" value="${spring.rabbitmq.ssl.keyStorePassphrase:}" />
+		<property name="trustStore" value="${spring.rabbitmq.ssl.trustStore:}" />
+		<property name="trustStorePassphrase" value="${spring.rabbitmq.ssl.trustStorePassphrase:}" />
 		<property name="longStringLimit" value="${xd.messagebus.rabbit.longStringLimit}" />
 	</bean>
 

--- a/spring-xd-messagebus-rabbit/src/test/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactoryIntegrationTests.java
+++ b/spring-xd-messagebus-rabbit/src/test/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactoryIntegrationTests.java
@@ -53,7 +53,8 @@ public class LocalizedQueueConnectionFactoryIntegrationTests {
 		String username = "guest";
 		String password = "guest";
 		this.lqcf = new LocalizedQueueConnectionFactory(defaultConnectionFactory, addresses,
-				adminAddresses, nodes, vhost, username, password, false, null);
+				adminAddresses, nodes, vhost, username, password, false, null,null,
+				null,null,null);
 	}
 
 	@Test

--- a/spring-xd-messagebus-rabbit/src/test/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactoryTests.java
+++ b/spring-xd-messagebus-rabbit/src/test/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactoryTests.java
@@ -90,7 +90,8 @@ public class LocalizedQueueConnectionFactoryTests {
 		String password = "guest";
 		final AtomicBoolean firstServer = new AtomicBoolean(true);
 		LocalizedQueueConnectionFactory lqcf = new LocalizedQueueConnectionFactory(defaultConnectionFactory, addresses,
-				adminAddresses, nodes, vhost, username, password, false, null) {
+				adminAddresses, nodes, vhost, username, password, false, null,null,
+				null, null, null) {
 
 			private final String[] nodes = new String[] { "rabbit@foo", "rabbit@bar" };
 

--- a/src/docs/asciidoc/Application-Configuration.asciidoc
+++ b/src/docs/asciidoc/Application-Configuration.asciidoc
@@ -903,6 +903,7 @@ password=
 
 A property file with the same keys, but likely different values would be located in `XD_MODULE_CONFIG_LOCATION\sink\jdbc\jdbc.properties`.
 
+[[encrypted-properties]]
 === Encrypted Properties
 
 If you wish encrypt passwords and other secret values stored in application configuration file, you must provide a Spring bean that implements

--- a/src/docs/asciidoc/MessageBus.asciidoc
+++ b/src/docs/asciidoc/MessageBus.asciidoc
@@ -146,7 +146,7 @@ spring:
     useSSL: true
 ----
 
-In +application.yml+ (and set the port(s) in the +addresses+ property appropriately).
+In +servers.yml+ (and set the port(s) in the +addresses+ property appropriately).
 
 To use SSL with certificate validation, set
 
@@ -155,6 +155,11 @@ spring:
   rabbitmq:
     useSSL: true
     sslProperties: file:path/to/secret/ssl.properties
+    #ssl:
+      #   keyStore:
+      #   keyStorePassphrase:
+      #   trustStore:
+      #   trustStorePassphrase:
 ----
 
 The +sslProperties+ property is a Spring resource (+file:+, +classpath:+ etc) that points to a properties file, Typically, this file would be secured by the operating system (and readable by the XD container) because it contains security information. Specifically:
@@ -167,6 +172,9 @@ trustStore.passPhrase=secret
 ----
 
 Where the +pkcs12+ keystore contains the client certificate and the truststore contains the server's certificate as described in the rabbit documentation. The key/trust store properties are Spring resources.
+
+Alternately, you may specify these properties in-line in lieu of using an external properties file. In this case,the passphrase properties may be encrypted. See xref:Application-Configuration#encrypted-properties[Encrypted Properties] for more details. In case
+both +sslProperties+ and in-line +ssl+ properties are configured,the in-line properties take precedence.
 
 NOTE: By default, the +rabbit+ source and sink modules inherit their default configuration from the container, but it can be overridden, either using +modules.yml+ or with specific module definitions.
 

--- a/src/docs/asciidoc/Sinks.asciidoc
+++ b/src/docs/asciidoc/Sinks.asciidoc
@@ -1313,10 +1313,14 @@ $$addresses$$:: $$a comma separated list of 'host[:port]' addresses$$ *($$String
 $$converterClass$$:: $$the class name of the message converter$$ *($$String$$, default: `org.springframework.amqp.support.converter.SimpleMessageConverter`)*
 $$deliveryMode$$:: $$the delivery mode (PERSISTENT, NON_PERSISTENT)$$ *($$String$$, default: `PERSISTENT`)*
 $$exchange$$:: $$the Exchange on the RabbitMQ broker to which messages should be sent$$ *($$String$$, default: ``)*
+$$keyStore$$:: $$keyStore location (if not using SSL properties)$$ *($$String$$, default: `${spring.rabbitmq.ssl.keyStore}`)*
+$$keyStorePassphrase$$:: $$keyStore passphrase (if not using SSL properties)$$ *($$String$$, default: `${spring.rabbitmq.ssl.keyStorePassphrase}`)*
 $$mappedRequestHeaders$$:: $$request message header names to be propagated to/from the adpater/gateway$$ *($$String$$, default: `STANDARD_REQUEST_HEADERS`)*
 $$password$$:: $$the password to use to connect to the broker$$ *($$String$$, default: `${spring.rabbitmq.password}`)*
 $$routingKey$$:: $$the routing key to be passed with the message, as a SpEL expression$$ *($$String$$, default: `'<stream name>'`)*
 $$sslPropertiesLocation$$:: $$resource containing SSL properties$$ *($$String$$, default: `${spring.rabbitmq.sslProperties}`)*
+$$trustStore$$:: $$trustStore location (if not using SSL properties)$$ *($$String$$, default: `${spring.rabbitmq.ssl.trustStore}`)*
+$$trustStorePassphrase$$:: $$trustStore passphrase (if not using SSL properties)$$ *($$String$$, default: `${spring.rabbitmq.ssl.trustStorePassphrase}`)*
 $$useSSL$$:: $$true if SSL should be used for the connection$$ *($$String$$, default: `${spring.rabbitmq.useSSL}`)*
 $$username$$:: $$the username to use to connect to the broker$$ *($$String$$, default: `${spring.rabbitmq.username}`)*
 $$vhost$$:: $$the RabbitMQ virtual host to use$$ *($$String$$, default: `${spring.rabbitmq.virtual_host}`)*

--- a/src/docs/asciidoc/Sources.asciidoc
+++ b/src/docs/asciidoc/Sources.asciidoc
@@ -224,7 +224,7 @@ NOTE: The `useLocator` option is intended for integration with an existing GemFi
 
 The last example creates connections to myhost1:10334, myhost2:10335, myhost3:10336
 
-NOTE: You may also configure default Gemfire connection settings for all gemfire modules in `config\modules.yml`:
+NOTE: You may also configure default Gemfire connection settings for all gemfire modules in `config/modules.yml`:
 
     gemfire:
        useLocator: true
@@ -274,10 +274,12 @@ To send binary data, set the `Content-Type` header to `application/octet-string`
 The **$$http$$** $$source$$ has the following options:
 
 $$https$$:: $$true for https://$$ *($$boolean$$, default: `false`)*
+$$keyStore$$:: $$key store location (if sslPropertiesLocation not used)$$ *($$String$$, no default)*
+$$keyStorePassphrase$$:: $$key store passphrase (if sslPropertiesLocation not used)$$ *($$String$$, no default)*
 $$maxContentLength$$:: $$the maximum allowed content length$$ *($$int$$, default: `1048576`)*
 $$messageConverterClass$$:: $$the name of a custom MessageConverter class, to convert HttpRequest to Message; must have a constructor with a 'MessageBuilderFactory' parameter$$ *($$String$$, default: `org.springframework.integration.x.http.NettyInboundMessageConverter`)*
 $$port$$:: $$the port to listen to$$ *($$int$$, default: `9000`)*
-$$sslPropertiesLocation$$:: $$location (resource) of properties containing the location of the pkcs12 keyStore and pass phrase$$ *($$String$$, default: `classpath:httpSSL.properties`)*
+$$sslPropertiesLocation$$:: $$location (resource) of properties containing the location of the pkcs12 keyStore and pass phrase$$ *($$String$$, no default)*
 //$source.http
 
 Here is an example
@@ -294,7 +296,9 @@ $ cat /tmp/xd/output/httptest9020
 hello world
 ----
 
-NOTE: When using +https+, you need to provide a properties file that references a pkcs12 key store (containing the server certificate(s)) and its passphrase. Setting +--https=true+ enables https:// and the module looks for the SSL properties in resource +classpath:httpSSL.properties+. This location can be overridden with the +--sslPropertiesLocation+ property. For example:
+NOTE: When using +https+, you may either provide a properties file that references a pkcs12 key store (containing the server certificate(s)) and its passphrase, or set +keyStore+ and +keyStorePassphrase+ explicitly.
+Setting +--https=true+ enables https:// and the module uses SSL properties configured in +config/modules/source/http/http.properties+. By default, the resource +classpath:httpSSL.properties+ is used.
+This location can be overridden in +config/modules/source/http/http.properties+ or with the +--sslPropertiesLocation+ property. For example:
 
     xd:> stream create --name https9021 --definition "http --port=9021 --https=true --sslPropertiesLocation=file:/secret/ssl.properties | file" --deploy
 
@@ -306,6 +310,8 @@ keyStore.passPhrase=secret
 ----
 
 Since this properties file contains sensitive information, it will typically be secured by the operating system with the XD container process having read access.
+
+NOTE: If you set +keyStore+ and +keyStorePassphrase+ in +config/modules/source/http/http.properties+ in lieue of using an external properties file, the passPhrase may be encrypted. See xref:Application-Configuration#encrypted-properties[Encrypted Properties] for more details.
 
 [[jdbc-source]]
 === JDBC Source (`jdbc`)
@@ -650,6 +656,8 @@ $$concurrency$$:: $$the minimum number of consumers$$ *($$int$$, default: `1`)*
 $$converterClass$$:: $$the class name of the message converter$$ *($$String$$, default: `org.springframework.amqp.support.converter.SimpleMessageConverter`)*
 $$enableRetry$$:: $$enable retry; when retries are exhausted the message will be rejected; message disposition will depend on dead letter configuration$$ *($$boolean$$, default: `false`)*
 $$initialRetryInterval$$:: $$initial interval between retries$$ *($$int$$, default: `1000`)*
+$$keyStore$$:: $$keyStore location (if not using SSL properties)$$ *($$String$$, default: `${spring.rabbitmq.ssl.keyStore}`)*
+$$keyStorePassphrase$$:: $$keyStore passphrase (if not using SSL properties)$$ *($$String$$, default: `${spring.rabbitmq.ssl.keyStorePassphrase}`)*
 $$mappedRequestHeaders$$:: $$request message header names to be propagated to/from the adpater/gateway$$ *($$String$$, default: `STANDARD_REQUEST_HEADERS`)*
 $$maxAttempts$$:: $$maximum delivery attempts$$ *($$int$$, default: `3`)*
 $$maxConcurrency$$:: $$the maximum number of consumers$$ *($$int$$, default: `1`)*
@@ -661,6 +669,8 @@ $$requeue$$:: $$whether rejected messages will be requeued by default$$ *($$bool
 $$retryMultiplier$$:: $$retry interval multiplier$$ *($$double$$, default: `2.0`)*
 $$sslPropertiesLocation$$:: $$resource containing SSL properties$$ *($$String$$, default: `${spring.rabbitmq.sslProperties}`)*
 $$transacted$$:: $$true if the channel is to be transacted$$ *($$boolean$$, default: `false`)*
+$$trustStore$$:: $$trustStore location (if not using SSL properties)$$ *($$String$$, default: `${spring.rabbitmq.ssl.trustStore}`)*
+$$trustStorePassphrase$$:: $$trustStore passphrase (if not using SSL properties)$$ *($$String$$, default: `${spring.rabbitmq.ssl.trustStorePassphrase}`)*
 $$txSize$$:: $$the number of messages to process before acking$$ *($$int$$, default: `1`)*
 $$useSSL$$:: $$true if SSL should be used for the connection$$ *($$String$$, default: `${spring.rabbitmq.useSSL}`)*
 $$username$$:: $$the username to use to connect to the broker$$ *($$String$$, default: `${spring.rabbitmq.username}`)*


### PR DESCRIPTION
This adds explicit in line properties for `keyStore`, `keyStorePassphrase`, `trustStore`, and `trustStorePassphrase`. These can be set enable storing properties in encrypted form enabled in https://jira.spring.io/browse/XD-3738.

This affects SSL settings for RabbitMessageBus,  Rabbit source, Rabbit sink, and Http source. 

Manual testing performed:

 - Regression test each of these using the current mechanisms: Enable SSL, use rabbit SSL address, external properties files with valid and invalid values in servers.yml, modules.yml, and module config properties.
- Test Rabbit MB with in line configuration in servers.yml
- Test Rabbit modules inherit the default MB configuration
- Test Streams with rabbit sink and source modules, configured with inline properties
- Regression test http source with SSL configured from new `config/modules/source/http/http.properties` 
`http --https=true | log` and `curl -X post --cacert path/to/cecert https://localhost:9000 -d hello`







 