### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'idea'
 
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/plugins-release" }
 		jcenter()
 	}
 	dependencies {
@@ -71,7 +71,7 @@ ext {
 	]
 
 	javadocLinks = [
-			"http://docs.spring.io/spring-xd/docs/1.0.x/api/"
+			"https://docs.spring.io/spring-xd/docs/1.0.x/api/"
 	] as String[]
 
 	nonJavaProjects = [
@@ -114,9 +114,9 @@ allprojects {
 
 	repositories {
 		mavenCentral()
-		maven { url 'http://repo.spring.io/milestone' }
-		maven { url 'http://repo.spring.io/libs-milestone' }
-		maven { url 'http://repo.spring.io/plugins-release' }
+		maven { url 'https://repo.spring.io/milestone' }
+		maven { url 'https://repo.spring.io/libs-milestone' }
+		maven { url 'https://repo.spring.io/plugins-release' }
 		maven { url 'https://repo.eclipse.org/content/repositories/paho-releases' }
 	}
 }
@@ -1410,7 +1410,7 @@ apply from: 'gradle/build-dist.gradle'
 
 task wrapper(type: Wrapper) {
 	description = "Generates build_xd[.bat] scripts"
-	//see http://stackoverflow.com/questions/29113972/spring-boot-gradle-plugin-application-plugin-and-gradle-2-3-wrapper
+	//see https://stackoverflow.com/questions/29113972/spring-boot-gradle-plugin-application-plugin-and-gradle-2-3-wrapper
 	//before upgrading to 2.3
 	gradleVersion = "2.2"
 	scriptFile = "gradle/build_xd"

--- a/gradle/build-dist.gradle
+++ b/gradle/build-dist.gradle
@@ -23,7 +23,7 @@ def customizePom = {
 	licenses {
 		license {
 			name 'The Apache Software License, Version 2.0'
-			url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+			url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 			distribution 'repo'
 		}
 	}
@@ -373,7 +373,7 @@ task dist(dependsOn: assemble) {
 def excludedMavenProjects = hadoopDistros << 'documentation-toolchain' << rootProject.name
 
 artifactory {
-	contextUrl = 'http://repo.spring.io'
+	contextUrl = 'https://repo.spring.io'
 	publish {
 		repository {
 			repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle/build-docs.gradle
+++ b/gradle/build-docs.gradle
@@ -3,7 +3,7 @@
 */
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-snapshot" }
+		maven { url "https://repo.spring.io/plugins-snapshot" }
 		jcenter()
 	}
 	dependencies {

--- a/gradle/build-gradle-plugins.gradle
+++ b/gradle/build-gradle-plugins.gradle
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradle/build-starters.gradle
+++ b/gradle/build-starters.gradle
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -22,7 +22,7 @@ def customizePom = {
 	licenses {
 		license {
 			name 'The Apache Software License, Version 2.0'
-			url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+			url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 			distribution 'repo'
 		}
 	}

--- a/spring-xd-starters/spring-xd-module-parent/publish-maven.gradle
+++ b/spring-xd-starters/spring-xd-module-parent/publish-maven.gradle
@@ -57,7 +57,7 @@ def customizePom = {
 	licenses {
 		license {
 			name 'The Apache Software License, Version 2.0'
-			url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+			url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 			distribution 'repo'
 		}
 	}
@@ -109,24 +109,24 @@ def customizePom = {
 		repository {
 			id 'jcenter'
 			name 'JCenter Repository'
-			url 'http://jcenter.bintray.com/'
+			url 'https://jcenter.bintray.com/'
 		}
 		repository {
 			id 'repository.io.snapshot'
 			name 'Spring Snapshot Repository'
-			url 'http://repo.spring.io/snapshot'
+			url 'https://repo.spring.io/snapshot'
 		}
 		repository {
 			id 'repository.io.milestone'
 			name 'Spring Milestone Repository'
-			url 'http://repo.spring.io/milestone'
+			url 'https://repo.spring.io/milestone'
 		}
 	}
 	pluginRepositories {
 		pluginRepository {
 			id 'repository.io.milestone'
 			name 'Spring Milestone Repository'
-			url 'http://repo.spring.io/milestone'
+			url 'https://repo.spring.io/milestone'
 		}
 	}
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://docs.spring.io/spring-xd/docs/1.0.x/api/ migrated to:  
  https://docs.spring.io/spring-xd/docs/1.0.x/api/ ([https](https://docs.spring.io/spring-xd/docs/1.0.x/api/) result 200).
* http://jcenter.bintray.com/ migrated to:  
  https://jcenter.bintray.com/ ([https](https://jcenter.bintray.com/) result 200).
* http://stackoverflow.com/questions/29113972/spring-boot-gradle-plugin-application-plugin-and-gradle-2-3-wrapper migrated to:  
  https://stackoverflow.com/questions/29113972/spring-boot-gradle-plugin-application-plugin-and-gradle-2-3-wrapper ([https](https://stackoverflow.com/questions/29113972/spring-boot-gradle-plugin-application-plugin-and-gradle-2-3-wrapper) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://repo.spring.io migrated to:  
  https://repo.spring.io ([https](https://repo.spring.io) result 302).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/milestone migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).
* http://repo.spring.io/plugins-snapshot migrated to:  
  https://repo.spring.io/plugins-snapshot ([https](https://repo.spring.io/plugins-snapshot) result 302).
* http://repo.spring.io/snapshot migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).