### PR TITLE
XD-3744: Rabbit Source: Filter amqp_deliveryMode

### DIFF
--- a/modules/source/rabbit/config/rabbit.xml
+++ b/modules/source/rabbit/config/rabbit.xml
@@ -15,7 +15,7 @@
 
 	<int-amqp:inbound-channel-adapter
 		auto-startup="false"
-		channel="output"
+		channel="filter"
 		listener-container="listenerContainer"
 		message-converter="messageConverter"
 		mapped-request-headers="${mappedRequestHeaders}" />
@@ -35,6 +35,8 @@
 	</bean>
 
 	<bean id="messageConverter" class="${converterClass}" />
+
+	<int:header-filter input-channel="filter" output-channel="output" header-names="amqp_deliveryMode" />
 
 	<int:channel id="output" />
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-3744

Remove the header to avoid the WARN log when the header
is not mapped in the `RabbitMessageBus`  because the object is from a
different classloader.