### PR TITLE
Fix stream failover

### DIFF
--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DepartedContainerModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DepartedContainerModuleRedeployer.java
@@ -137,15 +137,15 @@ public class DepartedContainerModuleRedeployer extends ModuleRedeployer {
 					try {
 						stream = DeploymentLoader.loadStream(client, unitName, streamFactory);
 						streamMap.put(unitName, stream);
-						if (stream != null) {
-							streamModuleDeployments.add(new ModuleDeployment(stream,
-									stream.getModuleDescriptor(moduleDeploymentsPath.getModuleLabel()),
-									deploymentProperties));
-						}
 					}
 					catch (Exception e) {
 						logger.error(String.format("Exception loading stream %s.", unitName), e);
 					}
+				}
+				if (stream != null) {
+					streamModuleDeployments.add(new ModuleDeployment(stream,
+							stream.getModuleDescriptor(moduleDeploymentsPath.getModuleLabel()),
+							deploymentProperties));
 				}
 			}
 		}


### PR DESCRIPTION
- Fix deployment handling in DepartedContainerModuleRedeployer
  so that modules in a same stream and same container will
  actually get re-deployed.
- Bug was a wrong if clause position regarding stream caching.
- Fixes #1924