### PR TITLE
URL Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ Please carefully follow the whitespace and formatting conventions already presen
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ Source Metrics are available via Sonar at:
 
 
 [Spring XD JIRA]: https://jira.springsource.org/browse/XD
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0
 [Spring Data Book]: http://bit.ly/sd-book 

--- a/config/sqoop-site.xml
+++ b/config/sqoop-site.xml
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/documentation-toolchain/src/main/java/org/springframework/xd/documentation/AsciidocLinkChecker.java
+++ b/documentation-toolchain/src/main/java/org/springframework/xd/documentation/AsciidocLinkChecker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/documentation-toolchain/src/main/java/org/springframework/xd/documentation/ModuleOptionsReferenceDoc.java
+++ b/documentation-toolchain/src/main/java/org/springframework/xd/documentation/ModuleOptionsReferenceDoc.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/documentation-toolchain/src/test/java/org/springframework/xd/documentation/ShellReferenceDoc.java
+++ b/documentation-toolchain/src/test/java/org/springframework/xd/documentation/ShellReferenceDoc.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/integration/x/IncrementalColumnRangePartitioner.java
+++ b/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/integration/x/IncrementalColumnRangePartitioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/integration/x/RemoteFilePartitioner.java
+++ b/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/integration/x/RemoteFilePartitioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/integration/x/RemoteFileToHadoopTasklet.java
+++ b/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/integration/x/RemoteFileToHadoopTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/integration/x/TimestampFileTasklet.java
+++ b/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/integration/x/TimestampFileTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/AbstractProcessBuilderTasklet.java
+++ b/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/AbstractProcessBuilderTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/ClasspathEnvironmentProvider.java
+++ b/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/ClasspathEnvironmentProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/EnvironmentProvider.java
+++ b/extensions/spring-xd-extension-batch/src/main/java/org/springframework/batch/step/tasklet/x/EnvironmentProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/IncrementalColumnRangePartitionerConfiguration.java
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/IncrementalColumnRangePartitionerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/IncrementalColumnRangePartitionerTest.java
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/IncrementalColumnRangePartitionerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTaskletTests.java
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTaskletTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests.java
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToHadoopTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests.java
+++ b/extensions/spring-xd-extension-batch/src/test/java/org/springframework/batch/integration/x/RemoteFileToTmpTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-cassandra/src/main/java/org/springframework/xd/cassandra/CassandraConfiguration.java
+++ b/extensions/spring-xd-extension-cassandra/src/main/java/org/springframework/xd/cassandra/CassandraConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-cassandra/src/main/java/org/springframework/xd/cassandra/CassandraSinkConfiguration.java
+++ b/extensions/spring-xd-extension-cassandra/src/main/java/org/springframework/xd/cassandra/CassandraSinkConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-cassandra/src/main/java/org/springframework/xd/cassandra/CassandraSinkOptionsMetadata.java
+++ b/extensions/spring-xd-extension-cassandra/src/main/java/org/springframework/xd/cassandra/CassandraSinkOptionsMetadata.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-cassandra/src/main/java/org/springframework/xd/cassandra/mixins/CassandraConnectionMixin.java
+++ b/extensions/spring-xd-extension-cassandra/src/main/java/org/springframework/xd/cassandra/mixins/CassandraConnectionMixin.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-cassandra/src/test/java/org/springframework/xd/cassandra/CassandraSinkModulePropertiesTests.java
+++ b/extensions/spring-xd-extension-cassandra/src/test/java/org/springframework/xd/cassandra/CassandraSinkModulePropertiesTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-cassandra/src/test/java/org/springframework/xd/cassandra/CassandraSinkTests.java
+++ b/extensions/spring-xd-extension-cassandra/src/test/java/org/springframework/xd/cassandra/CassandraSinkTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-cassandra/src/test/java/org/springframework/xd/test/domain/Book.java
+++ b/extensions/spring-xd-extension-cassandra/src/test/java/org/springframework/xd/test/domain/Book.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-encoder-support/src/main/java/org/springframework/xd/tcp/encdec/EncoderDecoderMixins.java
+++ b/extensions/spring-xd-extension-encoder-support/src/main/java/org/springframework/xd/tcp/encdec/EncoderDecoderMixins.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/integration/x/gemfire/JsonStringToObjectTransformer.java
+++ b/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/integration/x/gemfire/JsonStringToObjectTransformer.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  * 
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireCQSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireCQSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireHostPortMixin.java
+++ b/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireHostPortMixin.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireServerSinkModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireServerSinkModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-gemfire/src/main/java/org/springframework/xd/gemfire/GemfireSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gemfire/src/test/java/org/springframework/integration/x/gemfire/JsonStringToObjectTransformerTests.java
+++ b/extensions/spring-xd-extension-gemfire/src/test/java/org/springframework/integration/x/gemfire/JsonStringToObjectTransformerTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/config/GPFDistSinkOptionsMetadata.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/config/GPFDistSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/gpfdist/AbstractGPFDistMessageHandler.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/gpfdist/AbstractGPFDistMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/gpfdist/GPFDistCodec.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/gpfdist/GPFDistCodec.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/gpfdist/GPFDistMessageHandler.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/gpfdist/GPFDistMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/gpfdist/GPFDistServer.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/gpfdist/GPFDistServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/AbstractExternalTable.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/AbstractExternalTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/ControlFile.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/ControlFile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/ControlFileFactoryBean.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/ControlFileFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/DefaultGreenplumLoad.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/DefaultGreenplumLoad.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/DefaultLoadService.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/DefaultLoadService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/Format.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/Format.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/GreenplumDataSourceFactoryBean.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/GreenplumDataSourceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/GreenplumLoad.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/GreenplumLoad.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/JdbcCommands.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/JdbcCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/LoadConfiguration.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/LoadConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/LoadConfigurationFactoryBean.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/LoadConfigurationFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/LoadFactoryBean.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/LoadFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/LoadService.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/LoadService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/Mode.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/Mode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/NetworkUtils.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/NetworkUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/ReadableTable.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/ReadableTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/ReadableTableFactoryBean.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/ReadableTableFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/RuntimeContext.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/RuntimeContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/SegmentRejectType.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/SegmentRejectType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/SqlUtils.java
+++ b/extensions/spring-xd-extension-gpfdist/src/main/java/org/springframework/xd/greenplum/support/SqlUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/AbstractLoadTests.java
+++ b/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/AbstractLoadTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/LoadIT.java
+++ b/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/LoadIT.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/TestListenAddress.java
+++ b/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/TestListenAddress.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/TestUtils.java
+++ b/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/support/ControlFileTests.java
+++ b/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/support/ControlFileTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/support/LoadConfigurationFactoryBeanTests.java
+++ b/extensions/spring-xd-extension-gpfdist/src/test/java/org/springframework/xd/greenplum/support/LoadConfigurationFactoryBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpload/src/main/java/org/springframework/xd/gpload/GploadEnvironmentProvider.java
+++ b/extensions/spring-xd-extension-gpload/src/main/java/org/springframework/xd/gpload/GploadEnvironmentProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpload/src/main/java/org/springframework/xd/gpload/GploadOptionsMetadata.java
+++ b/extensions/spring-xd-extension-gpload/src/main/java/org/springframework/xd/gpload/GploadOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-gpload/src/main/java/org/springframework/xd/gpload/GploadTasklet.java
+++ b/extensions/spring-xd-extension-gpload/src/main/java/org/springframework/xd/gpload/GploadTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-header-enricher/src/test/java/org/springframework/xd/header/enricher/HeaderEnricherIntegrationTests.java
+++ b/extensions/spring-xd-extension-header-enricher/src/test/java/org/springframework/xd/header/enricher/HeaderEnricherIntegrationTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-header-enricher/src/test/java/org/springframework/xd/header/enricher/HeaderEnricherModuleTests.java
+++ b/extensions/spring-xd-extension-header-enricher/src/test/java/org/springframework/xd/header/enricher/HeaderEnricherModuleTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
+++ b/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyInboundMessageConverter.java
+++ b/extensions/spring-xd-extension-http/src/main/java/org/springframework/integration/x/http/NettyInboundMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-http/src/main/java/org/springframework/xd/http/HttpClientProcessorOptionsMetadata.java
+++ b/extensions/spring-xd-extension-http/src/main/java/org/springframework/xd/http/HttpClientProcessorOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-http/src/test/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapterTests.java
+++ b/extensions/spring-xd-extension-http/src/test/java/org/springframework/integration/x/http/NettyHttpInboundChannelAdapterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/AbstractImportToJdbcOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/AbstractImportToJdbcOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/FileJdbcJobOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/FileJdbcJobOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcConnectionMixin.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcConnectionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcConnectionPoolMixin.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcConnectionPoolMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcHdfsOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcHdfsOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcMessagePayloadTransformer.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcMessagePayloadTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcSinkModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcSinkModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcSourceModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/JdbcSourceModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcBatchItemWriter.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcBatchItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReader.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReaderFactory.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReaderFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/ResourcesIntoJdbcJobModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/ResourcesIntoJdbcJobModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/SingleTableDatabaseInitializer.java
+++ b/extensions/spring-xd-extension-jdbc/src/main/java/org/springframework/xd/jdbc/SingleTableDatabaseInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/test/java/org/springframework/xd/jdbc/JdbcMessagePayloadTransformerTests.java
+++ b/extensions/spring-xd-extension-jdbc/src/test/java/org/springframework/xd/jdbc/JdbcMessagePayloadTransformerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/test/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReaderFactoryTests.java
+++ b/extensions/spring-xd-extension-jdbc/src/test/java/org/springframework/xd/jdbc/NamedColumnJdbcItemReaderFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-jdbc/src/test/java/org/springframework/xd/jdbc/SingleTableDatabaseInitializerTests.java
+++ b/extensions/spring-xd-extension-jdbc/src/test/java/org/springframework/xd/jdbc/SingleTableDatabaseInitializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/AutoOffsetResetStrategy.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/AutoOffsetResetStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/InitialOffsetsFactoryBean.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/InitialOffsetsFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaConsumerOptionsMixin.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaConsumerOptionsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaMessageTransformer.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaMessageTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaOffsetTopicOptionsMixin.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaOffsetTopicOptionsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaPartitionAllocator.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaPartitionAllocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaProducerOptionsMixin.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaProducerOptionsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSinkModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSinkModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaSourceModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaZKOptionMixin.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/KafkaZKOptionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/NamespaceDelegatingMetadataStore.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/NamespaceDelegatingMetadataStore.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/WindowingOffsetManager.java
+++ b/extensions/spring-xd-extension-kafka/src/main/java/org/springframework/integration/x/kafka/WindowingOffsetManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/JavaMailPropertiesFactoryBean.java
+++ b/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/JavaMailPropertiesFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailProtocol.java
+++ b/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailProtocol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailServerMixin.java
+++ b/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailServerMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailSinkOptionsMetadata.java
+++ b/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-mail/src/main/java/org/springframework/xd/mail/MailSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/FieldSetConverter.java
+++ b/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/FieldSetConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/TupleWriteConverter.java
+++ b/extensions/spring-xd-extension-mongodb/src/main/java/org/springframework/xd/mongodb/TupleWriteConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/DelimitedStringToMapPropertyEditor.java
+++ b/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/DelimitedStringToMapPropertyEditor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellCommandProcessor.java
+++ b/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellCommandProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellModuleOptionsMetadata.java
+++ b/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellWordsParser.java
+++ b/extensions/spring-xd-extension-process/src/main/java/org/springframework/xd/extension/process/ShellWordsParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/PythonAvailableRule.java
+++ b/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/PythonAvailableRule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/ShellCommandProcessorTests.java
+++ b/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/ShellCommandProcessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/ShellWordsParserTest.java
+++ b/extensions/spring-xd-extension-process/src/test/java/org/springframework/xd/extension/process/ShellWordsParserTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/config/ReactorNamespaceHandler.java
+++ b/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/config/ReactorNamespaceHandler.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/config/SyslogInboundChannelAdapterParser.java
+++ b/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/config/SyslogInboundChannelAdapterParser.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/net/ReactorNetSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/net/ReactorNetSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/net/ReactorPeerFactoryBean.java
+++ b/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/net/ReactorPeerFactoryBean.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/net/ReactorPeerInboundChannelAdapter.java
+++ b/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/net/ReactorPeerInboundChannelAdapter.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/net/ReactorPeerInboundChannelAdapterConfiguration.java
+++ b/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/net/ReactorPeerInboundChannelAdapterConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/syslog/SyslogInboundChannelAdapter.java
+++ b/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/syslog/SyslogInboundChannelAdapter.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/syslog/SyslogInboundChannelAdapterConfiguration.java
+++ b/extensions/spring-xd-extension-reactor/src/main/java/org/springframework/xd/integration/reactor/syslog/SyslogInboundChannelAdapterConfiguration.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/test/java/org/springframework/xd/integration/reactor/NetServerInboundChannelAdapterIntegrationTests.java
+++ b/extensions/spring-xd-extension-reactor/src/test/java/org/springframework/xd/integration/reactor/NetServerInboundChannelAdapterIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/test/java/org/springframework/xd/integration/reactor/SyslogInboundChannelAdapterIntegrationTests.java
+++ b/extensions/spring-xd-extension-reactor/src/test/java/org/springframework/xd/integration/reactor/SyslogInboundChannelAdapterIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-reactor/src/test/java/org/springframework/xd/integration/reactor/TestMessageHandler.java
+++ b/extensions/spring-xd-extension-reactor/src/test/java/org/springframework/xd/integration/reactor/TestMessageHandler.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-redis/src/main/java/org/springframework/xd/redis/RedisSinkConfiguration.java
+++ b/extensions/spring-xd-extension-redis/src/main/java/org/springframework/xd/redis/RedisSinkConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-script/src/main/java/org/springframework/xd/extension/script/ScriptModulePropertiesFactoryBean.java
+++ b/extensions/spring-xd-extension-script/src/main/java/org/springframework/xd/extension/script/ScriptModulePropertiesFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-script/src/test/java/org/springframework/xd/extension/script/ScriptModulePropertiesFactoryBeanTest.java
+++ b/extensions/spring-xd-extension-script/src/test/java/org/springframework/xd/extension/script/ScriptModulePropertiesFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/SparkAppOptionsMetadata.java
+++ b/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/SparkAppOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/package-info.java
+++ b/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/tasklet/SparkTasklet.java
+++ b/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/tasklet/SparkTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/tasklet/package-info.java
+++ b/extensions/spring-xd-extension-spark/src/main/java/org/springframework/xd/spark/tasklet/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-splunk/src/main/java/org/springframework/integration/x/splunk/SplunkTransformer.java
+++ b/extensions/spring-xd-extension-splunk/src/main/java/org/springframework/integration/x/splunk/SplunkTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-splunk/src/main/java/org/springframework/xd/splunk/SplunkSinkOptionsMetadata.java
+++ b/extensions/spring-xd-extension-splunk/src/main/java/org/springframework/xd/splunk/SplunkSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopEnvironmentProvider.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopEnvironmentProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopOptionsMetadata.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopRunner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/SqoopTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/package-info.java
+++ b/extensions/spring-xd-extension-sqoop/src/main/java/org/springframework/xd/sqoop/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-syslog/src/main/java/org/springframework/xd/syslog/SyslogSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-syslog/src/main/java/org/springframework/xd/syslog/SyslogSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-syslog/src/main/java/org/springframework/xd/syslog/SyslogTcpSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-syslog/src/main/java/org/springframework/xd/syslog/SyslogTcpSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/AbstractTcpConnectionFactoryOptionsMetadata.java
+++ b/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/AbstractTcpConnectionFactoryOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/ClientTcpConnectionFactoryOptionsMetadataMixin.java
+++ b/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/ClientTcpConnectionFactoryOptionsMetadataMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/ServerTcpConnectionFactoryOptionsMetadataMixin.java
+++ b/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/ServerTcpConnectionFactoryOptionsMetadataMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/TcpClientSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/TcpClientSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/TcpSinkOptionsMetadata.java
+++ b/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/TcpSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/TcpSourceOptionsMetadata.java
+++ b/extensions/spring-xd-extension-tcp/src/main/java/org/springframework/xd/tcp/TcpSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-throughput/src/main/java/org/springframework/xd/integration/throughput/ThroughputSamplerMessageHandler.java
+++ b/extensions/spring-xd-extension-throughput/src/main/java/org/springframework/xd/integration/throughput/ThroughputSamplerMessageHandler.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-throughput/src/main/java/org/springframework/xd/integration/throughput/ThroughputSamplerOptionsMetadata.java
+++ b/extensions/spring-xd-extension-throughput/src/main/java/org/springframework/xd/integration/throughput/ThroughputSamplerOptionsMetadata.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-throughput/src/test/java/org/springframework/xd/integration/throughput/ThroughputSampleIntegrationTests.java
+++ b/extensions/spring-xd-extension-throughput/src/test/java/org/springframework/xd/integration/throughput/ThroughputSampleIntegrationTests.java
@@ -5,7 +5,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-throughput/src/test/resources/log4j.properties
+++ b/extensions/spring-xd-extension-throughput/src/test/resources/log4j.properties
@@ -5,7 +5,7 @@
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
 #
