### PR TITLE
Adding SQL support for JDBC incremental sink to HDFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ lib
 spring-xd-spark-streaming/.cache
 .gradletasknamecache
 spring-xd.ids
+build/
+spring-xd-shell/
+spring-xd-rest-client/
+spring-xd-gemfire-server/
+redis/

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,3 @@ lib
 spring-xd-spark-streaming/.cache
 .gradletasknamecache
 spring-xd.ids
-build/
-spring-xd-shell/
-spring-xd-rest-client/
-spring-xd-gemfire-server/
-redis/

--- a/modules/job/jdbchdfs/config/jdbchdfs.xml
+++ b/modules/job/jdbchdfs/config/jdbchdfs.xml
@@ -39,6 +39,7 @@
 	<bean id="partitioner" class="org.springframework.batch.integration.x.IncrementalColumnRangePartitioner" scope="step">
 		<property name="dataSource" ref="moduleDataSource"/>
 		<property name="table" value="${tableName}"/>
+		<property name="sql" value="${sql}" />
 		<property name="column" value="${partitionColumn}"/>
 		<property name="partitions" value="${partitions}"/>
 		<property name="jobExplorer" ref="jobExplorer"/>


### PR DESCRIPTION
Adding SQL support to load data incrementally to HDFS. This can support a join column queries too.
For example if i have a tables in mysql;

CREATE TABLE `user` (
  `userid` varchar(25) NOT NULL,
  `firstName` varchar(50) NOT NULL,
  `lastName` varchar(50) NOT NULL,
  `email` varchar(125) NOT NULL,
  PRIMARY KEY (`userid`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1;

CREATE TABLE `tweet` (
  `userid` varchar(25) NOT NULL,
  `msgid` int(11) NOT NULL AUTO_INCREMENT,
  `message` varchar(2096) NOT NULL,
  `timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`msgid`),
  KEY `userid_idx` (`userid`),
  CONSTRAINT `useridFK` FOREIGN KEY (`userid`) REFERENCES `user` (`userid`) ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE=InnoDB AUTO_INCREMENT=4705 DEFAULT CHARSET=latin1;


i use the below job definition to load data in hdfs/hawq;

job create loadTweetsJobTest --definition "jdbchdfs --driverClassName='com.mysql.jdbc.Driver' --url='jdbc:mysql://localhost/tweets?autoReconnect=true&useSSL=false' --username='root' --password='omsai' --sql='select msgid, firstname, lastname, message, timestamp from tweets.tweet join tweets.user on tweets.tweet.userid = tweets.user.userid' --checkColumn='msgid' --restartable=true"

Hawq table;

CREATE EXTERNAL TABLE tweets.extn_tweet
(
  msgid integer,
  firstname text,
  lastname text,
  message text,
  ts timestamp without time zone
)
 LOCATION (
    'pxf://172.16.65.129:50070/xd/loadTweetsJob/*.csv?profile=HdfsTextSimple'
)
 FORMAT 'text' (delimiter ',' null '\\N' escape '\\')
ENCODING 'UTF8';
ALTER TABLE tweets.extn_tweet
  OWNER TO gpadmin;