### PR TITLE
XD-3748: Fix ModuleObjectNamingStrategy

### DIFF
--- a/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/jmx/mbean-exporters.xml
+++ b/spring-xd-dirt/src/main/resources/META-INF/spring-xd/plugins/jmx/mbean-exporters.xml
@@ -22,8 +22,11 @@
 
 	<bean id="moduleObjectNamingStrategy"
 		class="org.springframework.xd.dirt.module.jmx.ModuleObjectNamingStrategy">
+		<constructor-arg ref="attributeSource" />
 		<constructor-arg name="domain" value="xd.${xd.stream.name:${xd.job.name:}}" />
 		<constructor-arg name="objectNameProperties" ref="objectNameProperties" />
 	</bean>
+
+	<bean id="attributeSource" class="org.springframework.jmx.export.annotation.AnnotationJmxAttributeSource" />
 
 </beans>

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/jmx/ModuleObjectNamingStrategyTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/jmx/ModuleObjectNamingStrategyTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.xd.dirt.module.jmx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Properties;
+
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.Test;
+
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.jmx.support.JmxUtils;
+
+
+/**
+ *
+ * @author Gary Russell
+ */
+public class ModuleObjectNamingStrategyTests {
+
+	@Test
+	public void testSimpleBeanName() throws Exception {
+		Properties props = new Properties();
+		props.setProperty("group", "fooGroup");
+		props.setProperty("label", "fooLabel");
+		props.setProperty("type", "fooType");
+		props.setProperty("sequence", "fooSequence");
+		ModuleObjectNamingStrategy namer = new ModuleObjectNamingStrategy("foo", props);
+		Object managedBean = new Object();
+		assertEquals(new ObjectName("foo:module=fooGroup.fooType.fooLabel.fooSequence,component=Object,name=foo"),
+				namer.getObjectName(managedBean, "foo"));
+		managedBean = new Foo();
+		assertEquals(new ObjectName("foo:module=fooGroup.fooType.fooLabel.fooSequence,"
+						+ "component=ModuleObjectNamingStrategyTests.Foo,name=foo"),
+				namer.getObjectName(managedBean, "foo"));
+	}
+
+	@Test
+	public void testXmlContext() throws Exception {
+		ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext(
+				"META-INF/spring-xd/plugins/jmx/mbean-exporters.xml",
+				"org/springframework/xd/dirt/module/jmx/test.xml");
+		MBeanServer server = JmxUtils.locateMBeanServer();
+		MBeanInfo mBeanInfo = server.getMBeanInfo(new ObjectName(
+				"xd.fooStream:module=fooGroup.fooType.fooModule.0,"
+				+ "component=MessageHistoryConfigurer,name=messageHistoryConfigurer"));
+		assertNotNull(mBeanInfo);
+		ctx.close();
+	}
+
+	public static class Foo {
+
+	}
+
+}

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/jmx/test.xml
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/jmx/test.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	<context:mbean-server />
+
+	<int:message-history />
+
+	<context:property-placeholder properties-ref="props" />
+
+	<util:properties id="props">
+		<prop key="xd.stream.name">fooStream</prop>
+		<prop key="xd.group.name">fooGroup</prop>
+		<prop key="xd.module.label">fooModule</prop>
+		<prop key="xd.module.type">fooType</prop>
+		<prop key="xd.module.sequence">0</prop>
+	</util:properties>
+
+</beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/XD-3748

Previously, the `ModuleObjectNamingStrategy` didn't handle beans with
a `beanKey` that's a simple bean name, such as the `MessageHistoryConfigurer`.

Subclass `MetadataNamingStrategy` which handles simple bean names.

Add tests.