-#        http://www.apache.org/licenses/LICENSE-2.0
+#        https://www.apache.org/licenses/LICENSE-2.0
 #
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/AbstractTwitterInboundChannelAdapter.java
+++ b/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/AbstractTwitterInboundChannelAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterMixin.java
+++ b/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterSearchChannelAdapter.java
+++ b/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterSearchChannelAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterSearchOptionsMetadata.java
+++ b/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterSearchOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterStreamChannelAdapter.java
+++ b/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterStreamChannelAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterStreamOptionsMetadata.java
+++ b/extensions/spring-xd-extension-twitter/src/main/java/org/springframework/integration/x/twitter/TwitterStreamOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/spring-xd-extension-twitter/src/test/java/org/springframework/integration/x/twitter/AbstractTwitterInboundChannelAdapterTests.java
+++ b/extensions/spring-xd-extension-twitter/src/test/java/org/springframework/integration/x/twitter/AbstractTwitterInboundChannelAdapterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/common/shell-command-processor.xml
+++ b/modules/common/shell-command-processor.xml
@@ -7,7 +7,7 @@
   ~  * you may not use this file except in compliance with the License.
   ~  * You may obtain a copy of the License at
   ~  *
-  ~  * http://www.apache.org/licenses/LICENSE-2.0
+  ~  * https://www.apache.org/licenses/LICENSE-2.0
   ~  *
   ~  * Unless required by applicable law or agreed to in writing, software
   ~  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/processor/header-enricher/config/header-enricher.groovy
+++ b/modules/processor/header-enricher/config/header-enricher.groovy
@@ -6,7 +6,7 @@ import groovy.json.JsonSlurper
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/processor/shell/config/shell.xml
+++ b/modules/processor/shell/config/shell.xml
@@ -7,7 +7,7 @@
   ~  * you may not use this file except in compliance with the License.
   ~  * You may obtain a copy of the License at
   ~  *
-  ~  * http://www.apache.org/licenses/LICENSE-2.0
+  ~  * https://www.apache.org/licenses/LICENSE-2.0
   ~  *
   ~  * Unless required by applicable law or agreed to in writing, software
   ~  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/sink/shell/config/shell.xml
+++ b/modules/sink/shell/config/shell.xml
@@ -7,7 +7,7 @@
   ~  * you may not use this file except in compliance with the License.
   ~  * You may obtain a copy of the License at
   ~  *
-  ~  * http://www.apache.org/licenses/LICENSE-2.0
+  ~  * https://www.apache.org/licenses/LICENSE-2.0
   ~  *
   ~  * Unless required by applicable law or agreed to in writing, software
   ~  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/sink/throughput-sampler/config/throughput-sampler.xml
+++ b/modules/sink/throughput-sampler/config/throughput-sampler.xml
@@ -6,7 +6,7 @@
   ~  you may not use this file except in compliance with the License.
   ~  You may obtain a copy of the License at
   ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~        https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~  Unless required by applicable law or agreed to in writing, software
   ~  distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/source/reactor-ip/config/reactor-ip.xml
+++ b/modules/source/reactor-ip/config/reactor-ip.xml
@@ -6,7 +6,7 @@
   ~  you may not use this file except in compliance with the License.
   ~  You may obtain a copy of the License at
   ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~        https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~  Unless required by applicable law or agreed to in writing, software
   ~  distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/LICENSE
