### PR TITLE
Adding a close for the JarOutputStream

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/support/ModuleDefinitionService.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/support/ModuleDefinitionService.java
@@ -122,16 +122,26 @@ public class ModuleDefinitionService {
 
 	private byte[] createComposedJobJar(String xml) {
 
-		try (ByteArrayOutputStream outStream = new ByteArrayOutputStream(); JarOutputStream target = new JarOutputStream(outStream)) {
+		JarOutputStream target = null;
+		try (ByteArrayOutputStream outStream = new ByteArrayOutputStream()) {
+			target = new JarOutputStream(outStream);
 			JarEntry entry = new JarEntry("config/");
 			target.putNextEntry(entry);
 			target.closeEntry();
 			writeXML(target, xml);
 			writeParameters(target, ComposedJobUtil.getPropertyDefinition());
+			target.close();
 			return outStream.toByteArray();
 		}
-		catch (IOException ioe) {
-			throw new IllegalStateException(ioe.getMessage(), ioe);
+		catch (Exception e) {
+			try{
+				if(target != null){
+					target.close();
+				}
+			}catch (IOException ie){
+				throw new IllegalStateException(e.getMessage(), e);
+			}
+			throw new IllegalStateException(e.getMessage(), e);
 		}
 	}
 


### PR DESCRIPTION
Was removed during a refactoring effort.  Caused the Composed jar to not be properly opened during deployment.
Also removed the JarOutputStream from the try parameters.