### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ env:
   - TERM=dumb
 
 script:
-  - travis_wait ./gradlew --debug clean build -PtestLoggingStarted=true -PwikiBranch=origin/master
+  - ./gradlew --debug clean build -PtestLoggingStarted=true -PwikiBranch=origin/master
 
 #test


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