+++ b/scripts/LICENSE
@@ -1,7 +1,7 @@
 2
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/AbstractFieldMappingAwareDataMapper.java
+++ b/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/AbstractFieldMappingAwareDataMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/Analytic.java
+++ b/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/Analytic.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/InputMapper.java
+++ b/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/InputMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/MappedAnalytic.java
+++ b/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/MappedAnalytic.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/Mapper.java
+++ b/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/Mapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/OutputMapper.java
+++ b/spring-xd-analytics-ml/src/main/java/org/springframework/xd/analytics/ml/OutputMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/AbstractFieldMappingAwareDataMapperTest.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/AbstractFieldMappingAwareDataMapperTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyAnalytic.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyAnalytic.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyInputMapper.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyInputMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyMappedAnalytic.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyMappedAnalytic.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyOutputMapper.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/DummyOutputMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/MappedAnalyticTest.java
+++ b/spring-xd-analytics-ml/src/test/java/org/springframework/xd/analytics/ml/MappedAnalyticTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCount.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCountResolution.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCountResolution.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/AggregateCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/Counter.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/Counter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/CounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/CounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/FieldValueCounter.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/FieldValueCounter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/FieldValueCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/FieldValueCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/Gauge.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/Gauge.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/GaugeRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/GaugeRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/Metric.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/Metric.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricUtils.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/MetricUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/RichGauge.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/RichGauge.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/RichGaugeRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/core/RichGaugeRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/AbstractMetricHandler.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/AbstractMetricHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/AggregateCounterHandler.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/AggregateCounterHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/FieldValueCounterHandler.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/FieldValueCounterHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/GaugeHandler.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/GaugeHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/MessageCounterHandler.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/MessageCounterHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/RichGaugeHandler.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/integration/RichGaugeHandler.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounter.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryFieldValueCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryFieldValueCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryGaugeRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryGaugeRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryMetricRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryMetricRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryRichGaugeRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/memory/InMemoryRichGaugeRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/metadata/AggregateCounterSinkOptionsMetadata.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/metadata/AggregateCounterSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/metadata/FieldValueCounterSinkOptionsMetadata.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/metadata/FieldValueCounterSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/metadata/MetricNameMixin.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/metadata/MetricNameMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/metadata/RichGaugeSinkOptionsMetadata.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/metadata/RichGaugeSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/AbstractRedisMetricRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/AbstractRedisMetricRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/AggregateKeyGenerator.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/AggregateKeyGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/LoggingRecoveryCallback.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/LoggingRecoveryCallback.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisGaugeRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisGaugeRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisRetryTemplate.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisRetryTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisRichGaugeRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisRichGaugeRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisUtils.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/RedisUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/StringRedisRetryTemplate.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/analytics/metrics/redis/StringRedisRetryTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/store/AbstractInMemoryRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/store/AbstractInMemoryRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/store/AbstractRedisRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/store/AbstractRedisRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/store/AbstractRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/store/AbstractRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/store/DomainRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/store/DomainRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/main/java/org/springframework/xd/store/RangeCapableRepository.java
+++ b/spring-xd-analytics/src/main/java/org/springframework/xd/store/RangeCapableRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractAggregateCounterTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractAggregateCounterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractCounterRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractCounterRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractFieldValueCounterRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractFieldValueCounterRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractRichGaugeRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/AbstractRichGaugeRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/SharedGaugeRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/SharedGaugeRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/common/RedisRepositoriesConfig.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/common/RedisRepositoriesConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/CounterTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/CounterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/FieldValueCounterTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/FieldValueCounterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/GaugeTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/GaugeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/MetricUtilsTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/MetricUtilsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/RichGaugeTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/core/RichGaugeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/AggregateCounterTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/AggregateCounterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/FieldValueCounterHandlerTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/FieldValueCounterHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/GaugeHandlerTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/GaugeHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/MessageCounterHandlerTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/MessageCounterHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/RichGaugeHandlerTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/RichGaugeHandlerTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/SimpleTweet.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/integration/SimpleTweet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounterTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryAggregateCounterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryCounterRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryCounterRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryFieldValueCounterRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryFieldValueCounterRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryGaugeRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryGaugeRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryRichGaugeRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/memory/InMemoryRichGaugeRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisAggregateCounterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisCounterRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisCounterRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisFieldValueCounterRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisGaugeRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisGaugeRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisRetryTemplateTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisRetryTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisRichGaugeRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/analytics/metrics/redis/RedisRichGaugeRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/store/AbstractInMemoryRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/store/AbstractInMemoryRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/store/AbstractRedisRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/store/AbstractRedisRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-analytics/src/test/java/org/springframework/xd/store/BaseRepositoryTests.java
+++ b/spring-xd-analytics/src/test/java/org/springframework/xd/store/BaseRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-batch/src/main/java/org/springframework/xd/batch/XdBatchDatabaseInitializer.java
+++ b/spring-xd-batch/src/main/java/org/springframework/xd/batch/XdBatchDatabaseInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HSQLServerBean.java
+++ b/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HSQLServerBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HsqlDatasourceConfiguration.java
+++ b/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HsqlDatasourceConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HsqlServerApplication.java
+++ b/spring-xd-batch/src/main/java/org/springframework/xd/batch/hsqldb/server/HsqlServerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-batch/src/main/java/org/springframework/xd/batch/item/jdbc/FieldSetSqlParameterSourceProvider.java
+++ b/spring-xd-batch/src/main/java/org/springframework/xd/batch/item/jdbc/FieldSetSqlParameterSourceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-benchmark/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportBenchmarkTests.java
+++ b/spring-xd-benchmark/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportBenchmarkTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-benchmark/src/test/java/org/springframework/xd/tuple/TupleCreationPerformanceTests.java
+++ b/spring-xd-benchmark/src/test/java/org/springframework/xd/tuple/TupleCreationPerformanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-benchmark/src/test/java/org/springframework/xd/tuple/serializer/kryo/TupleCodecBenchmarkTests.java
+++ b/spring-xd-benchmark/src/test/java/org/springframework/xd/tuple/serializer/kryo/TupleCodecBenchmarkTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/DirtException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/DirtException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/analytics/NoSuchMetricException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/analytics/NoSuchMetricException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/RuntimeBatchConfigurer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/RuntimeBatchConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/Admin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/Admin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/AdminAttributes.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/AdminAttributes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/Container.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/Container.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ContainerAttributes.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ContainerAttributes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ContainerFilter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ContainerFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ContainerShutdownException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ContainerShutdownException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ModuleMessageRateNotFoundException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/ModuleMessageRateNotFoundException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/NoContainerException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/NoContainerException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/NoSuchContainerException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/cluster/NoSuchContainerException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/decryptor/DecryptorContext.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/decryptor/DecryptorContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/decryptor/PropertiesDecryptor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/decryptor/PropertiesDecryptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/AbstractComponentScanningBeanDefinitionProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/AbstractComponentScanningBeanDefinitionProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/AbstractResourceBeanDefinitionProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/AbstractResourceBeanDefinitionProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/OrderedContextInitializer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/OrderedContextInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/PluginContextComponentScanningExtensionsInitializer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/PluginContextComponentScanningExtensionsInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/PluginContextResourceExtensionsInitializer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/PluginContextResourceExtensionsInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/PluginsInitializer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/initializer/PluginsInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/AdminRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/AdminRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ContainerRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ContainerRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/DetailedContainer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/DetailedContainer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperAdminRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperAdminRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperContainerRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/container/store/ZooKeeperContainerRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/BaseDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/BaseDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentStatusRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentStatusRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentUnit.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentUnit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentUnitStatus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/DeploymentUnitStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/Job.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/Job.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/JobDeploymentsPath.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/JobDeploymentsPath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ModuleDeploymentRequestsPath.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ModuleDeploymentRequestsPath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ModuleDeploymentsPath.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ModuleDeploymentsPath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ResourceDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/ResourceDeployer.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/RuntimeIOException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/RuntimeIOException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/RuntimeTimeoutException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/RuntimeTimeoutException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/Stream.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/Stream.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/StreamDeploymentsPath.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/core/StreamDeploymentsPath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/AbstractEvent.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/AbstractEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/AbstractModuleEvent.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/AbstractModuleEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/ModuleDeployedEvent.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/ModuleDeployedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/ModuleUndeployedEvent.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/event/ModuleUndeployedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleaner.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/BusCleaner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusAwareChannelResolver.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusAwareChannelResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusAwareRouterBeanPostProcessor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusAwareRouterBeanPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/StrictContentTypeResolver.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/StrictContentTypeResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/AbstractFromMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/AbstractFromMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/ByteArrayToStringMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/ByteArrayToStringMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/CompositeMessageConverterFactory.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/CompositeMessageConverterFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/ConversionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/ConversionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/JavaToSerializedMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/JavaToSerializedMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/JsonToPojoMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/JsonToPojoMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/JsonToTupleMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/JsonToTupleMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/MessageConverterUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/MessageConverterUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/PojoToJsonMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/PojoToJsonMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/PojoToStringMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/PojoToStringMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/SerializedToJavaMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/SerializedToJavaMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/StringToByteArrayMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/StringToByteArrayMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/TupleToJsonMessageConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/converter/TupleToJsonMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/NothingToDeleteException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/NothingToDeleteException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleaner.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleaner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/json/NewJsonPathUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/integration/json/NewJsonPathUtils.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/jdbc/util/DatabaseVendorFriendlyNameFactoryBean.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/jdbc/util/DatabaseVendorFriendlyNameFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/BatchJobAlreadyExistsException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/BatchJobAlreadyExistsException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/DetailedJobInfo.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/DetailedJobInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionAlreadyRunningException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionAlreadyRunningException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionInfo.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionNotRunningException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobExecutionNotRunningException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobFactory.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInfo.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceAlreadyCompleteException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceAlreadyCompleteException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceInfo.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobInstanceInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobParametersInvalidException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobParametersInvalidException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobRestartException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/JobRestartException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobInstanceException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchBatchJobInstanceException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchJobExecutionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchJobExecutionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchStepExecutionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/NoSuchStepExecutionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/StepExecutionInfo.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/StepExecutionInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/StepExecutionProgressInfo.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/StepExecutionProgressInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/StepType.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/StepType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/TaskletType.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/TaskletType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dao/XdJdbcSearchableJobExecutionDao.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dao/XdJdbcSearchableJobExecutionDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ArgumentNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ArgumentNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/AstNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/AstNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/CheckpointedJobDefinitionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/CheckpointedJobDefinitionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ComposedJobUtil.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/ComposedJobUtil.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Flow.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Flow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Graph.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDSLMessage.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDSLMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDescriptor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobReference.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobReference.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSeries.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSeries.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationVisitor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/JobSpecificationVisitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Link.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Link.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Node.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Split.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Split.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Token.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Token.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/TokenKind.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/TokenKind.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokenizer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokenizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokens.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Tokens.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Transition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/job/dsl/Transition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/CustomModuleRegistryFactoryBean.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/CustomModuleRegistryFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/DelegatingModuleRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/DelegatingModuleRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/DependencyException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/DependencyException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ExtendedResource.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ExtendedResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/MD5StalenessCheck.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/MD5StalenessCheck.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleAlreadyExistsException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleAlreadyExistsException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDependencyRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDependencyRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleDeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleNotDeployedException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleNotDeployedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ModuleRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/NoSuchModuleException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/NoSuchModuleException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ResourceDefinitionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ResourceDefinitionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ResourceModuleRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/ResourceModuleRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/StalenessCheck.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/StalenessCheck.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/SynchronizingModuleRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/SynchronizingModuleRegistry.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/UploadedModuleDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/UploadedModuleDefinition.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/WritableModuleRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/WritableModuleRegistry.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/WritableResourceModuleRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/WritableResourceModuleRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/jmx/ModuleObjectNamingStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/jmx/ModuleObjectNamingStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ModuleMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ModuleMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ModuleMetadataRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ModuleMetadataRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ZooKeeperComposedModuleDefinitionRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ZooKeeperComposedModuleDefinitionRegistry.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ZooKeeperModuleDependencyRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ZooKeeperModuleDependencyRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ZooKeeperModuleMetadataRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/store/ZooKeeperModuleMetadataRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/support/ModuleDefinitionRepositoryUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/support/ModuleDefinitionRepositoryUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/support/ModuleDefinitionService.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/support/ModuleDefinitionService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/support/ThreadContextClassLoaderSetterAdvice.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/module/support/ThreadContextClassLoaderSetterAdvice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/AggregatorProcessorModuleOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/AggregatorProcessorModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileAsRefMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FilePollHdfsJobOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FilePollHdfsJobOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileReadingMode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileReadingMode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileSinkOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FileSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpHdfsJobOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpHdfsJobOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpSinkOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/FtpSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HdfsMongodbJobOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HdfsMongodbJobOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/HttpSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/JmsSourceModuleOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/JmsSourceModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/LogSinkOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/LogSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/MqttConnectionMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/MqttConnectionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/MqttSinkOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/MqttSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/MqttSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/MqttSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitConnectionMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitConnectionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSinkOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RabbitSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RedisConnectionMixin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RedisConnectionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RedisSinkOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/RedisSinkOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/SftpSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/SftpSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/SplitterProcessorOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/SplitterProcessorOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TailSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TailSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TimeSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TimeSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TimestampFileJobOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TimestampFileJobOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TriggerSourceOptionsMetadata.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/modules/metadata/TriggerSourceOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractJobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractJobPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractMessageBusBinderPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/AbstractStreamPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ContainerInfoPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ContainerInfoPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/MBeanExportingPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/MBeanExportingPlugin.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ModuleConfigurationException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ModuleConfigurationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ModuleInfoPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ModuleInfoPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/PropertiesDecryptorPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/PropertiesDecryptorPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ZookeeperConnectionPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/ZookeeperConnectionPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobAlreadyExistsInRegistryException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobAlreadyExistsInRegistryException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobHeaders.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobHeaders.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobRegistryBeanPostProcessor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/BatchJobRegistryBeanPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/DistributedJobLocator.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/DistributedJobLocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/DistributedJobService.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/DistributedJobService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/ExpandedJobParametersConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/ExpandedJobParametersConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobEventsListenerPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobEventsListenerPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobLaunchRequestTransformer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobLaunchRequestTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobParametersBean.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobParametersBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPartitionerPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPartitionerPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPluginMetadataResolver.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/JobPluginMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/ModuleJobLauncher.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/ModuleJobLauncher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/ExecutionContextJacksonMixIn.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/ExecutionContextJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryFactoryBean.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/StepExecutionJacksonMixIn.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/StepExecutionJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/BatchJobListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/BatchJobListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/BatchListenerEventType.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/BatchListenerEventType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/ChunkContextInfo.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/ChunkContextInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/FileDeletionStepExecutionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/FileDeletionStepExecutionListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdChunkListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdChunkListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdItemListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdItemListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdJobExecutionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdJobExecutionListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdSkipListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdSkipListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdStepExecutionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/SimpleXdStepExecutionListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/XDJobListenerConstants.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/job/support/listener/XDJobListenerConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/LocalMessageBusHolder.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/LocalMessageBusHolder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusReceiver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusSender.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/MessageBusSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingChannel.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingChannel.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/spark/streaming/SparkStreamingPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/CustomMimeTypeConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/CustomMimeTypeConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionPluginMetadataResolver.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionPluginMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionSupport.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/ModuleTypeConversionSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/StreamPlugin.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/plugins/stream/StreamPlugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AbstractBatchJobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AbstractBatchJobsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AccessControlInterceptor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AccessControlInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/AdminController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobExecutionsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobInstancesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobInstancesController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchJobsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchStepExecutionsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/BatchStepExecutionsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/CompletionsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/CompletionsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ContainersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ContainersController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/DetailedJobInfoResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/DetailedJobInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/DetailedModuleDefinitionResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/DetailedModuleDefinitionResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/DocumentParseResultResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/DocumentParseResultResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobDefinitionResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobDefinitionResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobExecutionInfoResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobExecutionInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobInfoResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobInstanceInfoResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobInstanceInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/JobsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModuleDefinitionResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModuleDefinitionResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModuleMetadataResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModuleMetadataResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModulesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModulesController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModulesMetadataController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ModulesMetadataController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/PasswordUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/PasswordUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestConfiguration.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RestControllerAdvice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RuntimeContainerResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/RuntimeContainerResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StepExecutionInfoResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StepExecutionInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StepExecutionProgressInfoResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StepExecutionProgressInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamDefinitionResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamDefinitionResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/StreamsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ToolsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/ToolsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/XDController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/XDController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/XdErrorController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/XdErrorController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/meta/VersionController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/meta/VersionController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AbstractMetricsController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AbstractMetricsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/CountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/CountersController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepAggregateCountResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepAggregateCountResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepCounterResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepCounterResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepFieldValueCounterResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepFieldValueCounterResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepGaugeResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepGaugeResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepRichGaugeResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/DeepRichGaugeResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/FieldValueCountersController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/FieldValueCountersController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/GaugesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/GaugesController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/RichGaugesController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/RichGaugesController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/ShallowMetricResourceAssembler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/metrics/ShallowMetricResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/security/SecurityController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/security/SecurityController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/validation/ValidationController.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/rest/validation/ValidationController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ApplicationUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ApplicationUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/MessageBusClassLoaderFactory.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/MessageBusClassLoaderFactory.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/MessageBusExtensionsConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/MessageBusExtensionsConfiguration.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/ParentConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SharedServerContextConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/SharedServerContextConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminPortNotAvailableException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminPortNotAvailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/AdminServerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/ContainerMatcher.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/ContainerMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DefaultDeploymentUnitStateCalculator.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DefaultDeploymentUnitStateCalculator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentAction.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentAction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentHandler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentMessage.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentMessagePublisher.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentMessagePublisher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentUnitStateCalculator.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentUnitStateCalculator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentUnitType.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/DeploymentUnitType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/ModuleDeploymentPropertiesProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/ModuleDeploymentPropertiesProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/ModuleDeploymentStatus.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/ModuleDeploymentStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/RuntimeModuleDeploymentPropertiesProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/RuntimeModuleDeploymentPropertiesProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/StreamRuntimePropertiesProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/StreamRuntimePropertiesProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ContainerListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ContainerListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ContainerMatchingModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ContainerMatchingModuleRedeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DefaultDeploymentStateRecalculator.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DefaultDeploymentStateRecalculator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DefaultModuleDeploymentPropertiesProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DefaultModuleDeploymentPropertiesProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DepartedContainerModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DepartedContainerModuleRedeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentLoader.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentMessageConsumer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentMessageConsumer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentQueue.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentQueue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/DeploymentSupervisor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ModuleDeploymentWriter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ModuleDeploymentWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ModuleRedeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ModuleRedeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/SupervisorElectedEvent.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/SupervisorElectedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/SupervisorElectionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/SupervisorElectionListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ZKDeploymentHandler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ZKDeploymentHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ZKDeploymentMessagePublisher.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ZKDeploymentMessagePublisher.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ZKJobDeploymentHandler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ZKJobDeploymentHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ZKStreamDeploymentHandler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/admin/deployment/zk/ZKStreamDeploymentHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerBootstrapConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerBootstrapConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerBootstrapContext.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerBootstrapContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerRegistrar.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerServerApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/ContainerServerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/DeploymentListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/container/DeploymentListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/AdminOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/AdminOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/BeanPropertiesPropertySource.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/BeanPropertiesPropertySource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommandLinePropertySourceOverridingListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommandLinePropertySourceOverridingListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonDistributedOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonDistributedOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/CommonOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ContainerOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ContainerOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ResourcePatternScanningOptionHandler.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ResourcePatternScanningOptionHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ResourcePatternScanningOptionHandlers.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/ResourcePatternScanningOptionHandlers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/SingleNodeOptions.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/options/SingleNodeOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/security/FileAuthenticationConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/security/FileAuthenticationConfiguration.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/security/LdapAuthenticationConfiguration.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/security/LdapAuthenticationConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/singlenode/SingleNodeApplication.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/server/singlenode/SingleNodeApplication.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/spark/SparkStreamingContainerFilter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/spark/SparkStreamingContainerFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractDeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractInstancePersistingDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AbstractInstancePersistingDeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AlreadyDeployedException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/AlreadyDeployedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/BaseInstance.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/BaseInstance.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DefinitionAlreadyExistsException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DefinitionAlreadyExistsException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DeploymentValidator.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DeploymentValidator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DocumentParseResult.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/DocumentParseResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/Job.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/Job.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDefinition.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDefinitionRepository.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobDeployer.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/JobRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/NoSuchDefinitionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/NoSuchDefinitionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/NotDeployedException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/NotDeployedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/ParsingContext.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/ParsingContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/Stream.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/Stream.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDefinition.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDefinitionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDefinitionRepositoryUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDefinitionRepositoryUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDeployer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamDeployer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamFactory.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/StreamRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/XDStreamParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/AddModuleOptionsExpansionStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/AddModuleOptionsExpansionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionExpansionStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionExpansionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionProvider.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/CompletionRecoveryStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/EmptyStartYieldsModulesRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/EmptyStartYieldsModulesRecoveryStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/ExpandOneDashToTwoDashesRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/ExpandOneDashToTwoDashesRecoveryStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/ModulesAfterPipeRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/ModulesAfterPipeRecoveryStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/OptionNameAfterDashDashRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/OptionNameAfterDashDashRecoveryStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/PipeIntoOtherModulesExpansionStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/PipeIntoOtherModulesExpansionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/StacktraceFingerprintingCompletionRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/StacktraceFingerprintingCompletionRecoveryStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/UnfinishedModuleNameRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/UnfinishedModuleNameRecoveryStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/UnfinishedOptionNameRecoveryStrategy.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/completion/UnfinishedOptionNameRecoveryStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ArgumentNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ArgumentNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/AstNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/AstNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelType.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ChannelType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/CheckpointedStreamDefinitionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/CheckpointedStreamDefinitionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/LabelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/LabelNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ModuleNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/ModuleNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SinkChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SinkChannelNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SourceChannelNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/SourceChannelNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamDefinitionException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamDefinitionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamLookupEnvironment.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamLookupEnvironment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamNode.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/StreamNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/Token.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/Token.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/TokenKind.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/TokenKind.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/Tokenizer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/Tokenizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/XDDSLMessages.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/dsl/XDDSLMessages.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/RepositoryConnectionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/RepositoryConnectionListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperJobDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperJobDefinitionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperJobRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperJobRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamDefinitionRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamDefinitionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamRepository.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/AbstractSingleNodeNamedChannelModule.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/AbstractSingleNodeNamedChannelModule.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/AbstractSingleNodeNamedChannelModuleFactory.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/AbstractSingleNodeNamedChannelModuleFactory.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/NamedChannelModule.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/NamedChannelModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/ResourceStateVerifier.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/ResourceStateVerifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/SingleNodeIntegrationTestSupport.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/SingleNodeIntegrationTestSupport.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/SingletonModuleRegistry.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/SingletonModuleRegistry.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/AbstractSingleNodeProcessingChain.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/AbstractSingleNodeProcessingChain.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChain.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChain.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChainConsumer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChainConsumer.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChainProducer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChainProducer.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChainSupport.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/process/SingleNodeProcessingChainSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/AbstractSingleNodeNamedChannelSink.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/AbstractSingleNodeNamedChannelSink.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/NamedChannelSink.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/NamedChannelSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/SingleNodeNamedChannelSinkFactory.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/SingleNodeNamedChannelSinkFactory.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/SingleNodeNamedQueueSink.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/SingleNodeNamedQueueSink.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/SingleNodeNamedTopicSink.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/sink/SingleNodeNamedTopicSink.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/AbstractSingleNodeNamedChannelSource.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/AbstractSingleNodeNamedChannelSource.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/NamedChannelSource.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/NamedChannelSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/SingleNodeNamedChannelSourceFactory.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/SingleNodeNamedChannelSourceFactory.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/SingleNodeNamedQueueSource.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/SingleNodeNamedQueueSource.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/SingleNodeNamedTopicSource.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/test/source/SingleNodeNamedTopicSource.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/BannerUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/BannerUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/ConfigLocations.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/ConfigLocations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/DeploymentPropertiesUtility.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/DeploymentPropertiesUtility.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/PageNotFoundException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/PageNotFoundException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/PagingUtility.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/PagingUtility.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/RuntimeUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/RuntimeUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdConfigLoggingInitializer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdConfigLoggingInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdProfiles.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdProfiles.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/XdUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/CustomLoggerConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/CustomLoggerConverter.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/LoggerAbbreviator.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/LoggerAbbreviator.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/VersionPatternConverter.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/VersionPatternConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/VersionPatternLayout.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/VersionPatternLayout.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/VersionPatternParser.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/util/logging/VersionPatternParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ChildPathIterator.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ChildPathIterator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/EmbeddedZooKeeper.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/EmbeddedZooKeeper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/Paths.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/Paths.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperAccessException.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperAccessException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnection.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnectionConfigurer.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnectionConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnectionListener.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperConnectionListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
+++ b/spring-xd-dirt/src/main/java/org/springframework/xd/dirt/zookeeper/ZooKeeperUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/AdhocTestSuite.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/AdhocTestSuite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/RuntimeBatchConfigurerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/RuntimeBatchConfigurerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/RuntimeBatchConfigurerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/RuntimeBatchConfigurerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTaskletTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/batch/tasklet/JobLaunchingTaskletTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/AbstractSingleNodeInitializationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/AbstractSingleNodeInitializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/LocalSingleNodeInitializationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/LocalSingleNodeInitializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/RabbitSingleNodeInitializationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/RabbitSingleNodeInitializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/RedisSingleNodeInitializationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/RedisSingleNodeInitializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/TestMessageBusInjection.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/TestMessageBusInjection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/ZooKeeperConnectionConfiguration.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/ZooKeeperConnectionConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/ZookeeperClientConnectTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/config/ZookeeperClientConnectTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/container/store/ZooKeeperAdminRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/container/store/ZooKeeperAdminRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/core/ModuleDeploymentsPathTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/core/ModuleDeploymentsPathTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/core/StreamDeploymentsPathTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/core/StreamDeploymentsPathTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/AbstractMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/AbstractMessageBusTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/AbstractTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/AbstractTestMessageBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/BrokerBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/BrokerBusTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusAwareChannelResolverTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusAwareChannelResolverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/MessageBusSupportTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionCapableBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionCapableBusTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionTestSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/PartitionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/converter/FromMessageConverterTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/converter/FromMessageConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaMessageBusTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/KafkaTestMessageBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawKafkaPartitionTestSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawKafkaPartitionTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/kafka/RawModeKafkaMessageBusTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/local/LocalMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/local/LocalMessageBusTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleanerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitBusCleanerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitMessageBusTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/rabbit/RabbitTestMessageBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisMessageBusTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisTestMessageBus.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/bus/redis/RedisTestMessageBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/TestKafkaCluster.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/kafka/TestKafkaCluster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/AbstractRedisSerializerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/AbstractRedisSerializerTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/RedisPublishingMessageHandlerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/RedisPublishingMessageHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/RedisQueueInboundChannelAdapterTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/RedisQueueInboundChannelAdapterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/RedisQueueOutboundChannelAdapterTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/integration/redis/RedisQueueOutboundChannelAdapterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/jms/AmqBrokerAndTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/jms/AmqBrokerAndTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/job/StepExecutionInfoTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/job/StepExecutionInfoTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/job/dsl/JobParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/job/dsl/JobParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/listener/ZooKeeperContainerRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/listener/ZooKeeperContainerRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/CompositeModuleTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/CompositeModuleTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/DelegatingModuleRegistryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/DelegatingModuleRegistryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/ModuleDefinitionMatchers.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/ModuleDefinitionMatchers.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/ResourceModuleRegistryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/ResourceModuleRegistryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/SingletonModuleRegistryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/SingletonModuleRegistryTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/SynchronizingModuleRegistryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/SynchronizingModuleRegistryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/TestModuleEventListener.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/TestModuleEventListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/WritableResourceModuleRegistryLogicTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/WritableResourceModuleRegistryLogicTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/jmx/ModuleObjectNamingStrategyTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/module/jmx/ModuleObjectNamingStrategyTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/modules/metadata/InputTypeTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/modules/metadata/InputTypeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/modules/metadata/ModuleOptionsMetadataSanityTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/modules/metadata/ModuleOptionsMetadataSanityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/modules/metadata/TestTupleProcessorOptionsMetadata.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/modules/metadata/TestTupleProcessorOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/ModuleDeploymentTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/ModuleDeploymentTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/ExpandedJobParametersConverterTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/ExpandedJobParametersConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobLaunchRequestTransformerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobLaunchRequestTransformerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobParametersBeanTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobParametersBeanTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobPluginTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobRepoTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/JobRepoTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/RabbitJobPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/RabbitJobPluginTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/RedisJobPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/RedisJobPluginTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/JobLaunchingJobRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/JobSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/JobSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/StepExecutionJacksonMixInTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/StepExecutionJacksonMixInTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/StepSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/job/support/StepSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/MessageBusRegistrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/MessageBusRegistrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/plugins/stream/StreamPluginTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/AbstractControllerIntegrationTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/AbstractControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobExecutionsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobExecutionsControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobInstancesControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobInstancesControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchJobsControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchStepExecutionsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/BatchStepExecutionsControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ContainersControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ContainersControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/Dependencies.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/Dependencies.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTestsConfig.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/JobsControllerIntegrationTestsConfig.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ModuleMetadataControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ModuleMetadataControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ModulesControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/ModulesControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/PasswordUtilsTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/PasswordUtilsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationWithRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationWithRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationWithRepositoryTestsConfig.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/StreamsControllerIntegrationWithRepositoryTestsConfig.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/meta/VersionControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/meta/VersionControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/AggregateCountersControllerIntegrationTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/CountersControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/CountersControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/FieldValueCountersControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/FieldValueCountersControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/GaugeControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/GaugeControllerIntegrationTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/RichGaugeControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/metrics/RichGaugeControllerIntegrationTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/security/SecurityControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/security/SecurityControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/security/SecurityControllerIntegrationTestsInitializer.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/security/SecurityControllerIntegrationTestsInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/validation/ValidationControllerIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/rest/validation/ValidationControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/LdapServerResource.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/LdapServerResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SecurityTestUtils.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SecurityTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithDefaultSecurityTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithDefaultSecurityTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithLdapSearchAndBindTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithLdapSearchAndBindTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithLdapSimpleBindTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithLdapSimpleBindTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithSslTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithSslTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithUserBasedSecurityTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithUserBasedSecurityTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithUsersFileTest.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SingleNodeApplicationWithUsersFileTest.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SpringXdResource.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/SpringXdResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/support/UserCredentials.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/security/support/UserCredentials.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/ContainerServerApplicationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/ContainerServerApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/TestApplicationBootstrap.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/TestApplicationBootstrap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/admin/deployment/DefaultContainerMatcherTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/server/admin/deployment/DefaultContainerMatcherTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractDistributedTransportSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractDistributedTransportSingleNodeStreamDeploymentIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/AbstractSingleNodeStreamDeploymentIntegrationTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/ComposedModuleStreamTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/ComposedModuleStreamTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/DeployerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/DeployerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/DeploymentPropertiesParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/DeploymentPropertiesParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/ExampleProcessingChainTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/ExampleProcessingChainTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/FileSourceModuleTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/FileSourceModuleTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/KafkaSingleNodeStreamDeploymentIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/LocalSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/LocalSingleNodeStreamDeploymentIntegrationTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/ModuleOptionsDefaultsOrderingTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/ModuleOptionsDefaultsOrderingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RabbitSingleNodeStreamDeploymentIntegrationTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RedisSingleNodeStreamDeploymentIntegrationTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/RedisSingleNodeStreamDeploymentIntegrationTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/StreamTestSupport.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/StreamTestSupport.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/TypeConvertingStreamTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/TypeConvertingStreamTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/XDStreamParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/XDStreamParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/completionnoscan/CompletionProviderTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/completionnoscan/CompletionProviderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/StreamConfigParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/TokenizerTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/dsl/TokenizerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamDefinitionRepositoryTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/stream/zookeeper/ZooKeeperStreamDefinitionRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/util/PagingUtilityTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/dirt/util/PagingUtilityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/ExtensionsTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/ExtensionsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/PropertiesDecryptorTests.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/PropertiesDecryptorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/Bar.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/Bar.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/Foo.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/Foo.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/MyXDBeans.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/MyXDBeans.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/StubPojoToStringConverter.java
+++ b/spring-xd-dirt/src/test/java/org/springframework/xd/extensions/test/StubPojoToStringConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/spring/xd/bus/ext/CustomKryoRegistrarConfig.java
+++ b/spring-xd-dirt/src/test/java/spring/xd/bus/ext/CustomKryoRegistrarConfig.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/java/spring/xd/ext/encryption/MyDecryptor.java
+++ b/spring-xd-dirt/src/test/java/spring/xd/ext/encryption/MyDecryptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-dirt/src/test/resources/logback.groovy
+++ b/spring-xd-dirt/src/test/resources/logback.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/DefaultDistributedTestSupport.java
+++ b/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/DefaultDistributedTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/DistributedTestSupport.java
+++ b/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/DistributedTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/ServerProcessUtils.java
+++ b/spring-xd-distributed-test/src/main/java/org/springframework/xd/distributed/util/ServerProcessUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/AbstractDistributedTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/AbstractDistributedTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/ContainerRedeploymentTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/ContainerRedeploymentTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/DistributedTestSuite.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/DistributedTestSuite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/JobStateTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/JobStateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/StreamDeploymentTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/StreamDeploymentTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/StreamPartitionTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/StreamPartitionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/StreamStateTests.java
+++ b/spring-xd-distributed-test/src/test/java/org/springframework/xd/distributed/test/StreamStateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-gemfire-server/src/main/java/org/springframework/xd/gemfire/server/CacheServer.java
+++ b/spring-xd-gemfire-server/src/main/java/org/springframework/xd/gemfire/server/CacheServer.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-gemfire-server/src/main/java/org/springframework/xd/gemfire/server/LoggingCacheListener.java
+++ b/spring-xd-gemfire-server/src/main/java/org/springframework/xd/gemfire/server/LoggingCacheListener.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-gradle-plugins/spring-xd-module-plugin/src/main/groovy/org/springframework/xd/gradle/plugin/ModulePlugin.groovy
+++ b/spring-xd-gradle-plugins/spring-xd-module-plugin/src/main/groovy/org/springframework/xd/gradle/plugin/ModulePlugin.groovy
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/AbstractHdfsItemWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/AbstractHdfsItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/HdfsTextItemWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/HdfsTextItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/SimpleAbstractHdfsItemWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/SimpleAbstractHdfsItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/SimpleHdfsTextItemWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/batch/item/hadoop/SimpleHdfsTextItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/AbstractHdfsWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/AbstractHdfsWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetDefinitionFactoryBean.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetDefinitionFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetWriterFactory.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/DatasetWriterFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/HdfsTextFileWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/HdfsTextFileWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/HdfsTextFileWriterFactory.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/HdfsTextFileWriterFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/HdfsWriter.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/HdfsWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/HdfsWriterFactory.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/hadoop/fs/HdfsWriterFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/IntegrationHadoopSystemConstants.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/IntegrationHadoopSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParser.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/DatasetWritingMessageHandlerFactoryBean.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/DatasetWritingMessageHandlerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HadoopNamespaceHandler.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HadoopNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HdfsOutboundChannelAdapterParser.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HdfsOutboundChannelAdapterParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HdfsStoreMessageHandlerBeanDefinitionBuilder.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HdfsStoreMessageHandlerBeanDefinitionBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HdfsStoreMessageHandlerFactoryBean.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HdfsStoreMessageHandlerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HdfsWritingMessageHandlerFactoryBean.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/HdfsWritingMessageHandlerFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/IntegrationHadoopNamespaceUtils.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/IntegrationHadoopNamespaceUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/NamingStrategyParser.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/NamingStrategyParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/RolloverStrategyParser.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/RolloverStrategyParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterFactoryBean.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterParser.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/config/StoreWriterParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/expression/MessageExpressionMethods.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/expression/MessageExpressionMethods.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/expression/MessagePartitionKeyMethodResolver.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/expression/MessagePartitionKeyMethodResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/expression/MessagePartitionKeyPropertyAccessor.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/expression/MessagePartitionKeyPropertyAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsDataStoreMessageHandler.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsDataStoreMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsPartitionDataStoreMessageHandler.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsPartitionDataStoreMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsStoreMessageHandler.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsStoreMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsWritingMessageHandler.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/outbound/HdfsWritingMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/partition/MessagePartitionStrategy.java
+++ b/spring-xd-hadoop/src/main/java/org/springframework/xd/integration/hadoop/partition/MessagePartitionStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/hadoop/fs/StubDatasetOperations.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/hadoop/fs/StubDatasetOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/hadoop/fs/StubFileSystem.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/hadoop/fs/StubFileSystem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterIntegrationTests.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParserTests.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterPartitionedIntegrationTests.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/DatasetOutboundChannelAdapterPartitionedIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/HdfsOutboundChannelAdapterIntegrationTests.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/HdfsOutboundChannelAdapterIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/HdfsOutboundChannelAdapterParserTests.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/HdfsOutboundChannelAdapterParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/NamingStrategyParserTests.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/integration/hadoop/config/NamingStrategyParserTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-hadoop/src/test/java/org/springframework/xd/test/TestPojo.java
+++ b/spring-xd-hadoop/src/test/java/org/springframework/xd/test/TestPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/acceptance-test-sparkapp/src/main/java/spark/SparkPi.java
+++ b/spring-xd-integration-test/acceptance-test-sparkapp/src/main/java/spark/SparkPi.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  * https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ContainerResolver.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ContainerResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Jobs.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Jobs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ModuleFixture.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ModuleFixture.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ModuleType.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/ModuleType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Processors.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Processors.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sinks.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sinks.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/fixtures/Sources.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/ConfigUtil.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/ConfigUtil.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/HadoopUtils.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/HadoopUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/InvalidResultException.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/InvalidResultException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/StreamUtils.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/StreamUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEc2Validation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEnvironment.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/XdEnvironment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/JMXChannelResult.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/JMXChannelResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/JMXRequest.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/JMXRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/JMXResult.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/JMXResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/JMXValue.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/JMXValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/Module.java
+++ b/spring-xd-integration-test/src/main/java/org/springframework/xd/integration/util/jmxresult/Module.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractIntegrationTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractJobTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/AbstractJobTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/BasicJobTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/BasicJobTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/CountTests.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/CountTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FileJdbcTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FileJdbcTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FilePollHdfsTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FilePollHdfsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FileSourceTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FileSourceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FtpHdfsTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/FtpHdfsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/GemfireTests.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/GemfireTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsJdbcTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsJdbcTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsMongoDbTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsMongoDbTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HdfsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HttpTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/HttpTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/IntegrationTestConfig.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/IntegrationTestConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JdbcHdfsTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JdbcHdfsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JdbcTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JdbcTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JmsTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JmsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JobCommandTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/JobCommandTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/KafkaTests.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/KafkaTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/MqttTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/MqttTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/ProcessorTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/ProcessorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/RabbitTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/RabbitTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SimpleJobTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SimpleJobTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SparkAppTests.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SparkAppTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  * https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SyslogTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/SyslogTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TapTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TcpClientTests.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TcpClientTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TcpTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TcpTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TickTockTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TickTockTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TwitterSearchTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TwitterSearchTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TwitterStreamTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/TwitterStreamTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/util/JMXTest.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/util/JMXTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/util/package-info.java
+++ b/spring-xd-integration-test/src/test/java/org/springframework/xd/integration/test/util/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/IntegerEncoderDecoder.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/IntegerEncoderDecoder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
+++ b/spring-xd-messagebus-kafka/src/main/java/org/springframework/xd/dirt/integration/kafka/KafkaMessageBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-local/src/main/java/org/springframework/xd/dirt/integration/bus/local/LocalMessageBus.java
+++ b/spring-xd-messagebus-local/src/main/java/org/springframework/xd/dirt/integration/bus/local/LocalMessageBus.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/ConnectionFactorySettings.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/ConnectionFactorySettings.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactory.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
+++ b/spring-xd-messagebus-rabbit/src/main/java/org/springframework/xd/dirt/integration/rabbit/RabbitMessageBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-rabbit/src/test/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactoryIntegrationTests.java
+++ b/spring-xd-messagebus-rabbit/src/test/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactoryIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-rabbit/src/test/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactoryTests.java
+++ b/spring-xd-messagebus-rabbit/src/test/java/org/springframework/xd/dirt/integration/rabbit/LocalizedQueueConnectionFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
+++ b/spring-xd-messagebus-redis/src/main/java/org/springframework/xd/dirt/integration/redis/RedisMessageBus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/AbstractBusPropertiesAccessor.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/AbstractBusPropertiesAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/Binding.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/Binding.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusUtils.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/BusUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/EmbeddedHeadersMessageConverter.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/EmbeddedHeadersMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBus.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBus.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusException.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageBusSupport.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageValues.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/MessageValues.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/PartitionKeyExtractorStrategy.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/PartitionKeyExtractorStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/PartitionSelectorStrategy.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/PartitionSelectorStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitAdminException.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitAdminException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitManagementUtils.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/RabbitManagementUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/SerializationException.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/SerializationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/StringConvertingContentTypeResolver.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/StringConvertingContentTypeResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/XdHeaders.java
+++ b/spring-xd-messagebus-spi/src/main/java/org/springframework/xd/dirt/integration/bus/XdHeaders.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-messagebus-spi/src/test/java/org/springframework/xd/dirt/integration/bus/MessageConverterTests.java
+++ b/spring-xd-messagebus-spi/src/test/java/org/springframework/xd/dirt/integration/bus/MessageConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobCommitIntervalOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobCommitIntervalOptionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobDeleteFilesOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobDeleteFilesOptionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobFieldDelimiterOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobFieldDelimiterOptionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobFieldNamesOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobFieldNamesOptionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobResourcesOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobResourcesOptionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobRestartableOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobRestartableOptionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobSinglestepPartitionSupportOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/BatchJobSinglestepPartitionSupportOptionMixin.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/DateFormatMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/DateFormatMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/ExpressionOrScriptMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/ExpressionOrScriptMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/FromMongoDbOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/FromMongoDbOptionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/FromStringCharsetMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/FromStringCharsetMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/FtpConnectionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/FtpConnectionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/HadoopConfigurationMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/HadoopConfigurationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/IntoMongoDbOptionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/IntoMongoDbOptionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MappedRequestHeadersMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MappedRequestHeadersMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MappedResponseHeadersMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MappedResponseHeadersMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MapreduceConfigurationMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MapreduceConfigurationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MaxMessagesDefaultOneMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MaxMessagesDefaultOneMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MaxMessagesDefaultUnlimitedMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MaxMessagesDefaultUnlimitedMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MongoDbConnectionMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/MongoDbConnectionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/PeriodicTriggerMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/PeriodicTriggerMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/ScriptMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/ScriptMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/ToStringCharsetMixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/mixins/ToStringCharsetMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/Mixin.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/Mixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ModuleOption.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ModuleOption.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ModulePlaceholders.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ModulePlaceholders.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ProfileNamesProvider.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ProfileNamesProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ValidationGroupsProvider.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/spi/ValidationGroupsProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/types/Password.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/types/Password.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/validation/CronExpression.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/validation/CronExpression.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/validation/DateFormat.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/validation/DateFormat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/validation/DateWithCustomFormat.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/validation/DateWithCustomFormat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/validation/Exclusives.java
+++ b/spring-xd-module-spi/src/main/java/org/springframework/xd/module/options/validation/Exclusives.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/test/java/org/springframework/xd/module/options/types/PasswordTests.java
+++ b/spring-xd-module-spi/src/test/java/org/springframework/xd/module/options/types/PasswordTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/test/java/org/springframework/xd/module/options/validation/CronValidatorTests.java
+++ b/spring-xd-module-spi/src/test/java/org/springframework/xd/module/options/validation/CronValidatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/test/java/org/springframework/xd/module/options/validation/DateFormatValidatorTests.java
+++ b/spring-xd-module-spi/src/test/java/org/springframework/xd/module/options/validation/DateFormatValidatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module-spi/src/test/java/org/springframework/xd/module/options/validation/DateWithCustomFormatTests.java
+++ b/spring-xd-module-spi/src/test/java/org/springframework/xd/module/options/validation/DateWithCustomFormatTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/CompositeModuleDefinition.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/CompositeModuleDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDefinition.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDefinitions.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDefinitions.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDeploymentProperties.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDeploymentProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleDescriptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleType.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/ModuleType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/RuntimeModuleDeploymentProperties.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/RuntimeModuleDeploymentProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/SimpleModuleDefinition.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/SimpleModuleDefinition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/AbstractModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/AbstractModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/CompositeModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/CompositeModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/JavaConfiguredModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/JavaConfiguredModule.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/Module.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/Module.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/ModuleEnvironment.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/ModuleEnvironment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/ModuleFactory.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/ModuleFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/NonBindingResourceConfiguredModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/NonBindingResourceConfiguredModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/Plugin.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/Plugin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/ResourceConfiguredModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/ResourceConfiguredModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/core/SimpleModule.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/core/SimpleModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/info/DefaultSimpleModuleInformationResolver.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/info/DefaultSimpleModuleInformationResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/info/DelegatingModuleInformationResolver.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/info/DelegatingModuleInformationResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/info/ModuleInformation.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/info/ModuleInformation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/info/ModuleInformationResolver.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/info/ModuleInformationResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataCollector.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolver.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/DelegatingModuleOptionsMetadataResolver.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/DelegatingModuleOptionsMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/EnvironmentAwareModuleOptionsMetadataResolver.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/EnvironmentAwareModuleOptionsMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/FlattenedCompositeModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/FlattenedCompositeModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/HierarchicalCompositeModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/HierarchicalCompositeModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOption.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOption.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOptions.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOptionsMetadataResolver.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleOptionsMetadataResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleUtils.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/ModuleUtils.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/PassthruModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/PassthruModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/PojoModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/PojoModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/PrefixNarrowingModuleOptions.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/PrefixNarrowingModuleOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/SimpleModuleOptionsMetadata.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/SimpleModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/options/support/StringToEnumIgnoringCaseConverterFactory.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/options/support/StringToEnumIgnoringCaseConverterFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/spark/streaming/package-info.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/spark/streaming/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/support/ArchiveResourceLoader.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/support/ArchiveResourceLoader.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/support/DateTrigger.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/support/DateTrigger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/support/NestedArchiveResource.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/support/NestedArchiveResource.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/support/NullClassLoader.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/support/NullClassLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/main/java/org/springframework/xd/module/support/ParentLastURLClassLoader.java
+++ b/spring-xd-module/src/main/java/org/springframework/xd/module/support/ParentLastURLClassLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/core/ModuleEnvironmentTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/core/ModuleEnvironmentTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/core/ModuleFactoryTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/core/ModuleFactoryTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/info/DefaultSimpleModuleInformationResolverTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/info/DefaultSimpleModuleInformationResolverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/info/DelegatingModuleInformationResolverTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/info/DelegatingModuleInformationResolverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/AlmostOverlappingPojo.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/AlmostOverlappingPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/BackingPojo.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/BackingPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataCollectorTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataCollectorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolverTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/DefaultModuleOptionsMetadataResolverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/FlattenedCompositeModuleOptionsMetadataTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/FlattenedCompositeModuleOptionsMetadataTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/HierarchicalCompositeModuleOptionsMetadataTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/HierarchicalCompositeModuleOptionsMetadataTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/ModuleOptionMatchers.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/ModuleOptionMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/OtherBackingPojo.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/OtherBackingPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/OverlappingPojo.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/OverlappingPojo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/PojoModuleOptionsMetadataTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/PojoModuleOptionsMetadataTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/PojoWithAlmostOverlappingMixins.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/PojoWithAlmostOverlappingMixins.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/PojoWithMixin.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/PojoWithMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/PojoWithOverlappingMixins.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/PojoWithOverlappingMixins.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/PrefixNarrowingModuleOptionsTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/PrefixNarrowingModuleOptionsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/options/SimpleModuleOptionsMetadataTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/options/SimpleModuleOptionsMetadataTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/support/ArchiveResourceLoaderTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/support/ArchiveResourceLoaderTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/support/DateTriggerTest.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/support/DateTriggerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/support/ModuleUtilsTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/support/ModuleUtilsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/java/org/springframework/xd/module/support/ParentLastURLClassLoaderTests.java
+++ b/spring-xd-module/src/test/java/org/springframework/xd/module/support/ParentLastURLClassLoaderTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-module/src/test/resources/ModuleUtilsTests/dynamic_classpath/source/foobar/config/foobar.properties
+++ b/spring-xd-module/src/test/resources/ModuleUtilsTests/dynamic_classpath/source/foobar/config/foobar.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/AbstractReactorMessageHandler.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/AbstractReactorMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/BroadcasterMessageHandler.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/BroadcasterMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandler.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/Processor.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/Processor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/ReactorReflectionUtils.java
+++ b/spring-xd-reactor/src/main/java/org/springframework/xd/reactor/ReactorReflectionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractMessageHandlerTests.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractMessageHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractPongStringProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractPongStringProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractRawTypeProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AbstractRawTypeProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AdditionalInterface.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/AdditionalInterface.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/BroadcasterMessageHandlerTests.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/BroadcasterMessageHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandlerTests.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/MultipleBroadcasterMessageHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongMessageProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongMessageProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongRawTypeProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongRawTypeProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongStringProcessor.java
+++ b/spring-xd-reactor/src/test/java/org/springframework/xd/reactor/PongStringProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/AggregateCounterOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/AggregateCounterOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/CompletionOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/CompletionOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/CounterOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/CounterOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/FieldValueCounterOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/FieldValueCounterOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/GaugeOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/GaugeOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/JobOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/JobOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/ModuleOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/ModuleOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/ResourceOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/ResourceOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/RichGaugeOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/RichGaugeOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/RuntimeOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/RuntimeOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/SpringXDOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/SpringXDOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/StreamOperations.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/StreamOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractMetricTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractMetricTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractResourceTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractResourceTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractSingleMetricTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractSingleMetricTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AbstractTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AggregateCounterTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/AggregateCounterTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/CompletionTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/CompletionTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/CounterTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/CounterTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/FieldValueCounterTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/FieldValueCounterTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/GaugeTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/GaugeTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/JobTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/JobTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/ModuleTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/ModuleTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/RichGaugeTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/RichGaugeTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/RuntimeTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/RuntimeTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDException.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/SpringXDTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/StreamTemplate.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/StreamTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/VndErrorResponseErrorHandler.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/VndErrorResponseErrorHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/ExecutionContextJacksonMixIn.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/ExecutionContextJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/ExitStatusJacksonMixIn.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/ExitStatusJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobExecutionJacksonMixIn.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobExecutionJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobInstanceJacksonMixIn.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobInstanceJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobParameterJacksonDeserializer.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobParameterJacksonDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobParameterJacksonMixIn.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobParameterJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobParametersJacksonMixIn.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/JobParametersJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/StepExecutionHistoryJacksonMixIn.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/StepExecutionHistoryJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/StepExecutionJacksonMixIn.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/StepExecutionJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/package-info.java
+++ b/spring-xd-rest-client/src/main/java/org/springframework/xd/rest/client/impl/support/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/JobExecutionDeserializationTests.java
+++ b/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/JobExecutionDeserializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/JobTemplateTests.java
+++ b/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/JobTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/StreamTemplateTests.java
+++ b/spring-xd-rest-client/src/test/java/org/springframework/xd/rest/client/impl/StreamTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/CompletionKind.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/CompletionKind.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DeployableResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DeployableResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DetailedContainerResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DetailedContainerResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DetailedJobInfoResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DetailedJobInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DetailedModuleDefinitionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DetailedModuleDefinitionResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DocumentParseResultResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/DocumentParseResultResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/JobDefinitionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/JobDefinitionResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/JobExecutionInfoResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/JobExecutionInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/JobInfoResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/JobInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/JobInstanceInfoResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/JobInstanceInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/ModuleDefinitionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/ModuleDefinitionResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/ModuleMetadataResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/ModuleMetadataResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/NamedResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/NamedResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/RESTDeploymentState.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/RESTDeploymentState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/RESTModuleType.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/RESTModuleType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/StepExecutionInfoResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/StepExecutionInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/StepExecutionProgressInfoResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/StepExecutionProgressInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/StreamDefinitionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/StreamDefinitionResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/XDRuntime.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/XDRuntime.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/meta/VersionResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/meta/VersionResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/AggregateCountsResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/AggregateCountsResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/CounterResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/CounterResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/FieldValueCounterResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/FieldValueCounterResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/GaugeResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/GaugeResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/MetricResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/MetricResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/RichGaugeResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/metrics/RichGaugeResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/security/SecurityInfoResource.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/security/SecurityInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/support/DeploymentPropertiesFormat.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/support/DeploymentPropertiesFormat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/support/RestTemplateMessageConverterUtil.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/support/RestTemplateMessageConverterUtil.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/util/ISO8601DateFormatWithMilliSeconds.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/util/ISO8601DateFormatWithMilliSeconds.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/util/TimeUtils.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/util/TimeUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/validation/CronValidation.java
+++ b/spring-xd-rest-domain/src/main/java/org/springframework/xd/rest/domain/validation/CronValidation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rest-domain/src/test/java/org/springframework/xd/rest/client/domain/StepExecutionInfoResourceSerializationTests.java
+++ b/spring-xd-rest-domain/src/test/java/org/springframework/xd/rest/client/domain/StepExecutionInfoResourceSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/MultipleSubjectMessageHandler.java
+++ b/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/MultipleSubjectMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/Processor.java
+++ b/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/Processor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/SubjectMessageHandler.java
+++ b/spring-xd-rxjava/src/main/java/org/springframework/xd/rxjava/SubjectMessageHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/AbstractMessageHandlerTests.java
+++ b/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/AbstractMessageHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/MultipleSubjectMessageHandlerTests.java
+++ b/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/MultipleSubjectMessageHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/PongMessageProcessor.java
+++ b/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/PongMessageProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/PongStringProcessor.java
+++ b/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/PongStringProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/SubjectMessageHandlerTests.java
+++ b/spring-xd-rxjava/src/test/java/org/springframework/xd/rxjava/SubjectMessageHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/Configuration.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/Configuration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/Target.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/Target.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/XDShell.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/XDShell.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/XDShellBannerProvider.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/XDShellBannerProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/XDShellPromptProvider.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/XDShellPromptProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/AbstractMetricsCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/AbstractMetricsCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/AggregateCounterCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/AggregateCounterCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ConfigCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ConfigCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ConsoleUserInput.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ConsoleUserInput.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/CounterCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/CounterCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/DeploymentOptionKeys.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/DeploymentOptionKeys.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/FieldValueCounterCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/FieldValueCounterCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/GaugeCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/GaugeCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/HttpCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/HttpCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/JobCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ModuleCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ModuleCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ModuleList.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/ModuleList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RichGaugeCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RichGaugeCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RuntimeCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/RuntimeCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/StreamCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/StreamCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/UserInput.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/UserInput.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/support/JobCommandsUtils.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/command/support/JobCommandsUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/CompletionConverter.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/CompletionConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/ExistingXDEntityConverter.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/ExistingXDEntityConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/MediaTypeConverter.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/MediaTypeConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/NumberFormatConverter.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/NumberFormatConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/QualifiedModuleNameConverter.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/converter/QualifiedModuleNameConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/hadoop/ConfigurationAware.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/hadoop/ConfigurationAware.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/hadoop/ConfigurationCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/hadoop/ConfigurationCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/hadoop/ConfigurationModifiedEvent.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/hadoop/ConfigurationModifiedEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/hadoop/FsShellCommands.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/hadoop/FsShellCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/Assertions.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/Assertions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/CommonUtils.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/CommonUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/JsonUtil.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/JsonUtil.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/Table.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/Table.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/TableHeader.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/TableHeader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/TableRow.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/TableRow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/UiUtils.java
+++ b/spring-xd-shell/src/main/java/org/springframework/xd/shell/util/UiUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/AbstractShellIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/ModuleTypeTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/ModuleTypeTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/bus/RabbitBusCleanerIntegrationTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/bus/RabbitBusCleanerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractCommandTemplate.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractCommandTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractFileSourceAndFileSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractFileSourceAndFileSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractFtpModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractFtpModulesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractHttpCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractHttpCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJarDeletingModuleCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJarDeletingModuleCommandsTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJdbcModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJdbcModulesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobCommandsWithHadoopTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobCommandsWithHadoopTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractJobIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractKafkaSourceSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractKafkaSourceSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractMailCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractMailCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractMetricsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractMetricsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractModuleClasspathTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractModuleClasspathTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractModuleCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractModuleCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractNamedChannelTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractNamedChannelTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractProcessorsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractProcessorsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractRabbitSourceAndRabbitSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractRabbitSourceAndRabbitSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractRedisSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractRedisSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractRouterSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractRouterSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractRuntimeCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractRuntimeCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractSftpSourceTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractSftpSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractSpelPropertyAccessorIntegrationTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractSpelPropertyAccessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractStreamCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractStreamCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractStreamIntegrationTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractStreamIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractTcpModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractTcpModulesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractTriggerModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/AbstractTriggerModulesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MessageStoreBenchmarkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MessageStoreBenchmarkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MetricsTemplate.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MetricsTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ModuleListTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ModuleListTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ModuleTemplate.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/ModuleTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MySuite.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/MySuite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SimpleTasklet.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SimpleTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SimpleTwoPartitionsPartitioner.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SimpleTwoPartitionsPartitioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpringBatchStepExecutionTestTasklet.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpringBatchStepExecutionTestTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpringBatchWithParametersTasklet.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/SpringBatchWithParametersTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandsTemplate.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandsTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandsUnitTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/StreamCommandsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/FieldValueCounterSink.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/FieldValueCounterSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/HttpSource.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/HttpSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/MetricExistsMatcher.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/MetricExistsMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/RichGaugeSink.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/RichGaugeSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/XDMatchers.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/XDMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/package-info.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/fixtures/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/FileSourceAndFileSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/FileSourceAndFileSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/FtpModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/FtpModulesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/HttpCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/HttpCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/JarDeletingModuleCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/JarDeletingModuleCommandsTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/JdbcModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/JdbcModulesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/JobCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/JobCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/JobCommandsWithHadoopTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/JobCommandsWithHadoopTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/KafkaSourceSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/KafkaSourceSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/MailCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/MailCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/MetricsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/MetricsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/ModuleClasspathTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/ModuleClasspathTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/ModuleCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/ModuleCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/NamedChannelTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/NamedChannelTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/ProcessorsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/ProcessorsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/RabbitSourceAndRabbitSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/RabbitSourceAndRabbitSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/RedisSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/RedisSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/RouterSinkTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/RouterSinkTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/RuntimeCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/RuntimeCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/SftpSourceTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/SftpSourceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/ShellCommandsTestSuite.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/ShellCommandsTestSuite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/SpelPropertyAccessorIntegrationTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/SpelPropertyAccessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/StreamCommandsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/StreamCommandsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/TcpModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/TcpModulesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/TriggerModulesTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/nosecurity/TriggerModulesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/FileSourceAndFileSinkWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/FileSourceAndFileSinkWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/FtpModulesWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/FtpModulesWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/HttpCommandsWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/HttpCommandsWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/JarDeletingModuleCommandsWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/JarDeletingModuleCommandsWithSecurityTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/JdbcModulesWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/JdbcModulesWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/JobCommandsWithHadoopAndSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/JobCommandsWithHadoopAndSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/JobCommandsWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/JobCommandsWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/KafkaSourceSinkWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/KafkaSourceSinkWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/MailCommandsWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/MailCommandsWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/MetricsWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/MetricsWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/ModuleClasspathWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/ModuleClasspathWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/ModuleCommandsWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/ModuleCommandsWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/NamedChannelWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/NamedChannelWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/ProcessorsWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/ProcessorsWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/RabbitSourceAndRabbitSinkWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/RabbitSourceAndRabbitSinkWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/RedisSinkWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/RedisSinkWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/RouterSinkWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/RouterSinkWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/RuntimeCommandsWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/RuntimeCommandsWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/SftpSourceWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/SftpSourceWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/ShellCommandsWithSecurityTestSuite.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/ShellCommandsWithSecurityTestSuite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/SpelPropertyAccessorIntegrationWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/SpelPropertyAccessorIntegrationWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/StreamCommandsWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/StreamCommandsWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/TcpModulesWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/TcpModulesWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/TriggerModulesWithSecurityTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/security/TriggerModulesWithSecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/support/JobCommandsUtilsTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/command/support/JobCommandsUtilsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTestSuite.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTestSuite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessWithSslTests.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/security/SecuredShellAccessWithSslTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/CliAvailabilityIndicatorChecker.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/CliAvailabilityIndicatorChecker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/CommonUtilsTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/CommonUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/TableMatchers.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/TableMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/TestFtpServer.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/TestFtpServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/TestSftpServer.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/TestSftpServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/UiUtilsTest.java
+++ b/spring-xd-shell/src/test/java/org/springframework/xd/shell/util/UiUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/AbstractSparkStreamingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/KafkaTransportSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/KafkaTransportSparkStreamingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/LocalTransportSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/LocalTransportSparkStreamingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/RabbitTransportSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/RabbitTransportSparkStreamingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/RedisTransportSparkStreamingTests.java
+++ b/spring-xd-spark-streaming-tests/src/test/java/org/springframework/xd/spark/streaming/RedisTransportSparkStreamingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/DefaultSparkStreamingModuleOptionsMetadata.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/DefaultSparkStreamingModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkConfig.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkMessageSender.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkMessageSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkStreamingModuleExecutor.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkStreamingModuleExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkStreamingSupport.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/SparkStreamingSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/FileLogger.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/FileLogger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/FileLoggerModuleOptionsMetadata.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/FileLoggerModuleOptionsMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/WordCount.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/examples/java/WordCount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/ModuleExecutor.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/ModuleExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/Processor.java
+++ b/spring-xd-spark-streaming/src/main/java/org/springframework/xd/spark/streaming/java/Processor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/examples/scala/FileLogger.scala
+++ b/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/examples/scala/FileLogger.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/examples/scala/WordCount.scala
+++ b/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/examples/scala/WordCount.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
+++ b/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/ModuleExecutor.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/Processor.scala
+++ b/spring-xd-spark-streaming/src/main/scala/org/springframework/xd/spark/streaming/scala/Processor.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/AbstractMailSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/AbstractMailSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/AbstractMetricSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/AbstractMetricSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/AbstractModuleFixture.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/AbstractModuleFixture.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/AggregateCounterSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/AggregateCounterSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/CounterSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/CounterSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/Disposable.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/Disposable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/DisposableFileSupport.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/DisposableFileSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/DisposableMailSupport.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/DisposableMailSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/EventuallyMatcher.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/EventuallyMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FileJdbcJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FileJdbcJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FilePollHdfsJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FilePollHdfsJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ import org.springframework.util.Assert;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FileSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FileSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FileSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FileSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpDummyUserManager.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpDummyUserManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpHdfsJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpHdfsJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ import org.springframework.util.Assert;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/FtpSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/GemFireCQSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/GemFireCQSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/GemFireServerSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/GemFireServerSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/GemFireSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/GemFireSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HasDisplayValue.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HasDisplayValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsJdbcJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsJdbcJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsMongoDbJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsMongoDbJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/HdfsSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/IncrementalJdbcHdfsJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/IncrementalJdbcHdfsJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JdbcHdfsJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JdbcHdfsJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JdbcSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JdbcSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JdbcSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JdbcSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JmsSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/JmsSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/KafkaSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/KafkaSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/KafkaSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/KafkaSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/LogSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/LogSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MailSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MailSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MetricHasSimpleValueMatcher.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MetricHasSimpleValueMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MqttSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MqttSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MqttSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/MqttSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/NonPollingImapSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/NonPollingImapSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/PartitionedJdbcHdfsJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/PartitionedJdbcHdfsJob.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/PollingMailSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/PollingMailSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/RabbitSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/RabbitSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/RabbitSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/RabbitSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleCounterSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleCounterSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleFileSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleFileSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleFileSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleFileSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleHttpSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleHttpSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleTailSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SimpleTailSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SparkAppJob.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SparkAppJob.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  * https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SyslogTcpSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SyslogTcpSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SyslogUdpSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/SyslogUdpSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TailSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TailSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/Tap.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/Tap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TcpClientSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TcpClientSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TcpSink.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TcpSink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TcpSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TcpSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/Transform.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/Transform.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TwitterSearchSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TwitterSearchSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TwitterStreamSource.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/TwitterStreamSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/util/AvailableSocketPorts.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/util/AvailableSocketPorts.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/util/FixtureUtils.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/util/FixtureUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/util/KafkaUtils.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/fixtures/util/KafkaUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/generator/GeneratorException.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/generator/GeneratorException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/generator/HttpGenerator.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/generator/HttpGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/generator/SimpleHttpGenerator.java
+++ b/spring-xd-test-fixtures/src/main/java/org/springframework/xd/test/generator/SimpleHttpGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/test/java/org/springframework/xd/test/fixtures/TapTest.java
+++ b/spring-xd-test-fixtures/src/test/java/org/springframework/xd/test/fixtures/TapTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test-fixtures/src/test/java/org/springframework/xd/test/fixtures/util/FixtureUtilsTests.java
+++ b/spring-xd-test-fixtures/src/test/java/org/springframework/xd/test/fixtures/util/FixtureUtilsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/dirt/integration/bus/BusTestUtils.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/dirt/integration/bus/BusTestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/module/TestModuleDefinitions.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/module/TestModuleDefinitions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/AbstractExternalResourceTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/AbstractExternalResourceTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/HostNotWindowsRule.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/HostNotWindowsRule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/PackageSuiteRunner.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/PackageSuiteRunner.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/RandomConfigurationSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/RandomConfigurationSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/EmbeddedZookeeper.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/EmbeddedZookeeper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/kafka/KafkaTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/mqtt/MqttTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/mqtt/MqttTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/rabbit/RabbitAdminTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/rabbit/RabbitAdminTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/rabbit/RabbitTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/rabbit/RabbitTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-test/src/main/java/org/springframework/xd/test/redis/RedisTestSupport.java
+++ b/spring-xd-test/src/main/java/org/springframework/xd/test/redis/RedisTestSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/DefaultTuple.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/DefaultTuple.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/DefaultTupleConversionService.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/DefaultTupleConversionService.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/JsonBytesToTupleConverter.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/JsonBytesToTupleConverter.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/JsonNodeToTupleConverter.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/JsonNodeToTupleConverter.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/JsonStringToTupleConverter.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/JsonStringToTupleConverter.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/LocaleAwareStringToNumberConverterFactory.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/LocaleAwareStringToNumberConverterFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/StringToDateConverter.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/StringToDateConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/Tuple.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/Tuple.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleBuilder.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleJsonMarshaller.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleJsonMarshaller.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleStringMarshaller.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleStringMarshaller.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleToJsonStringConverter.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/TupleToJsonStringConverter.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/FieldSetType.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/FieldSetType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleFieldExtractor.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleFieldExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleFieldSetMapper.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleFieldSetMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleRowMapper.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleRowMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleSqlParameterSource.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleSqlParameterSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleSqlParameterSourceProvider.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/batch/TupleSqlParameterSourceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/integration/JsonToTupleTransformer.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/integration/JsonToTupleTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/integration/MapToTupleTransformer.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/integration/MapToTupleTransformer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/processor/TupleProcessor.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/processor/TupleProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/serializer/kryo/DefaultTupleSerializer.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/serializer/kryo/DefaultTupleSerializer.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/serializer/kryo/TupleKryoRegistrar.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/serializer/kryo/TupleKryoRegistrar.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/serializer/kryo/package-info.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/serializer/kryo/package-info.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/spel/TuplePropertyAccessor.java
+++ b/spring-xd-tuple/src/main/java/org/springframework/xd/tuple/spel/TuplePropertyAccessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/AbstractTupleMarshallerTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/AbstractTupleMarshallerTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/DefaultTupleTestForBatch.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/DefaultTupleTestForBatch.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/DefaultTupleTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/DefaultTupleTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/JsonBytesToTupleConverterTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/JsonBytesToTupleConverterTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/SpringToDateConverterTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/SpringToDateConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/TupleJsonMarshallerTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/TupleJsonMarshallerTests.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleFieldExtractorTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleFieldExtractorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleFieldSetMapperTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleFieldSetMapperTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleRowMapperTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/batch/TupleRowMapperTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/integration/JsonToTupleTransformerTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/integration/JsonToTupleTransformerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/integration/MapToTupleTransformerTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/integration/MapToTupleTransformerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/serializer/kryo/TupleCodecTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/serializer/kryo/TupleCodecTests.java
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/spel/TuplePropertyAccessorTests.java
+++ b/spring-xd-tuple/src/test/java/org/springframework/xd/tuple/spel/TuplePropertyAccessorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/StandAloneUiApp.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/StandAloneUiApp.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/WebConfiguration.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/WebConfiguration.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/config/SecurityConfiguration.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/config/SecurityConfiguration.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/config/package-info.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/config/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/controller/LoginController.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/controller/LoginController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/controller/package-info.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/controller/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/controller/support/AuthenticationRequest.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/controller/support/AuthenticationRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/controller/support/package-info.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/controller/support/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/package-info.java
+++ b/spring-xd-ui/src/main/java/org/springframework/xd/dirt/web/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-ui/src/test/java/org/springframework/xd/dirt/web/SecurityConfigurationTests.java
+++ b/spring-xd-ui/src/test/java/org/springframework/xd/dirt/web/SecurityConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-ui/src/test/java/org/springframework/xd/dirt/web/SecurityDisabledConfigurationTests.java
+++ b/spring-xd-ui/src/test/java/org/springframework/xd/dirt/web/SecurityDisabledConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-yarn/spring-xd-yarn-appmaster/src/main/java/org/springframework/xd/yarn/AppmasterApplication.java
+++ b/spring-xd-yarn/spring-xd-yarn-appmaster/src/main/java/org/springframework/xd/yarn/AppmasterApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-yarn/spring-xd-yarn-appmaster/src/main/java/org/springframework/xd/yarn/XdAppmaster.java
+++ b/spring-xd-yarn/spring-xd-yarn-appmaster/src/main/java/org/springframework/xd/yarn/XdAppmaster.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/ClientApplication.java
+++ b/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/ClientApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/XdYarnAdminInfoCommand.java
+++ b/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/XdYarnAdminInfoCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/XdYarnClusterCreateCommand.java
+++ b/spring-xd-yarn/spring-xd-yarn-client/src/main/java/org/springframework/xd/yarn/XdYarnClusterCreateCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/docs/asciidoc/Introduction.asciidoc
+++ b/src/docs/asciidoc/Introduction.asciidoc
@@ -3,7 +3,7 @@
 
 === Overview
 
-Spring XD is a unified, distributed, and extensible service for data ingestion, real time analytics, batch processing, and data export. The Spring XD project is an open source http://www.apache.org/licenses/LICENSE-2.0[Apache 2 License] licenced project whose goal is to tackle big data complexity.  Much of the complexity in building real-world big data applications is related to integrating many disparate systems into one cohesive solution across a range of use-cases.
+Spring XD is a unified, distributed, and extensible service for data ingestion, real time analytics, batch processing, and data export. The Spring XD project is an open source https://www.apache.org/licenses/LICENSE-2.0[Apache 2 License] licenced project whose goal is to tackle big data complexity.  Much of the complexity in building real-world big data applications is related to integrating many disparate systems into one cohesive solution across a range of use-cases.
  Common use-cases encountered in creating a comprehensive big data solution are
 
 * High throughput distributed data ingestion from a variety of input sources into big data store such as HDFS or Splunk

--- a/src/etc/header.txt
+++ b/src/etc/header.txt
@@ -4,7 +4,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 1444 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).